### PR TITLE
fix: 이미지 형식이 아닌 파일 제한

### DIFF
--- a/frontend/src/hooks/@common/useFileUpload.ts
+++ b/frontend/src/hooks/@common/useFileUpload.ts
@@ -1,7 +1,11 @@
 import { useState } from 'react';
 
-const useFileUpload = () => {
-  const [imageFiles, setImageFiles] = useState<File[]>([]);
+interface FileUploadProps {
+  fileType: string;
+}
+
+const useFileUpload = ({ fileType }: FileUploadProps) => {
+  const [files, setFiles] = useState<File[]>([]);
   const [previewUrls, setPreviewUrls] = useState<string[]>([]);
 
   const addPreviewUrlsFromFiles = (files: File[]) => {
@@ -9,7 +13,7 @@ const useFileUpload = () => {
     setPreviewUrls((prev) => [...prev, ...urls]);
   };
 
-  const isImageFile = (file: File) => file.type.startsWith('image/');
+  const isImageFile = (file: File) => file.type.startsWith(`${fileType}/`);
 
   const handleFilesUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
     //TODO: 파일 업로드 최대 용량 제한 | 업로드 최대 개수 제한?
@@ -21,24 +25,24 @@ const useFileUpload = () => {
         `이미지 파일만 업로드 가능해요. 파일을 다시 확인해주세요.\n${invalidFiles.map((file) => file.name).join('\n')}`,
       );
     }
-    setImageFiles((prev) => [...prev, ...validFiles]);
+    setFiles((prev) => [...prev, ...validFiles]);
     addPreviewUrlsFromFiles(validFiles);
   };
 
   const handleFilesDrop = (event: React.DragEvent<HTMLLabelElement>) => {
     const files = Array.from(event.dataTransfer.files || []);
-    setImageFiles((prev) => [...prev, ...files]);
+    setFiles((prev) => [...prev, ...files]);
     addPreviewUrlsFromFiles(files);
   };
 
   const clearFiles = () => {
     previewUrls.forEach((url) => URL.revokeObjectURL(url));
-    setImageFiles([]);
+    setFiles([]);
     setPreviewUrls([]);
   };
 
   return {
-    imageFiles,
+    files,
     previewUrls,
     handleFilesUpload,
     handleFilesDrop,

--- a/frontend/src/hooks/@common/useFileUpload.ts
+++ b/frontend/src/hooks/@common/useFileUpload.ts
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { isValidFileType } from '../../utils/isValidFileType';
 
 interface FileUploadProps {
   fileType: string;
@@ -7,32 +8,53 @@ interface FileUploadProps {
 const useFileUpload = ({ fileType }: FileUploadProps) => {
   const [files, setFiles] = useState<File[]>([]);
   const [previewUrls, setPreviewUrls] = useState<string[]>([]);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const addPreviewUrlsFromFiles = (files: File[]) => {
     const urls = files.map((file) => URL.createObjectURL(file));
     setPreviewUrls((prev) => [...prev, ...urls]);
   };
 
-  const isImageFile = (file: File) => file.type.startsWith(`${fileType}/`);
+  const partitionValidFilesByType = (files: File[], type: string) => {
+    return files.reduce(
+      (acc, file) => {
+        isValidFileType(file, type)
+          ? acc.validFiles.push(file)
+          : acc.invalidFiles.push(file);
+        return acc;
+      },
+      { validFiles: [] as File[], invalidFiles: [] as File[] },
+    );
+  };
 
   const handleFilesUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
     //TODO: 파일 업로드 최대 용량 제한 | 업로드 최대 개수 제한?
     const files = Array.from(event.target.files || []);
-    const validFiles = files.filter(isImageFile);
-    const invalidFiles = files.filter((file) => !isImageFile(file));
-    if (invalidFiles.length > 0) {
-      alert(
+    const { validFiles, invalidFiles } = partitionValidFilesByType(
+      files,
+      fileType,
+    );
+    if (invalidFiles.length > 0)
+      setErrorMessage(
         `이미지 파일만 업로드 가능해요. 파일을 다시 확인해주세요.\n${invalidFiles.map((file) => file.name).join('\n')}`,
       );
-    }
     setFiles((prev) => [...prev, ...validFiles]);
     addPreviewUrlsFromFiles(validFiles);
   };
 
   const handleFilesDrop = (event: React.DragEvent<HTMLLabelElement>) => {
     const files = Array.from(event.dataTransfer.files || []);
-    setFiles((prev) => [...prev, ...files]);
-    addPreviewUrlsFromFiles(files);
+    const { validFiles, invalidFiles } = partitionValidFilesByType(
+      files,
+      fileType,
+    );
+    if (invalidFiles.length > 0)
+      setErrorMessage(
+        `이미지 파일만 업로드 가능해요. 파일을 다시 확인해주세요.\n${invalidFiles.map((file) => file.name).join('\n')}`,
+      );
+
+    setFiles((prev) => [...prev, ...validFiles]);
+    addPreviewUrlsFromFiles(validFiles);
   };
 
   const clearFiles = () => {
@@ -44,6 +66,7 @@ const useFileUpload = ({ fileType }: FileUploadProps) => {
   return {
     files,
     previewUrls,
+    errorMessage,
     handleFilesUpload,
     handleFilesDrop,
     clearFiles,

--- a/frontend/src/hooks/@common/useFileUpload.ts
+++ b/frontend/src/hooks/@common/useFileUpload.ts
@@ -9,11 +9,20 @@ const useFileUpload = () => {
     setPreviewUrls((prev) => [...prev, ...urls]);
   };
 
+  const isImageFile = (file: File) => file.type.startsWith('image/');
+
   const handleFilesUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
     //TODO: 파일 업로드 최대 용량 제한 | 업로드 최대 개수 제한?
     const files = Array.from(event.target.files || []);
-    setImageFiles((prev) => [...prev, ...files]);
-    addPreviewUrlsFromFiles(files);
+    const validFiles = files.filter(isImageFile);
+    const invalidFiles = files.filter((file) => !isImageFile(file));
+    if (invalidFiles.length > 0) {
+      alert(
+        `이미지 파일만 업로드 가능해요. 파일을 다시 확인해주세요.\n${invalidFiles.map((file) => file.name).join('\n')}`,
+      );
+    }
+    setImageFiles((prev) => [...prev, ...validFiles]);
+    addPreviewUrlsFromFiles(validFiles);
   };
 
   const handleFilesDrop = (event: React.DragEvent<HTMLLabelElement>) => {

--- a/frontend/src/pages/guest/imageUploadPage/ImageUploadPage.tsx
+++ b/frontend/src/pages/guest/imageUploadPage/ImageUploadPage.tsx
@@ -15,13 +15,8 @@ import * as S from './ImageUploadPage.styles';
 import { mockSpaceData } from './mockSpaceData';
 
 const ImageUploadPage = () => {
-  const {
-    imageFiles,
-    previewUrls,
-    handleFilesUpload,
-    handleFilesDrop,
-    clearFiles,
-  } = useFileUpload();
+  const { files, previewUrls, handleFilesUpload, handleFilesDrop, clearFiles } =
+    useFileUpload({ fileType: 'image' });
   const hasImages = Array.isArray(previewUrls) && previewUrls.length > 0;
   const uploadBoxText = '함께한 순간을 올려주세요';
   const { targetRef: hideBlurAreaTriggerRef, isIntersecting: isAtPageBottom } =
@@ -31,7 +26,7 @@ const ImageUploadPage = () => {
 
   const handleUpload = async () => {
     try {
-      await photoService.uploadFiles('1234567890', imageFiles);
+      await photoService.uploadFiles('1234567890', files);
       //TODO: 완성 페이지로 이동
       alert('사진 업로드가 완료되었습니다.');
       clearFiles();

--- a/frontend/src/pages/guest/imageUploadPage/ImageUploadPage.tsx
+++ b/frontend/src/pages/guest/imageUploadPage/ImageUploadPage.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { ReactComponent as ArrowUpSvg } from '../../../@assets/icons/upwardArrow.svg';
 import { photoService } from '../../../apis/services/photo.service';
 import FloatingActionButton from '../../../components/@common/buttons/floatingActionButton/FloatingActionButton';
@@ -15,8 +16,14 @@ import * as S from './ImageUploadPage.styles';
 import { mockSpaceData } from './mockSpaceData';
 
 const ImageUploadPage = () => {
-  const { files, previewUrls, handleFilesUpload, handleFilesDrop, clearFiles } =
-    useFileUpload({ fileType: 'image' });
+  const {
+    files,
+    previewUrls,
+    errorMessage,
+    handleFilesUpload,
+    handleFilesDrop,
+    clearFiles,
+  } = useFileUpload({ fileType: 'image' });
   const hasImages = Array.isArray(previewUrls) && previewUrls.length > 0;
   const uploadBoxText = '함께한 순간을 올려주세요';
   const { targetRef: hideBlurAreaTriggerRef, isIntersecting: isAtPageBottom } =
@@ -36,6 +43,13 @@ const ImageUploadPage = () => {
     }
   };
 
+  //TODO: 에러 토스트 구현 후 사라질 로직
+  useEffect(() => {
+    if (errorMessage) {
+      alert(errorMessage);
+    }
+  }, [errorMessage]);
+
   return (
     <S.Wrapper $hasImages={hasImages}>
       <div ref={scrollTopTriggerRef} />
@@ -43,7 +57,6 @@ const ImageUploadPage = () => {
         title={`${mockSpaceData.name}`}
         description="클릭해서 불러올 수 있어요"
       />
-
       <S.UploadContainer $hasImages={hasImages}>
         <UploadBox
           text={uploadBoxText}

--- a/frontend/src/utils/isValidFileType.ts
+++ b/frontend/src/utils/isValidFileType.ts
@@ -1,0 +1,3 @@
+export const isValidFileType = (file: File, expectedType: string): boolean => {
+  return file.type.startsWith(`${expectedType}/`);
+};


### PR DESCRIPTION
## 연관된 이슈

- close #186

## 작업 내용

https://github.com/user-attachments/assets/6415c829-8e32-46a3-b18b-0dc764358731

- 용량이슈로 클릭 이벤트일 때 alert를 띄우는 것은 안올라가지만, 동일하게 적용됩니다.

- useFile hook이 기존에는 image 형식에만 대응할 수 있도록 되어 있는데, 확장성을 고려하여 fielType을 받아서 처리할 수 있도록 구현하였습니다.
- 현재 파일의 타입이 유효한지 검사하는 util을 추가하였습니다.
- 추후 errorToast를 구현할 것을 대비하여, useFileUpload에서 직접 alert를 주기보다는 errorMessage를 export하도록 수정하였습니다.
그래서 uploadPage에 useEffect가 존재하지만, 추후 없어질 예정입니다.