### PR TITLE
feature: Button 컴포넌트 제작

### DIFF
--- a/frontend/src/components/@common/Button.styles.ts
+++ b/frontend/src/components/@common/Button.styles.ts
@@ -1,7 +1,8 @@
 import styled from '@emotion/styled';
+import type { ButtonVariant } from './variant';
 
 export const StyledButton = styled.button<{
-  variant: 'primary' | 'secondary' | 'tertiary';
+  variant: ButtonVariant;
   disabled: boolean;
 }>`
   display: flex;

--- a/frontend/src/components/@common/Button.styles.ts
+++ b/frontend/src/components/@common/Button.styles.ts
@@ -1,9 +1,77 @@
+import type { Theme } from '@emotion/react';
 import styled from '@emotion/styled';
 import type { ButtonVariant } from './variant';
 
+const buttonStyles = {
+  primary: {
+    enabled: (theme: Theme) => `
+      border-radius: 12px;
+      background: ${theme.colors.primary};
+      color: ${theme.colors.white};
+      border: none;
+
+      &:active {
+        border-radius: 12px;
+        background: ${theme.colors.primary};
+        box-shadow: 0px 2px 3px 0px rgba(0, 0, 0, 0.60) inset;
+      }
+    `,
+    disabled: (theme: Theme) => `
+      border-radius: 12px;
+      background: ${theme.colors.gray01};
+      color: ${theme.colors.gray04};
+      border: none;
+    `,
+  },
+  secondary: {
+    enabled: (theme: Theme) => `
+      border-radius: 12px;
+      color: ${theme.colors.primary};
+      background: ${theme.colors.white};
+      border: 1px solid ${theme.colors.primary};
+
+      &:active {
+        border-radius: 12px;
+        background: ${theme.colors.primary10}; 
+        border: 1px solid ${theme.colors.primary};
+      }
+    `,
+    disabled: (theme: Theme) => `
+      border-radius: 12px;
+      color: ${theme.colors.gray04};
+      background: ${theme.colors.gray01};
+      border: 1px solid ${theme.colors.gray03};
+    `,
+  },
+  tertiary: {
+    enabled: (theme: Theme) => `
+      background: transparent;
+      border: none;
+      color: ${theme.colors.gray03};
+      font-size: 12px;
+      font-style: normal;
+      font-weight: 500;
+      line-height: 120%;
+
+      &:active {
+        color: ${theme.colors.primary};
+      }
+    `,
+    disabled: (theme: Theme) => `
+      font-size: 12px;
+      font-style: normal;
+      font-weight: 500;
+      line-height: 120%;
+      background: transparent;
+      color: ${theme.colors.gray01};
+      border: none;
+    `,
+  },
+};
+
 export const StyledButton = styled.button<{
-  variant: ButtonVariant;
-  disabled: boolean;
+  $variant: ButtonVariant;
+  $disabled: boolean;
 }>`
   display: flex;
   padding: 12px 20px;
@@ -13,85 +81,10 @@ export const StyledButton = styled.button<{
 
   ${({ theme }) => ({ ...theme.typography.buttonPrimary })}
 
-  ${({ variant, theme, disabled }) =>
-    variant === 'primary' &&
-    !disabled &&
-    `
-    border-radius: 12px;
-    background: ${theme.colors.primary};
-    color: ${theme.colors.white};
-    border: none;
+  ${({ $variant, theme, $disabled }) => {
+    const variantStyles = buttonStyles[$variant];
+    const state = $disabled ? 'disabled' : 'enabled';
 
-    &:active {
-      border-radius: 12px;
-      background: ${theme.colors.primary};
-      box-shadow: 0px 2px 3px 0px rgba(0, 0, 0, 0.60) inset;
-    }
-  `}
-
-  ${({ variant, theme, disabled }) =>
-    variant === 'primary' &&
-    disabled &&
-    `
-    border-radius: 12px;
-    background: ${theme.colors.gray01};
-    color: ${theme.colors.gray04};
-    border: none;
-  `}
-
-  ${({ variant, theme, disabled }) =>
-    variant === 'secondary' &&
-    !disabled &&
-    `
-    border-radius: 12px;
-    color: ${theme.colors.primary};
-    background: ${theme.colors.white};
-    border: 1px solid ${theme.colors.primary};
-
-    &:active {
-      border-radius: 12px;
-      background: ${theme.colors.primary10}; 
-      border: 1px solid ${theme.colors.primary};
-    }
-  `}
-
-  ${({ variant, theme, disabled }) =>
-    variant === 'secondary' &&
-    disabled &&
-    `
-    border-radius: 12px;
-    color: ${theme.colors.gray04};
-    background: ${theme.colors.gray01};
-    border: 1px solid ${theme.colors.gray03};
-  `}
-
-  ${({ variant, theme, disabled }) =>
-    variant === 'tertiary' &&
-    !disabled &&
-    `
-    background: transparent;
-    border: none;
-    color: ${theme.colors.gray03};
-    font-size: 12px;
-    font-style: normal;
-    font-weight: 500;
-    line-height: 120%;
-
-    &:active {
-      color: ${theme.colors.primary};
-    }
-  `}
-
-  ${({ variant, theme, disabled }) =>
-    variant === 'tertiary' &&
-    disabled &&
-    `
-    font-size: 12px;
-    font-style: normal;
-    font-weight: 500;
-    line-height: 120%;
-    background: transparent;
-    color: ${theme.colors.gray01};
-    border: none;
-  `}
+    return variantStyles[state](theme);
+  }}
 `;

--- a/frontend/src/components/@common/Button.styles.ts
+++ b/frontend/src/components/@common/Button.styles.ts
@@ -26,7 +26,7 @@ export const StyledButton = styled.button<{
     &:active {
       border-radius: 12px;
       background: ${theme.colors.primary};
-      box-shadow: 0px 2px 3px 0px rgba(0, 0, 0, 0.30) inset;
+      box-shadow: 0px 2px 3px 0px rgba(0, 0, 0, 0.60) inset;
     }
   `}
 

