### PR TITLE
fix: parsedImagePath에 heic, heif, gif 추가

### DIFF
--- a/frontend/src/utils/parsedImagePath.ts
+++ b/frontend/src/utils/parsedImagePath.ts
@@ -12,7 +12,7 @@ export const parsedImagePath = (path: string): string => {
 
   const parts = lastSegment.split('.');
   const ext = parts.pop()?.toLowerCase();
-  const supportedExtensions = ['jpg', 'jpeg', 'png'];
+  const supportedExtensions = ['jpg', 'jpeg', 'png', 'heic', 'webp', 'heif'];
   if (!ext || !supportedExtensions.includes(ext)) {
     console.warn(DEBUG_MESSAGES.NO_FILE_NAME);
     return '';


### PR DESCRIPTION
## 연관된 이슈

- close #183 

## 작업 내용

- parsedImagePath에 heic, heif, gif 확장명을 추가했습니다.
- 지금은 heic 등의 다른 형식을 모두 jpg로 바꿔서 상관없지만, 나중에 원본을 제공할 때 생길 수 있는 문제입니다.