### PR TITLE
test: parsedImagePath의 테스트 커버리지 충족

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -27,3 +27,4 @@ dist-ssr
 
 *storybook.log
 storybook-static
+coverage

--- a/frontend/__test__/parsedImagePath.test.ts
+++ b/frontend/__test__/parsedImagePath.test.ts
@@ -2,10 +2,26 @@ import { parsedImagePath } from '../src/utils/parsedImagePath';
 
 describe('parsedImagePath 테스트', () => {
   it('이미지의 형식과 경로를 파싱하여 맨 마지막 image 경로만 반환한다', () => {
-    const imagePath =
-      'https://example.com/image1.jpg,https://example.com/image2.jpg,https://example.com/image3.jpg';
+    const imagePath = 'https://example.com/image3.jpg';
     const expected = 'image3';
     const result = parsedImagePath(imagePath);
     expect(result).toBe(expected);
+  });
+
+  it('파일명이 존재하지 않을 경우 빈 문자열을 반환한다', () => {
+    const invalidPath = 'https://example.com/';
+    const result = parsedImagePath(invalidPath);
+    expect(result).toBe('');
+  });
+
+  it('파일명이 없이 확장자만 있을 경우 빈 문자열을 반환한다', () => {
+    const invalidPath = '.jpg';
+    const result = parsedImagePath(invalidPath);
+    expect(result).toBe('');
+  });
+
+  it('지원하지 않는 확장자(.exe)인 경우 빈 문자열을 반환한다', () => {
+    const result = parsedImagePath('https://example.com/file/virus.exe');
+    expect(result).toBe('');
   });
 });

--- a/frontend/src/utils/parsedImagePath.ts
+++ b/frontend/src/utils/parsedImagePath.ts
@@ -1,12 +1,23 @@
 import { DEBUG_MESSAGES } from '../constants/debugMessages';
 
 export const parsedImagePath = (path: string): string => {
-  const reg = /(.*)(.png|.jpg|.jpeg)/;
-  const pathWithoutExtension = path.split(reg)[1];
-  const fileName = pathWithoutExtension.split('/').pop();
-  if (!fileName) {
+  const cleanPath = path.split('?')[0];
+  const segments = cleanPath.split('/');
+  const lastSegment = segments.pop();
+
+  if (!lastSegment) {
     console.warn(DEBUG_MESSAGES.NO_FILE_NAME);
     return '';
   }
+
+  const parts = lastSegment.split('.');
+  const ext = parts.pop()?.toLowerCase();
+  const supportedExtensions = ['jpg', 'jpeg', 'png'];
+  if (!ext || !supportedExtensions.includes(ext)) {
+    console.warn(DEBUG_MESSAGES.NO_FILE_NAME);
+    return '';
+  }
+
+  const fileName = parts.join('.');
   return fileName;
 };


### PR DESCRIPTION
## 연관된 이슈

- close #164 

## 작업 내용

- parsedImagePath에서 확장자가 없는 경우를 찾지 못하는 오류 수정
- parsedImagePath의 테스트 커버리지 충족
<img width="1370" height="509" alt="image" src="https://github.com/user-attachments/assets/c7629d62-1498-4781-9dae-d64037cfb15a" />