### PR TITLE
refactor: 업로드 페이지 수정

### DIFF
--- a/frontend/src/components/layout/Layout.styles.ts
+++ b/frontend/src/components/layout/Layout.styles.ts
@@ -4,6 +4,7 @@ export const Container = styled.div<{ $isHighlightPage: boolean }>`
   margin: 0 auto;
   max-width: 400px;
   width: 100%;
+  //TODO: theme으로 추출하는 것은?
   padding: 32px 16px;
   border: 1px solid #000;
   min-height: 100dvh;

--- a/frontend/src/pages/manager/imageUploadPage/ImageUploadPage.styles.ts
+++ b/frontend/src/pages/manager/imageUploadPage/ImageUploadPage.styles.ts
@@ -4,11 +4,12 @@ export const Wrapper = styled.div<{ $hasImages: boolean }>`
   ${({ theme }) => theme.typography.header03}
   width: 100%;
   height: 100%;
+  //TODO: height 고정 값 때문에 의도적으로 top,bottom padding을 빼준 값 사용
+  min-height: calc(100dvh - 64px);
   border-radius: 12px;
   display: flex;
   flex-direction: column;
   gap: 16px;
-  //TODO: page scroll 해결 후 UploadBox padding 조정 필요
 `;
 
 export const TitleContainer = styled.div`
@@ -30,6 +31,7 @@ export const Description = styled.p`
 
 export const UploadContainer = styled.div<{ $hasImages: boolean }>`
   flex: ${({ $hasImages }) => ($hasImages ? 0 : 1)};
+  height: 100%;
   display: flex;
   margin-bottom: 16px;
 `;

--- a/frontend/src/pages/manager/imageUploadPage/ImageUploadPage.tsx
+++ b/frontend/src/pages/manager/imageUploadPage/ImageUploadPage.tsx
@@ -1,24 +1,21 @@
 import FloatingActionButton from '../../../components/@common/buttons/floatingActionButton/FloatingActionButton';
 import HighlightText from '../../../components/@common/highlightText/HighlightText';
 import ImageGrid from '../../../components/@common/imageGrid/ImageGrid';
+import SpaceHeader from '../../../components/spaceHeader/SpaceHeader';
 import UploadBox from '../../../components/uploadBox/UploadBox';
 import * as S from './ImageUploadPage.styles';
 import { mockImageList, mockSpaceData } from './mockSpaceData';
 
 const ImageUploadPage = () => {
   const hasImages = Array.isArray(mockImageList) && mockImageList.length > 0;
-  const uploadBoxText = hasImages ? '이어 올리기' : '함께한 순간을 올려주세요';
+  const uploadBoxText = '함께한 순간을 올려주세요';
 
   return (
     <S.Wrapper $hasImages={hasImages}>
-      <S.TitleContainer>
-        <S.Title>{mockSpaceData.name}</S.Title>
-        {!hasImages && (
-          <S.Description>
-            {'끌어다 놓거나,\n클릭해서 불러올 수 있어요'}
-          </S.Description>
-        )}
-      </S.TitleContainer>
+      <SpaceHeader
+        title={`${mockSpaceData.name}`}
+        description="클릭해서 불러올 수 있어요"
+      />
 
       <S.UploadContainer $hasImages={hasImages}>
         <UploadBox text={uploadBoxText} />


### PR DESCRIPTION
## 연관된 이슈

- close #98 

## 작업 내용

* 공통 컴포넌트 SpaceHeader로 변경
* layout `min-height: 100dvh` 변경에 따른 uploadBox flex 변경

-> UI merge 후 기능 추가 구현 예정(업로드)

### 추후 논의해볼 사항
> padding 값을 theme에서 상수로 관리하는 방식에 대해 어떻게 생각하시나요?

기존에는 layout에 `height: 100dvh`가 적용되어 있었지만, 이를 `min-height: 100dvh`로 변경하여 내부 콘텐츠에 따라 스크롤이 가능하도록 수정되었어요.

이 변경에 따라, 이미지 리스트 여부(hasImages)에 따라 높이가 유동적으로 변하는 uploadBox를 구현하려면 고정된 height 값이 필요했습니다.

여러 컴포넌트 중 layout, Wrapper(ImageUploadPage), UploadContainer 중 어떤 곳에 고정 height를 지정할지 고민한 끝에, 가장 적절한 위치는 Wrapper라고 판단하여 다음과 같이 작성했습니다

```js
min-height: calc(100dvh - 64px);
```

여기서 64px은 layout의 상하 패딩 (32px * 2)을 의미합니다.

현재로서는 문제가 없지만, 유지보수 측면에서 다소 이슈가 발생할 수 있어요.
향후 layout의 패딩 값이 변경될 경우, 해당 페이지의 UI 역시 의도와 다르게 표시될 수 있습니다.

이를 방지하기 위해, padding 값도 theme 안에서 다음과 같이 상수로 추출해 관리하면 어떨까요?

``` js
padding: {
  topBottom: '32px',
  leftRight: '16px',
}
```