### PR TITLE
feat: 메타데이터 누락 핸들링

### DIFF
--- a/backend/forgather/src/main/java/com/forgather/domain/space/util/MetaDataExtractor.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/space/util/MetaDataExtractor.java
@@ -19,17 +19,13 @@ public class MetaDataExtractor {
         return new PhotoMetaData(extractCapturedAt(file));
     }
 
+    /**
+     * 사진 메타데이터 표준 포맷은 EXIF(Exchangeable Image File Format) 다.
+     * ExifSubIFDDirectory 는 EXIF 메타데이터의 서브 디렉토리로, 사진의 촬영 날짜와 시간 정보를 포함한다.
+     */
     private static LocalDateTime extractCapturedAt(MultipartFile file) {
         Metadata metadata = extractMetaData(file);
-
-        /**
-         * 사진 메타데이터 표준 포맷은 EXIF(Exchangeable Image File Format) 다.
-         * ExifSubIFDDirectory 는 EXIF 메타데이터의 서브 디렉토리로, 사진의 촬영 날짜와 시간 정보를 포함한다.
-         */
         ExifSubIFDDirectory directory = metadata.getFirstDirectoryOfType(ExifSubIFDDirectory.class);
-        if (directory == null) {
-            throw new IllegalArgumentException("ExifSubIFDDirectory 를 메타데이터에서 찾을 수 없습니다.");
-        }
         return extractLocalDateTime(directory);
     }
 
@@ -43,8 +39,11 @@ public class MetaDataExtractor {
     }
 
     private static LocalDateTime extractLocalDateTime(ExifSubIFDDirectory directory) {
+        if (directory == null || !directory.containsTag(ExifSubIFDDirectory.TAG_DATETIME_ORIGINAL)) {
+            return null;
+        }
+
         Date date = directory.getDateOriginal();
         return LocalDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault());
     }
-
 }


### PR DESCRIPTION
## 연관된 이슈

- close #134

## 작업 내용
메타데이터 없을 때 `Exception throw` 안하고, null 처리하도록 로직 수정