--- a/frontend/src/components/@common/Button.styles.ts
+++ b/frontend/src/components/@common/Button.styles.ts
@@ -1,0 +1,98 @@
+import styled from '@emotion/styled';
+
+export const StyledButton = styled.button<{
+  variant: 'primary' | 'secondary' | 'tertiary';
+  disabled: boolean;
+}>`
+  display: flex;
+  padding: 12px 20px;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+
+  font-weight: ${({ theme }) => theme.typography.buttonPrimary.fontWeight};
+  font-size: ${({ theme }) => theme.typography.buttonPrimary.fontSize};
+  line-height: ${({ theme }) => theme.typography.buttonPrimary.lineHeight};
+
+  ${({ variant, theme, disabled }) =>
+    variant === 'primary' &&
+    !disabled &&
+    `
+    border-radius: 12px;
+    background: ${theme.colors.primary};
+    color: ${theme.colors.white};
+    border: none;
+
+    &:active {
+      border-radius: 12px;
+      background: ${theme.colors.primary};
+      box-shadow: 0px 2px 3px 0px rgba(0, 0, 0, 0.30) inset;
+    }
+  `}
+
+  ${({ variant, theme, disabled }) =>
+    variant === 'primary' &&
+    disabled &&
+    `
+    border-radius: 12px;
+    background: ${theme.colors.gray01};
+    color: ${theme.colors.gray04};
+    border: none;
+  `}
+
+  ${({ variant, theme, disabled }) =>
+    variant === 'secondary' &&
+    !disabled &&
+    `
+    border-radius: 12px;
+    color: ${theme.colors.primary};
+    background: ${theme.colors.white};
+    border: 1px solid ${theme.colors.primary};
+
+    &:active {
+      border-radius: 12px;
+      background: ${theme.colors.primary10}; 
+      border: 1px solid ${theme.colors.primary};
+    }
+  `}
+
+  ${({ variant, theme, disabled }) =>
+    variant === 'secondary' &&
+    disabled &&
+    `
+    border-radius: 12px;
+    color: ${theme.colors.gray04};
+    background: ${theme.colors.gray01};
+    border: 1px solid ${theme.colors.gray03};
+  `}
+
+  ${({ variant, theme, disabled }) =>
+    variant === 'tertiary' &&
+    !disabled &&
+    `
+    background: transparent;
+    border: none;
+    color: ${theme.colors.gray03};
+    font-size: 12px;
+    font-style: normal;
+    font-weight: 500;
+    line-height: 120%;
+
+    &:active {
+      color: ${theme.colors.primary};
+    }
+  `}
+
+  ${({ variant, theme, disabled }) =>
+    variant === 'tertiary' &&
+    disabled &&
+    `
+    font-size: 12px;
+    font-style: normal;
+    font-weight: 500;
+    line-height: 120%;
+    background: transparent;
+    color: ${theme.colors.gray01};
+    border: none;
+  `}
+`;

