### PR TITLE
feature: 데모용 임시 메인페이지 제작

### DIFF
--- a/frontend/src/pages/demo/DemoHome.styles.ts
+++ b/frontend/src/pages/demo/DemoHome.styles.ts
@@ -1,17 +1,17 @@
 import styled from '@emotion/styled';
 
 export const Wrapper = styled.div`
-    width: 100%;
-    height: ${({ theme }) => `calc(100dvh - ${parseInt(theme.layout.padding.topBottom) * 2}px)`};
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    gap: 24px;
+  width: 100%;
+  height: ${({ theme }) => `calc(100dvh - ${parseInt(theme.layout.padding.topBottom) * 2}px)`};
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 24px;
 `;
 
 export const Title = styled.p`
-    ${({ theme }) => ({ ...theme.typography.header01 })};
+  ${({ theme }) => ({ ...theme.typography.header01 })};
 `;
 
 export const Icon = styled.img`

--- a/frontend/src/pages/demo/DemoHome.styles.ts
+++ b/frontend/src/pages/demo/DemoHome.styles.ts
@@ -1,0 +1,20 @@
+import styled from '@emotion/styled';
+
+export const Wrapper = styled.div`
+    width: 100%;
+    height: ${({ theme }) => `calc(100dvh - ${parseInt(theme.layout.padding.topBottom) * 2}px)`};
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 24px;
+`;
+
+export const Title = styled.p`
+    ${({ theme }) => ({ ...theme.typography.header01 })};
+`;
+
+export const Icon = styled.img`
+  width: 120px;
+  height: 120px;
+`;

--- a/frontend/src/pages/demo/DemoHome.tsx
+++ b/frontend/src/pages/demo/DemoHome.tsx
@@ -1,8 +1,25 @@
+import rocketImage from '@assets/images/rocket.png';
+import { useNavigate } from 'react-router-dom';
+import Button from '../../components/@common/buttons/button/Button';
+import { ROUTES } from '../../constants/routes';
+import * as S from './DemoHome.styles';
+
 const DemoHome = () => {
+  const navigate = useNavigate();
+
   return (
-    <div>
-      <p>데모 메인페이지임</p>
-    </div>
+    <S.Wrapper>
+      <S.Icon src={rocketImage} alt="데모 페이지 아이콘"></S.Icon>
+      <S.Title>Forgather 데모</S.Title>
+      <Button
+        text="(GUEST) 스페이스 업로드 페이지"
+        onClick={() => navigate(ROUTES.GUEST.IMAGE_UPLOAD)}
+      />
+      <Button
+        text="(MANAGER) 스페이스 관리 페이지 이동"
+        onClick={() => navigate(ROUTES.MANAGER.SPACE_HOME)}
+      />
+    </S.Wrapper>
   );
 };
 

--- a/frontend/src/pages/demo/DemoHome.tsx
+++ b/frontend/src/pages/demo/DemoHome.tsx
@@ -1,0 +1,9 @@
+const DemoHome = () => {
+  return (
+    <div>
+      <p>데모 메인페이지임</p>
+    </div>
+  );
+};
+
+export default DemoHome;

--- a/frontend/src/pages/demo/DemoHome.tsx
+++ b/frontend/src/pages/demo/DemoHome.tsx
@@ -10,7 +10,7 @@ const DemoHome = () => {
   return (
     <S.Wrapper>
       <S.Icon src={rocketImage} alt="데모 페이지 아이콘"></S.Icon>
-      <S.Title>Forgather 데모</S.Title>
+      <S.Title>Forgather DEMO</S.Title>
       <Button
         text="(GUEST) 스페이스 업로드 페이지"
         onClick={() => navigate(ROUTES.GUEST.IMAGE_UPLOAD)}

--- a/frontend/src/router/router.tsx
+++ b/frontend/src/router/router.tsx
@@ -1,5 +1,6 @@
 import { createBrowserRouter } from 'react-router-dom';
 import Layout from '../components/layout/Layout';
+import DemoHome from '../pages/demo/DemoHome';
 import ImageUploadPage from '../pages/guest/imageUploadPage/ImageUploadPage';
 import SharePage from '../pages/guest/sharePage/SharePage';
 import SpaceHome from '../pages/manager/spaceHome/SpaceHome';
@@ -9,6 +10,10 @@ const router = createBrowserRouter([
     path: '/',
     element: <Layout />,
     children: [
+      {
+        path: '/',
+        element: <DemoHome />,
+      },
       {
         // TODO : 데모 후 삭제
         path: 'manager',


### PR DESCRIPTION
## 연관된 이슈

- close #154 

## 작업 내용

- 데모용 임시 메인페이지 생성
  - / (메인 루트)로 접속 시 페이지로 이동
  - guest의 업로드와 manager의 관리페이지로 이동

<img width="380" height="715" alt="image" src="https://github.com/user-attachments/assets/09cfd144-5076-4760-ac08-8f6f0dbd3192" />

## 논의 사항

- 페이지 확인해주시고 추가적으로 넣어야 할 버튼이 있다면 코멘트 부탁드립니다! 🫡