### PR TITLE
fix: usePhotosBySpaceCode import 에러 해결

### DIFF
--- a/frontend/src/hooks/usePhotosBySpaceCode.ts
+++ b/frontend/src/hooks/usePhotosBySpaceCode.ts
@@ -1,5 +1,6 @@
 import { useMemo, useRef, useState } from 'react';
 import { photoService } from '../apis/services/photo.service';
+import { DEBUG_MESSAGES } from '../constants/debugMessages';
 import { NETWORK } from '../constants/errors';
 import type { Photo } from '../types/photo.type';
 import { buildThumbnailUrl } from '../utils/buildImageUrl';


### PR DESCRIPTION
## 연관된 이슈

- close #240

## 작업 내용

깃허브에서 conflict를 해결하며, import가 제대로 되어있지 않아 npm start로 로컬에서 실행했을 때 오류가 발생했습니다. 
이를 해결하기 위해 `usePhotosBySpaceCode`에 import를 추가했습니다.