--- a/frontend/src/components/@common/Button.styles.ts
+++ b/frontend/src/components/@common/Button.styles.ts
@@ -11,9 +11,7 @@ export const StyledButton = styled.button<{
   align-items: center;
   gap: 10px;
 
-  font-weight: ${({ theme }) => theme.typography.buttonPrimary.fontWeight};
-  font-size: ${({ theme }) => theme.typography.buttonPrimary.fontSize};
-  line-height: ${({ theme }) => theme.typography.buttonPrimary.lineHeight};
+  ${({ theme }) => ({ ...theme.typography.buttonPrimary })}
 
   ${({ variant, theme, disabled }) =>
     variant === 'primary' &&

--- a/frontend/src/components/@common/Button.tsx
+++ b/frontend/src/components/@common/Button.tsx
@@ -1,8 +1,9 @@
 import * as S from './Button.styles';
+import type { ButtonVariant } from './variant';
 
 interface ButtonProps {
   /** 버튼의 variant */
-  variant?: 'primary' | 'secondary' | 'tertiary';
+  variant?: ButtonVariant;
   /** 버튼 내부 텍스트 */
   text: string;
   /** 버튼 클릭했을 때 실행할 함수*/

--- a/frontend/src/components/@common/Button.tsx
+++ b/frontend/src/components/@common/Button.tsx
@@ -1,0 +1,22 @@
+import * as S from './Button.styles';
+
+interface ButtonProps {
+  variant?: 'primary' | 'secondary' | 'tertiary';
+  text: string;
+  onClick: () => void;
+  disabled?: boolean;
+}
+
+const Button = ({ variant = 'primary', text, onClick, disabled = false }: ButtonProps) => {
+  return (
+    <S.StyledButton
+      variant={variant}
+      onClick={onClick}
+      disabled={disabled}
+    >
+      {text}
+    </S.StyledButton>
+  );
+};
+
+export default Button;

--- a/frontend/src/components/@common/Button.tsx
+++ b/frontend/src/components/@common/Button.tsx
@@ -19,7 +19,7 @@ const Button = ({
   disabled = false,
 }: ButtonProps) => {
   return (
-    <S.StyledButton variant={variant} onClick={onClick} disabled={disabled}>
+    <S.StyledButton $variant={variant} $disabled={disabled} onClick={onClick}>
       {text}
     </S.StyledButton>
   );

--- a/frontend/src/components/@common/Button.tsx
+++ b/frontend/src/components/@common/Button.tsx
@@ -1,19 +1,24 @@
 import * as S from './Button.styles';
 
 interface ButtonProps {
+  /** 버튼의 variant */
   variant?: 'primary' | 'secondary' | 'tertiary';
+  /** 버튼 내부 텍스트 */
   text: string;
+  /** 버튼 클릭했을 때 실행할 함수*/
   onClick: () => void;
+  /** 버튼 활성화 여부*/
   disabled?: boolean;
 }
 
-const Button = ({ variant = 'primary', text, onClick, disabled = false }: ButtonProps) => {
+const Button = ({
+  variant = 'primary',
+  text,
+  onClick,
+  disabled = false,
+}: ButtonProps) => {
   return (
-    <S.StyledButton
-      variant={variant}
-      onClick={onClick}
-      disabled={disabled}
-    >
+    <S.StyledButton variant={variant} onClick={onClick} disabled={disabled}>
       {text}
     </S.StyledButton>
   );

--- a/frontend/src/components/@common/variant.ts
+++ b/frontend/src/components/@common/variant.ts
@@ -1,0 +1,1 @@
+export type ButtonVariant = 'primary' | 'secondary' | 'tertiary';

--- a/frontend/src/stories/Button.stories.tsx
+++ b/frontend/src/stories/Button.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
+import Button from '../components/@common/Button';
+
+const meta: Meta<typeof Button> = {
+  title: 'Components/Button',
+  component: Button,
+  argTypes: {
+    variant: {
+      description: '버튼의 스타일 variant',
+      control: { type: 'select' },
+      options: ['primary', 'secondary', 'tertiary'],
+    },
+    text: {
+      description: '버튼에 표시될 텍스트',
+      control: 'text',
+    },
+    onClick: {
+      description: '버튼 클릭 시 실행될 함수',
+      action: 'clicked',
+    },
+    disabled: {
+      description: '버튼 비활성화 여부',
+      control: 'boolean',
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: {
+    variant: 'primary',
+    text: 'Primary Button',
+    onClick: () => {},
+    disabled: false,
+  },
+};
+
+export const Secondary: Story = {
+  args: {
+    variant: 'secondary',
+    text: 'Secondary Button',
+    onClick: () => {},
+    disabled: false,
+  },
+};
+
+export const Tertiary: Story = {
+  args: {
+    variant: 'tertiary',
+    text: 'Tertiary Button',
+    onClick: () => {},
+    disabled: false,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    variant: 'primary',
+    text: 'Disabled Button',
+    onClick: () => {},
+    disabled: true,
+  },
+};


### PR DESCRIPTION
## 연관된 이슈

- close #22

## 작업 내용

- 버튼 컴포넌트를 제작했습니다.
- Primary Button, Secondary Button, Tertiary Button 3가지의 테마를 적용했습니다. 
- props로  `variant`, `text`, `onClick`, `disabled`을 받습니다.

### 브라우저

<img width="200" height="1070" alt="CleanShot 2025-07-15 at 15 31 29@2x" src="https://github.com/user-attachments/assets/b14a132c-033d-4d06-bbba-0835f2547179" />

### 동작 영상

https://github.com/user-attachments/assets/be2d128a-3c6c-45d3-ba0b-a404575f0b1e

### 스토리북

<img width="1000" height="1282" alt="CleanShot 2025-07-15 at 15 39 49@2x" src="https://github.com/user-attachments/assets/dde60339-fe30-46e5-921e-8e1f6bfb5e4a" />
<img width="300" alt="CleanShot 2025-07-15 at 15 47 20@2x" src="https://github.com/user-attachments/assets/556d1320-6b04-4813-9639-0ccf7d276c4c" />
