### PR TITLE
fix: FloatingIconButton 스타일 수정

### DIFF
--- a/frontend/src/components/@common/buttons/floatingIconButton/FloatingIconButton.styles.ts
+++ b/frontend/src/components/@common/buttons/floatingIconButton/FloatingIconButton.styles.ts
@@ -12,6 +12,6 @@ export const Wrapper = styled.button`
   border-radius: 50%;
   border: 1px solid ${({ theme }) => theme.colors.gray03};
   background-color: ${({ theme }) => theme.colors.white};
-  filter: drop-shadow(5px 5px 5px rgba(0, 0, 0, 0.25));
+  box-shadow: 3px 3px 5px rgba(0, 0, 0, 0.25);
   overflow: hidden;
 `;

--- a/frontend/src/pages/guest/imageUploadPage/ImageUploadPage.styles.ts
+++ b/frontend/src/pages/guest/imageUploadPage/ImageUploadPage.styles.ts
@@ -53,7 +53,7 @@ export const TopButtonContainer = styled.div<{ $isVisible: boolean }>`
   position: fixed;
   bottom: 25px;
   left: 50%;
-  transform: translateX(calc(-50% + 114px));
+  transform: translateX(calc(-50% + 140px));
   z-index: ${({ theme }) => theme.zIndex.floatingActionButton};
   opacity: ${({ $isVisible }) => ($isVisible ? 1 : 0)};
   transition: opacity 0.1s ease-in-out;

--- a/frontend/src/pages/manager/spaceHome/SpaceHome.styles.ts
+++ b/frontend/src/pages/manager/spaceHome/SpaceHome.styles.ts
@@ -42,7 +42,7 @@ export const TopButtonContainer = styled.div<{ $isVisible: boolean }>`
   position: fixed;
   bottom: 25px;
   left: 50%;
-  transform: translateX(calc(-50% + 114px));
+  transform: translateX(calc(-50% + 140px));
   z-index: ${({ theme }) => theme.zIndex.floatingActionButton};
   opacity: ${({ $isVisible }) => ($isVisible ? 1 : 0)};
   transition: opacity 0.1s ease-in-out;


### PR DESCRIPTION
## 연관된 이슈

- close #179

## 작업 내용

- FloatingIconButton의 위치를 최우단으로 정렬
  - 해당 버튼을 사용하는 `ImageUploadPage`, `SpaceHome` 페이지에서 수정
- 최상단으로 이동시키는 FloatingIconButton 그라데이션 수정
	- filter -> box-shadow으로 변경

### 전

<img width="1636" height="386" alt="CleanShot 2025-07-24 at 20 37 16@2x" src="https://github.com/user-attachments/assets/b36d9e91-0e8a-41e6-81de-61b888f91a90" />

### 후

<img width="1530" height="268" alt="CleanShot 2025-07-24 at 20 37 28@2x" src="https://github.com/user-attachments/assets/f4fc3dad-4d16-499c-8bab-4ee61ac0b8ff" />
