### PR TITLE
refactor: FloatingIconButton 반응형 적용 및 크기 확대

### DIFF
--- a/frontend/src/components/@common/buttons/floatingIconButton/FloatingIconButton.styles.ts
+++ b/frontend/src/components/@common/buttons/floatingIconButton/FloatingIconButton.styles.ts
@@ -5,8 +5,8 @@ export const Wrapper = styled.button`
   flex-direction: row;
   justify-content: center;
   align-items: center;
-  width: 30px;
-  height: 30px;
+  width: 40px;
+  height: 40px;
   white-space: nowrap;
 
   border-radius: 50%;

--- a/frontend/src/pages/guest/imageUploadPage/ImageUploadPage.styles.ts
+++ b/frontend/src/pages/guest/imageUploadPage/ImageUploadPage.styles.ts
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { theme } from '../../../styles/theme';
 
 export const Wrapper = styled.div<{ $hasImages: boolean }>`
   ${({ theme }) => theme.typography.header03}
@@ -62,7 +63,7 @@ export const TopButtonContainer = styled.div<{ $isVisible: boolean }>`
   opacity: ${({ $isVisible }) => ($isVisible ? 1 : 0)};
   transition: opacity 0.1s ease-in-out;
 
-  @media screen and (max-width: 375px) {
+  @media screen and (max-width: ${theme.breakpoints.mobile}) {
     transform: translateX(calc(-50% + 140px));
   }
 `;

--- a/frontend/src/pages/guest/imageUploadPage/ImageUploadPage.styles.ts
+++ b/frontend/src/pages/guest/imageUploadPage/ImageUploadPage.styles.ts
@@ -55,12 +55,16 @@ export const IntersectionArea = styled.div`
 
 export const TopButtonContainer = styled.div<{ $isVisible: boolean }>`
   position: fixed;
-  bottom: 25px;
+  bottom: 21px;
   left: 50%;
-  transform: translateX(calc(-50% + 140px));
+  transform: translateX(calc(-50% + 150px));
   z-index: ${({ theme }) => theme.zIndex.floatingActionButton};
   opacity: ${({ $isVisible }) => ($isVisible ? 1 : 0)};
   transition: opacity 0.1s ease-in-out;
+
+  @media screen and (max-width: 375px) {
+    transform: translateX(calc(-50% + 140px));
+  }
 `;
 
 export const LoadingSpinnerContainer = styled.div`

--- a/frontend/src/pages/manager/spaceHome/SpaceHome.styles.ts
+++ b/frontend/src/pages/manager/spaceHome/SpaceHome.styles.ts
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { ReactComponent as GiftIcon } from '../../../@assets/icons/gift.svg';
+import { theme } from '../../../styles/theme';
 import { hexToRgba } from '../../../utils/hexToRgba';
 
 export const Wrapper = styled.div`
@@ -46,7 +47,7 @@ export const TopButtonContainer = styled.div<{ $isVisible: boolean }>`
   opacity: ${({ $isVisible }) => ($isVisible ? 1 : 0)};
   transition: opacity 0.1s ease-in-out;
 
-  @media screen and (max-width: 375px) {
+  @media screen and (max-width: ${theme.breakpoints.mobile}) {
     transform: translateX(calc(-50% + 140px));
   }
 `;

--- a/frontend/src/pages/manager/spaceHome/SpaceHome.styles.ts
+++ b/frontend/src/pages/manager/spaceHome/SpaceHome.styles.ts
@@ -39,12 +39,16 @@ export const IntersectionArea = styled.div`
 
 export const TopButtonContainer = styled.div<{ $isVisible: boolean }>`
   position: fixed;
-  bottom: 25px;
+  bottom: 21px;
   left: 50%;
-  transform: translateX(calc(-50% + 140px));
+  transform: translateX(calc(-50% + 150px));
   z-index: ${({ theme }) => theme.zIndex.floatingActionButton};
   opacity: ${({ $isVisible }) => ($isVisible ? 1 : 0)};
   transition: opacity 0.1s ease-in-out;
+
+  @media screen and (max-width: 375px) {
+    transform: translateX(calc(-50% + 140px));
+  }
 `;
 
 export const NoImageContainer = styled.div`

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -90,4 +90,8 @@ export const theme = {
       leftRight: '16px',
     },
   },
+  breakpoints: {
+    desktop: '',
+    mobile: '375px',
+  },
 };


### PR DESCRIPTION
## 연관된 이슈

- close #204 

## 작업 내용

- 미디어 쿼리를 적용해 모바일과 데스크탑 화면에서 최적화되어 보이도록 구현
- 버튼 크기가 작아서 모바일에서 클릭하기 어려웠던 문제를 버튼 크기를 확대해서 해결

### 스크린샷과 영상

<img width="786" height="212" alt="CleanShot 2025-07-28 at 19 33 17@2x" src="https://github.com/user-attachments/assets/ab829df4-bffe-408a-bf7f-5c0053effabf" />


https://github.com/user-attachments/assets/4f6336a0-9b9e-4522-a559-b51ae5a367e4



## 참고 자료

### 반응형 break point 기준

미디어 쿼리를 375px 기준으로 했는데, 이는 아이폰 SE의 width를 기준으로 한 것입니다. 

```
@media screen and (max-width: 375px) {
```

### FloatingIconButton 크기

무신사와 GS Shop가 width, height 40px을 사용하고 있어, 동일하게 FloatingIconButton의 크기를 적용했어요.

<img width="300" height="1328" alt="CleanShot 2025-07-28 at 14 50 57@2x" src="https://github.com/user-attachments/assets/5448196c-71dc-4de0-a9bb-32e4bbc3c8ef" />

<img width="300" height="1340" alt="CleanShot 2025-07-28 at 14 50 40@2x" src="https://github.com/user-attachments/assets/e9d9594a-a5a1-4dd2-8b7c-3b71d4d66f70" />
