### PR TITLE
fix: swagger 서버 url 설정파일 분리

### DIFF
--- a/backend/forgather/src/main/java/com/forgather/global/config/SwaggerConfig.java
+++ b/backend/forgather/src/main/java/com/forgather/global/config/SwaggerConfig.java
@@ -2,6 +2,7 @@ package com.forgather.global.config;
 
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -13,13 +14,16 @@ import io.swagger.v3.oas.models.servers.Server;
 @Configuration
 public class SwaggerConfig {
 
+    @Value("${api.base-url}")
+    private String serverUrl;
+
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
             .info(apiInfo())
             .components(new Components())
             .servers(List.of(
-                new Server().url("https://api.forgather.me").description("Production Server")
+                new Server().url(serverUrl).description("API Server")
             ));
     }
 


### PR DESCRIPTION
## 연관된 이슈


## 작업 내용

로컬에서도 실제 서버를 찌르도록 설정되어있어서 로컬과 프로덕션이 다른 url을 가질 수 있도록 설정파일로 분리했습니다.