### PR TITLE
fix: 모바일 이미지 그리드 열 기준 수정

### DIFF
--- a/frontend/src/components/@common/imageGrid/ImageGrid.styles.ts
+++ b/frontend/src/components/@common/imageGrid/ImageGrid.styles.ts
@@ -6,7 +6,7 @@ export const Wrapper = styled.div<{ $rowImageAmount: number }>`
   height: 100%;
   display: grid;
   align-items: start;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
   max-height: 100%;
   border-top-left-radius: 12px;
   border-top-right-radius: 12px;


### PR DESCRIPTION
## 연관된 이슈

- close #191 

## 작업 내용

- 모바일 환경에서 3 column으로 보일 수 있도록 기준 수정
  - 일반적인 모바일 화면: 320px ~ 414px
  - 100px × 3 = 300px + gap 고려
  - 320px 화면에서도 3개가 들어갈 수 있음

### 코드

120px에서 100px로 변경했어요.

`grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));` 

### 스크린샷

<img width="400" height="1372" alt="CleanShot 2025-07-24 at 22 14 43@2x" src="https://github.com/user-attachments/assets/00419761-a74a-435d-b229-6904ae4c43b4" />

