### PR TITLE
fix: JSON 형식이 아닌 응답에서 parsing하는 오류 해결

### DIFF
--- a/frontend/src/apis/http.ts
+++ b/frontend/src/apis/http.ts
@@ -59,8 +59,10 @@ const request = async <T>(
         error: !response.ok ? `Error: ${response.status}` : undefined,
       };
     }
+    console.log(response);
 
-    const data = await response.json();
+    const text = await response.text();
+    const data = text ? JSON.parse(text) : null;
 
     if (!response.ok) {
       return {
@@ -74,7 +76,7 @@ const request = async <T>(
       data: data as T,
     };
   } catch (error) {
-    console.log(error);
+    console.log(`여기서 에러 발생 : ${error}`);
     const getErrorMessage = (error: unknown): string => {
       if (isNetworkError(error)) {
         return NETWORK.DEFAULT;


### PR DESCRIPTION
## 연관된 이슈

- close #291

## 작업 내용
* 오류 내용
```
SyntaxError: Failed to execute 'json' on 'Response': Unexpected end of JSON input
    at eval (http.ts:84:27)
    at Generator.eval (http.ts:10:1660)
    at Generator.eval [as next] (http.ts:11:362)
    at asyncGeneratorStep (http.ts:12:70)
    at _next (http.ts:13:163)

```
* JSON 형식이 아닌 응답에서 parsing 하는 오류 해결