### PR TITLE
test: copyLinkToClipboard 유틸 함수 테스트

### DIFF
--- a/frontend/__test__/copyLinkToClipboard.test.ts
+++ b/frontend/__test__/copyLinkToClipboard.test.ts
@@ -1,0 +1,61 @@
+import { copyLinkToClipboard } from "../src/utils/copyLinkToClipboard";
+
+describe('copyLinkToClipboard 테스트', () => {
+  const originalClipboard = { ...global.navigator.clipboard };
+
+  const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    Object.assign(navigator, {
+      clipboard: originalClipboard,
+    });
+    consoleLogSpy.mockRestore();
+  });
+
+  it('텍스트를 클립보드에 복사한다', async () => {
+    const writeTextMock = jest.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: writeTextMock,
+      },
+    });
+
+    const testText = 'https://example.com';
+    await copyLinkToClipboard(testText);
+
+    expect(writeTextMock).toHaveBeenCalledWith(testText);
+    expect(writeTextMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('복사 실패 시 에러를 콘솔로 출력한다', async () => {
+    const testError = new Error('복사 실패');
+    const writeTextMock = jest.fn().mockRejectedValue(testError);
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: writeTextMock,
+      },
+    });
+
+    await copyLinkToClipboard('https://example.com');
+
+    expect(writeTextMock).toHaveBeenCalled();
+    expect(consoleLogSpy).toHaveBeenCalledWith(testError);
+  });
+
+  it('빈 문자열도 복사할 수 있다', async () => {
+    const writeTextMock = jest.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: writeTextMock,
+      },
+    });
+
+    await copyLinkToClipboard('');
+
+    expect(writeTextMock).toHaveBeenCalledWith('');
+  });
+});

--- a/frontend/__test__/copyLinkToClipboard.test.ts
+++ b/frontend/__test__/copyLinkToClipboard.test.ts
@@ -1,6 +1,6 @@
-import { copyLinkToClipboard } from "../src/utils/copyLinkToClipboard";
+import { copyLinkToClipboard } from '../src/utils/copyLinkToClipboard';
 
-describe('copyLinkToClipboard 테스트', () => {
+describe('copyLinkToClipboard 유틸 함수 테스트', () => {
   const originalClipboard = { ...global.navigator.clipboard };
 
   const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();


### PR DESCRIPTION
## 연관된 이슈

- close #119 

## 작업 내용

copyLinkToClipboard 유틸 함수의 jest 테스트 코드를 작성했습니다.

<img width="894" height="432" alt="CleanShot 2025-07-22 at 01 09 20@2x" src="https://github.com/user-attachments/assets/60abbf68-709a-4b55-8eb7-fe29d655d333" />
