### PR TITLE
fix: position으로 top에 gap이 16px 존재하는 오류 수정

### DIFF
--- a/frontend/src/pages/guest/imageUploadPage/ImageUploadPage.styles.ts
+++ b/frontend/src/pages/guest/imageUploadPage/ImageUploadPage.styles.ts
@@ -12,6 +12,10 @@ export const Wrapper = styled.div<{ $hasImages: boolean }>`
   position: relative;
 `;
 
+export const ScrollTopAnchor = styled.div`
+  position: absolute;
+`;
+
 export const TitleContainer = styled.div`
   display: flex;
   flex-direction: column;
@@ -46,6 +50,7 @@ export const ButtonContainer = styled.div`
 
 export const IntersectionArea = styled.div`
   position: absolute;
+  background-color: red;
   bottom: ${({ theme }) => theme.layout.padding.topBottom};
 `;
 

--- a/frontend/src/pages/guest/imageUploadPage/ImageUploadPage.tsx
+++ b/frontend/src/pages/guest/imageUploadPage/ImageUploadPage.tsx
@@ -43,7 +43,7 @@ const ImageUploadPage = () => {
 
   return (
     <S.Wrapper $hasImages={hasImages}>
-      <div ref={scrollTopTriggerRef} />
+      <S.ScrollTopAnchor ref={scrollTopTriggerRef} />
       <SpaceHeader
         title={`${mockSpaceData.name}`}
         description="클릭해서 불러올 수 있어요"


### PR DESCRIPTION
## 연관된 이슈

- close #180 

## 작업 내용

<img width="397" height="745" alt="image" src="https://github.com/user-attachments/assets/0a305cd5-9594-4283-9b3f-a97691ac088b" />

- top에 gap이 16px이 적용되어 있던 문제를 해결하였습니다.

### 원인

- Top으로 끌어올릴 div가 존재하여 gap이 적용되어 있었습니다.

### 해결

- `ScrollTopAnchor`이라는 이름으로, 분리하고, position에 absolute를 적용하였습니다.