### PR TITLE
fix: 별 위치 수정

### DIFF
--- a/frontend/src/components/layout/starField/StarField.styles.ts
+++ b/frontend/src/components/layout/starField/StarField.styles.ts
@@ -7,8 +7,9 @@ export const Wrapper = styled.div`
   top: 0;
   left: 0;
   width: 100%;
-  height: 100vh;
+  height: 100%;
   pointer-events: none;
+  overflow: hidden;
 `;
 
 export const StarContainer = styled.div<{


### PR DESCRIPTION
## 연관된 이슈

- close #285 

## 작업 내용

- 별이 고정 위치에 박혀있고 따라가지 않는 문제가 있었으나 `height: 100%`로 수정하였습니다.
- 별의 크기가 달라짐에 따라 scroll이 생기는 문제가 있었으나 `overflow: hidden`으로 수정하였습니다.
- svg에게 style-prop이 전달될 때 발생하는 오류를 해결하였습니다.
<img width="425" height="88" alt="image" src="https://github.com/user-attachments/assets/5b47b4f6-a2fb-40d5-9d42-a5646656cbaf" />
