### PR TITLE
feature: FloatingIconButton 제작

### DIFF
--- a/frontend/src/@assets/icons/upwardArrow.svg
+++ b/frontend/src/@assets/icons/upwardArrow.svg
@@ -1,0 +1,3 @@
+<svg width="12" height="8" viewBox="0 0 12 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1.4 7.4L0 6L6 0L12 6L10.6 7.4L6 2.8L1.4 7.4Z" fill="#9E9E9E"/>
+</svg>

--- a/frontend/src/components/@common/buttons/floatingIconButton/FloatingIconButton.styles.ts
+++ b/frontend/src/components/@common/buttons/floatingIconButton/FloatingIconButton.styles.ts
@@ -1,15 +1,16 @@
 import styled from '@emotion/styled';
 
 export const Wrapper = styled.button`
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    align-items: center;
-    width: 30px;
-    height: 30px;
-    
-    border-radius: 50%;
-    border: 1px solid ${({ theme }) => theme.colors.gray03};
-    background-color: ${({ theme }) => theme.colors.white};
-    filter: drop-shadow(5px 5px 5px rgba(0, 0, 0, 0.25));
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  width: 30px;
+  height: 30px;
+
+  border-radius: 50%;
+  border: 1px solid ${({ theme }) => theme.colors.gray03};
+  background-color: ${({ theme }) => theme.colors.white};
+  filter: drop-shadow(5px 5px 5px rgba(0, 0, 0, 0.25));
+  overflow: hidden;
 `;

--- a/frontend/src/components/@common/buttons/floatingIconButton/FloatingIconButton.styles.ts
+++ b/frontend/src/components/@common/buttons/floatingIconButton/FloatingIconButton.styles.ts
@@ -7,7 +7,6 @@ export const Wrapper = styled.button`
     align-items: center;
     width: 30px;
     height: 30px;
-    flex-shrink: 0;
     
     border-radius: 50%;
     border: 1px solid ${({ theme }) => theme.colors.gray03};

--- a/frontend/src/components/@common/buttons/floatingIconButton/FloatingIconButton.styles.ts
+++ b/frontend/src/components/@common/buttons/floatingIconButton/FloatingIconButton.styles.ts
@@ -1,0 +1,16 @@
+import styled from '@emotion/styled';
+
+export const Wrapper = styled.button`
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    width: 30px;
+    height: 30px;
+    flex-shrink: 0;
+    
+    border-radius: 50%;
+    border: 1px solid ${({ theme }) => theme.colors.gray03};
+    background-color: ${({ theme }) => theme.colors.white};
+    filter: drop-shadow(5px 5px 5px rgba(0, 0, 0, 0.25));
+`;

--- a/frontend/src/components/@common/buttons/floatingIconButton/FloatingIconButton.tsx
+++ b/frontend/src/components/@common/buttons/floatingIconButton/FloatingIconButton.tsx
@@ -1,0 +1,22 @@
+import { ReactComponent as UpwardArrow } from '@assets/icons/upwardArrow.svg';
+import { theme } from '../../../../styles/theme';
+import * as S from './FloatingIconButton.styles';
+
+interface FloatingIconButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  /** 버튼 클릭했을 때 실행할 함수*/
+  onClick: () => void;
+}
+
+const FloatingIconButton = ({
+  onClick,
+  ...buttonProps
+}: FloatingIconButtonProps) => {
+  return (
+    <S.Wrapper onClick={onClick} {...buttonProps}>
+      <UpwardArrow fill={theme.colors.gray03} />
+    </S.Wrapper>
+  );
+};
+
+export default FloatingIconButton;

--- a/frontend/src/components/@common/buttons/floatingIconButton/FloatingIconButton.tsx
+++ b/frontend/src/components/@common/buttons/floatingIconButton/FloatingIconButton.tsx
@@ -1,20 +1,21 @@
-import { ReactComponent as UpwardArrow } from '@assets/icons/upwardArrow.svg';
-import { theme } from '../../../../styles/theme';
 import * as S from './FloatingIconButton.styles';
 
 interface FloatingIconButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  /** 아이콘 React Node */
+  icon: React.ReactNode;
   /** 버튼 클릭했을 때 실행할 함수*/
   onClick: () => void;
 }
 
 const FloatingIconButton = ({
+  icon,
   onClick,
   ...buttonProps
 }: FloatingIconButtonProps) => {
   return (
     <S.Wrapper onClick={onClick} {...buttonProps}>
-      <UpwardArrow fill={theme.colors.gray03} />
+      {icon}
     </S.Wrapper>
   );
 };

--- a/frontend/src/stories/FloatingIconButton.stories.tsx
+++ b/frontend/src/stories/FloatingIconButton.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
+import FloatingIconButton from '../components/@common/buttons/floatingIconButton/FloatingIconButton';
+
+const meta: Meta<typeof FloatingIconButton> = {
+  title: 'Components/FloatingIconButton',
+  component: FloatingIconButton,
+  parameters: {
+    layout: 'centered',
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};


### PR DESCRIPTION
## 연관된 이슈

- close #92 

## 작업 내용

### 스크린샷

화면의 하단에 위치하며, 클릭 시 최상단으로 이동하는 기능을 가지는 버튼을 구현했습니다.

- 상단으로 올라가는 기능은 페이지에서 구현해 `onClick`으로 넘겨주면 됩니다.
- 시안과 다른 위치에서 사용될 가능성이 있어, 해당 컴포넌트의 위치는 고정하지 않았습니다.

<img width="400" height="1284" alt="CleanShot 2025-07-18 at 18 11 55@2x" src="https://github.com/user-attachments/assets/7ef256f8-42f2-49e3-b378-affc40fe865b" />

### 스토리북

<img width="2136" height="1026" alt="CleanShot 2025-07-18 at 18 13 49@2x" src="https://github.com/user-attachments/assets/ee1cbb39-04cf-4934-ba6e-45c5a65d5c42" />
