### PR TITLE
fix: iOS에서 백스페이스를 2번 눌러야 input에 입력된 값이 삭제되는 문제 해결

### DIFF
--- a/frontend/__test__/useInputLength.test.tsx
+++ b/frontend/__test__/useInputLength.test.tsx
@@ -5,7 +5,11 @@ import useInputLength from '../src/hooks/@common/useInputLength';
 describe('useInputLength 훅 테스트', () => {
   it('value가 maxCount보다 길면 splicedValue는 maxCount만큼 잘린다.', () => {
     const { result } = renderHook(() =>
-      useInputLength({ value: '1234567890', maxCount: 5 }),
+      useInputLength({
+        value: '1234567890',
+        maxCount: 5,
+        updateValue: () => {},
+      }),
     );
 
     expect(result.current.splicedValue).toBe('12345');
@@ -16,7 +20,11 @@ describe('useInputLength 훅 테스트', () => {
     const expectedValue = '가나다라ㅁ';
 
     const { result } = renderHook(() =>
-      useInputLength({ value: inputValue, maxCount: 5 }),
+      useInputLength({
+        value: inputValue,
+        maxCount: 5,
+        updateValue: () => {},
+      }),
     );
 
     expect(result.current.splicedValue).toBe(expectedValue);
@@ -26,7 +34,11 @@ describe('useInputLength 훅 테스트', () => {
     const inputValue = '가나다라마ㅂ';
     const expectedValue = '가나다라마';
     const { result } = renderHook(() =>
-      useInputLength({ value: inputValue, maxCount: 5 }),
+      useInputLength({
+        value: inputValue,
+        maxCount: 5,
+        updateValue: () => {},
+      }),
     );
 
     act(() => {
@@ -40,12 +52,19 @@ describe('useInputLength 훅 테스트', () => {
     const inputValue = '가나다라마바사아자차카타파하';
     const expectedValue = '가나다라마';
     const { result } = renderHook(() =>
-      useInputLength({ value: inputValue, maxCount: 5 }),
+      useInputLength({
+        value: inputValue,
+        maxCount: 5,
+        updateValue: () => {},
+      }),
     );
 
     const mockEvent = {
-      currentTarget: { value: inputValue },
-    } as React.CompositionEvent<HTMLInputElement>;
+      currentTarget: {
+        value: '가나다라마',
+        blur: jest.fn(),
+      },
+    } as unknown as React.CompositionEvent<HTMLInputElement>;
 
     act(() => {
       result.current.handleCompositionEnd(mockEvent);

--- a/frontend/src/components/@common/input/Input.tsx
+++ b/frontend/src/components/@common/input/Input.tsx
@@ -4,11 +4,23 @@ import * as S from './Input.styles';
 interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   errorMessage?: string;
   maxCount: number;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  value: string;
+  updateValue: (value: string) => void;
 }
 
-const Input = ({ errorMessage, maxCount, ...inputProps }: InputProps) => {
-  const { splicedValue, handleCompositionEnd, handleCompositionStart } =
-    useInputLength({ maxCount, value: String(inputProps.value) });
+const Input = ({
+  errorMessage,
+  maxCount,
+  updateValue,
+  ...inputProps
+}: InputProps) => {
+  const { handleCompositionEnd, handleCompositionStart, handleChange } =
+    useInputLength({
+      maxCount,
+      value: String(inputProps.value),
+      updateValue: updateValue,
+    });
 
   return (
     <S.Wrapper>
@@ -16,15 +28,16 @@ const Input = ({ errorMessage, maxCount, ...inputProps }: InputProps) => {
         {...inputProps}
         id={inputProps.id}
         aria-label={inputProps['aria-label']}
-        value={splicedValue}
+        value={inputProps.value}
         onCompositionStart={handleCompositionStart}
         onCompositionEnd={handleCompositionEnd}
+        onChange={handleChange}
         $isError={!!errorMessage}
       />
       <S.InputFooterContainer>
         <S.ErrorMessage>{errorMessage ? errorMessage : ''}</S.ErrorMessage>
         <S.InputCount>
-          {maxCount && `${splicedValue.length} / ${maxCount}`}
+          {maxCount && `${inputProps.value.length} / ${maxCount}`}
         </S.InputCount>
       </S.InputFooterContainer>
     </S.Wrapper>

--- a/frontend/src/components/@common/input/Input.tsx
+++ b/frontend/src/components/@common/input/Input.tsx
@@ -15,7 +15,7 @@ const Input = ({
   updateValue,
   ...inputProps
 }: InputProps) => {
-  const { handleCompositionEnd, handleCompositionStart, handleChange } =
+  const { splicedValue, handleCompositionEnd, handleCompositionStart } =
     useInputLength({
       maxCount,
       value: String(inputProps.value),
@@ -28,16 +28,15 @@ const Input = ({
         {...inputProps}
         id={inputProps.id}
         aria-label={inputProps['aria-label']}
-        value={inputProps.value}
+        value={splicedValue}
         onCompositionStart={handleCompositionStart}
         onCompositionEnd={handleCompositionEnd}
-        onChange={handleChange}
         $isError={!!errorMessage}
       />
       <S.InputFooterContainer>
         <S.ErrorMessage>{errorMessage ? errorMessage : ''}</S.ErrorMessage>
         <S.InputCount>
-          {maxCount && `${inputProps.value.length} / ${maxCount}`}
+          {maxCount && `${splicedValue.length} / ${maxCount}`}
         </S.InputCount>
       </S.InputFooterContainer>
     </S.Wrapper>

--- a/frontend/src/hooks/@common/useInputLength.ts
+++ b/frontend/src/hooks/@common/useInputLength.ts
@@ -3,10 +3,22 @@ import { useRef } from 'react';
 interface useInputLengthProps {
   value: string;
   maxCount: number;
+  updateValue: (value: string) => void;
 }
 
-const useInputLength = ({ value, maxCount }: useInputLengthProps) => {
+const useInputLength = ({
+  value,
+  maxCount,
+  updateValue,
+}: useInputLengthProps) => {
   const isComposingRef = useRef<boolean>(false);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const rawValue = e.currentTarget.value;
+    const shouldSlice = isComposingRef.current && rawValue.length <= maxCount;
+    const patchedValue = shouldSlice ? rawValue : rawValue.slice(0, maxCount);
+    updateValue(patchedValue);
+  };
 
   const handleCompositionStart = () => {
     isComposingRef.current = true;
@@ -15,16 +27,34 @@ const useInputLength = ({ value, maxCount }: useInputLengthProps) => {
     e: React.CompositionEvent<HTMLInputElement>,
   ) => {
     if (!value || !maxCount) return;
+    const currentTarget = e.currentTarget;
 
-    const currentValue = e.currentTarget.value;
-    if (currentValue.length > maxCount) {
-      e.currentTarget.value = currentValue.slice(0, maxCount);
+    const currentValue = currentTarget.value;
+    const shouldSlice = currentValue.length >= maxCount;
+    const patchedValue = shouldSlice
+      ? currentValue.slice(0, maxCount)
+      : currentValue;
+    updateValue(patchedValue);
+    currentTarget.value = patchedValue;
+    if (shouldSlice) {
+      currentTarget.blur();
+      setTimeout(() => {
+        currentTarget.focus();
+        currentTarget.setSelectionRange(
+          patchedValue.length,
+          patchedValue.length,
+        );
+      }, 0);
     }
+
     isComposingRef.current = false;
   };
-  const splicedValue = String(value).slice(0, maxCount);
 
-  return { splicedValue, handleCompositionEnd, handleCompositionStart };
+  return {
+    handleCompositionEnd,
+    handleCompositionStart,
+    handleChange,
+  };
 };
 
 export default useInputLength;

--- a/frontend/src/hooks/@common/useInputLength.ts
+++ b/frontend/src/hooks/@common/useInputLength.ts
@@ -13,13 +13,6 @@ const useInputLength = ({
 }: useInputLengthProps) => {
   const isComposingRef = useRef<boolean>(false);
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const rawValue = e.currentTarget.value;
-    const shouldSlice = isComposingRef.current && rawValue.length <= maxCount;
-    const patchedValue = shouldSlice ? rawValue : rawValue.slice(0, maxCount);
-    updateValue(patchedValue);
-  };
-
   const handleCompositionStart = () => {
     isComposingRef.current = true;
   };
@@ -39,21 +32,19 @@ const useInputLength = ({
     if (shouldSlice) {
       currentTarget.blur();
       setTimeout(() => {
-        currentTarget.focus();
-        currentTarget.setSelectionRange(
-          patchedValue.length,
-          patchedValue.length,
-        );
+        currentTarget.blur();
       }, 0);
     }
 
     isComposingRef.current = false;
   };
 
+  const splicedValue = value.slice(0, maxCount);
+
   return {
     handleCompositionEnd,
     handleCompositionStart,
-    handleChange,
+    splicedValue,
   };
 };
 

--- a/frontend/src/pages/demo/DemoHome.tsx
+++ b/frontend/src/pages/demo/DemoHome.tsx
@@ -1,20 +1,11 @@
 import rocketImage from '@assets/images/rocket.png';
-import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Button from '../../components/@common/buttons/button/Button';
-import Input from '../../components/@common/input/Input';
 import { ROUTES } from '../../constants/routes';
 import * as S from './DemoHome.styles';
 
 const DemoHome = () => {
   const navigate = useNavigate();
-  const [value, setValue] = useState('');
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setValue(e.target.value);
-  };
-  const updateValue = (value: string) => {
-    setValue(value);
-  };
 
   return (
     <S.Wrapper>
@@ -27,12 +18,6 @@ const DemoHome = () => {
       <Button
         text="(MANAGER) 스페이스 관리 페이지 이동"
         onClick={() => navigate(ROUTES.MANAGER.SPACE_HOME)}
-      />
-      <Input
-        maxCount={10}
-        value={value}
-        onChange={handleChange}
-        updateValue={updateValue}
       />
     </S.Wrapper>
   );

--- a/frontend/src/pages/demo/DemoHome.tsx
+++ b/frontend/src/pages/demo/DemoHome.tsx
@@ -1,11 +1,20 @@
 import rocketImage from '@assets/images/rocket.png';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Button from '../../components/@common/buttons/button/Button';
+import Input from '../../components/@common/input/Input';
 import { ROUTES } from '../../constants/routes';
 import * as S from './DemoHome.styles';
 
 const DemoHome = () => {
   const navigate = useNavigate();
+  const [value, setValue] = useState('');
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(e.target.value);
+  };
+  const updateValue = (value: string) => {
+    setValue(value);
+  };
 
   return (
     <S.Wrapper>
@@ -18,6 +27,12 @@ const DemoHome = () => {
       <Button
         text="(MANAGER) 스페이스 관리 페이지 이동"
         onClick={() => navigate(ROUTES.MANAGER.SPACE_HOME)}
+      />
+      <Input
+        maxCount={10}
+        value={value}
+        onChange={handleChange}
+        updateValue={updateValue}
       />
     </S.Wrapper>
   );

--- a/frontend/src/pages/manager/spaceHome/SpaceHome.tsx
+++ b/frontend/src/pages/manager/spaceHome/SpaceHome.tsx
@@ -1,6 +1,5 @@
 import downloadLoadingSpinner from '@assets/loading-spinner.gif';
 import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { ReactComponent as SaveIcon } from '../../../@assets/icons/download.svg';
 import { ReactComponent as SettingSvg } from '../../../@assets/icons/setting.svg';
 import { ReactComponent as ArrowUpSvg } from '../../../@assets/icons/upwardArrow.svg';


### PR DESCRIPTION
## 연관된 이슈

- close #51

## 작업 내용
* iOS에서 maxLength에 도달했을 경우 백스페이스를 두 번 눌러야 입력값이 삭제 되는 문제 원인 발견
* IME 조합 문제로 본질적인 해결 불가하다고 판단, 우회 해결책으로 maxLength에 도달했을 경우 input의 focus를 제거함

[📝노션 문서](https://catkin-chokeberry-f58.notion.site/onCompositionEnd-onCompositionStart-238864a9cb03803b979ff2dc2774e9c7?source=copy_link)

## 리뷰 받고 싶은 부분
* 해당 이슈가 IME 조합 처리로 인한 문제가 아닌, 로직 측면의 문제일 수 있으니 코드 검토 부탁드립니다
* splicedValue는 UI에 표시되는 값이며, value는 실제 DOM에 반영되는 입력값입니다.
: value 상태만으로도 slice 등의 제어는 가능하지만, UI에 보여줄 값과 DOM에 실제 반영되는 값을 분리함으로써 로직을 더 명확하게 이해할 수 있을 것이라 판단해 나누어 사용했습니다. 이 방식에 대해 어떻게 생각하시는지도 함께 피드백 주시면 감사하겠습니다!