### PR TITLE
test: hexToRgba 유틸 함수 테스트

### DIFF
--- a/frontend/__test__/hexToRgba.test.ts
+++ b/frontend/__test__/hexToRgba.test.ts
@@ -1,7 +1,31 @@
 import { hexToRgba } from '../src/utils/hexToRgba';
 
-test('renders hello text', () => {
-  const rgba = hexToRgba('#FFFFFF', 0);
-  expect(rgba).toBe('rgba(255, 255, 255, 0)');
-  expect(rgba).toBe('rgba(10, 255, 255, 0)');
+describe('hexToRgba', () => {
+  it('hex 색상을 rgba로 변환한다', () => {
+    expect(hexToRgba('#FF0000')).toBe('rgba(255, 0, 0, 1)');
+    expect(hexToRgba('#00FF00')).toBe('rgba(0, 255, 0, 1)');
+    expect(hexToRgba('#0000FF')).toBe('rgba(0, 0, 255, 1)');
+    expect(hexToRgba('#FFFFFF')).toBe('rgba(255, 255, 255, 1)');
+    expect(hexToRgba('#000000')).toBe('rgba(0, 0, 0, 1)');
+  });
+
+  it('# 없는 hex 값도 처리한다', () => {
+    expect(hexToRgba('FF0000')).toBe('rgba(255, 0, 0, 1)');
+    expect(hexToRgba('00FF00')).toBe('rgba(0, 255, 0, 1)');
+  });
+
+  it('소문자 hex 값도 처리한다', () => {
+    expect(hexToRgba('#ff0000')).toBe('rgba(255, 0, 0, 1)');
+    expect(hexToRgba('aabbcc')).toBe('rgba(170, 187, 204, 1)');
+  });
+
+  it('alpha 값을 설정할 수 있다', () => {
+    expect(hexToRgba('#000000', 0)).toBe('rgba(0, 0, 0, 0)');
+    expect(hexToRgba('#FFFFFF', 0.5)).toBe('rgba(255, 255, 255, 0.5)');
+    expect(hexToRgba('#FF0000', 0.25)).toBe('rgba(255, 0, 0, 0.25)');
+  });
+
+  it('alpha 값이 없으면 기본값 1을 사용한다', () => {
+    expect(hexToRgba('#000000')).toBe('rgba(0, 0, 0, 1)');
+  });
 });

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,3 +1,4 @@
+/** @type {import('jest').Config} */
 const config = {
   preset: 'ts-jest',
   testEnvironment: 'jest-environment-jsdom',
@@ -5,4 +6,4 @@ const config = {
   testPathIgnorePatterns: ['/node_modules/', '/dist/'],
 };
 
-export default config;
+module.exports = config;

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,4 +1,3 @@
-/** @type {import('jest').Config} */
 const config = {
   preset: 'ts-jest',
   testEnvironment: 'jest-environment-jsdom',


### PR DESCRIPTION
## 연관된 이슈

- close #120 

## 작업 내용

hexToRgba 유틸 함수의 jest 테스트 코드를 작성했습니다. 

### 변경 사항

테스트 세팅을 pull 받아 진행했는데 오류가 발생했어요.(스크린샷 첨부)
Jest가 기본적으로 CommonJS 방식으로 설정 파일을 불러오는데, export default 같은 ESM 문법을 만나서 해석에 실패했다는 의미였습니다.
이를 해결하기 위해 `jest.config.js`를 CommonJS 방식으로 변경해서 해결했습니다.

<img width="2140" height="630" alt="CleanShot 2025-07-21 at 18 24 03@2x" src="https://github.com/user-attachments/assets/0d1b4582-4d8b-45e1-a222-9afc9ac5fe60" />


