### PR TITLE
feature: spaceCode 기반 라우터 연결

### DIFF
--- a/frontend/src/apis/http.ts
+++ b/frontend/src/apis/http.ts
@@ -59,7 +59,6 @@ const request = async <T>(
         error: !response.ok ? `Error: ${response.status}` : undefined,
       };
     }
-    console.log(response);
 
     const text = await response.text();
     const data = text ? JSON.parse(text) : null;

--- a/frontend/src/components/layout/Layout.styles.ts
+++ b/frontend/src/components/layout/Layout.styles.ts
@@ -6,7 +6,6 @@ export const Container = styled.div<{ $isHighlightPage: boolean }>`
   max-width: ${({ theme }) => theme.layout.width};
   width: 100%;
   padding: ${({ theme }) => `${theme.layout.padding.topBottom} ${theme.layout.padding.leftRight}`};
-  //border: 1px solid #000; // TODO: 개발 시 border 살리기
   min-height: 100dvh;
   background: ${({ theme, $isHighlightPage }) =>
     $isHighlightPage

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -8,7 +8,9 @@ const Layout = () => {
   const { pathname } = useLocation();
   useGoogleAnalytics();
 
-  const isHighlightPage = HIGHLIGHT_PAGES.includes(pathname);
+  const isHighlightPage = HIGHLIGHT_PAGES.some((page) =>
+    pathname.includes(page),
+  );
 
   return (
     <S.Container $isHighlightPage={isHighlightPage}>

--- a/frontend/src/constants/routes.ts
+++ b/frontend/src/constants/routes.ts
@@ -2,10 +2,10 @@ export const ROUTES = {
   MAIN: '/',
   CREATE: '/create',
   MANAGER: {
-    SPACE_HOME: '/manager/space-home',
+    SPACE_HOME: (spaceId: string) => `/manager/space-home/${spaceId}`,
   },
   GUEST: {
-    IMAGE_UPLOAD: '/guest/image-upload',
+    IMAGE_UPLOAD: (spaceId: string) => `/guest/image-upload/${spaceId}`,
     SHARE: '/guest/share',
   },
   COMPLETE: {
@@ -19,6 +19,6 @@ export const ROUTES = {
 } as const;
 
 export const HIGHLIGHT_PAGES: readonly string[] = [
-  ROUTES.MANAGER.SPACE_HOME,
-  ROUTES.GUEST.IMAGE_UPLOAD,
+  ROUTES.MANAGER.SPACE_HOME(''),
+  ROUTES.GUEST.IMAGE_UPLOAD(''),
 ];

--- a/frontend/src/constants/routes.ts
+++ b/frontend/src/constants/routes.ts
@@ -22,3 +22,6 @@ export const HIGHLIGHT_PAGES: readonly string[] = [
   ROUTES.MANAGER.SPACE_HOME(''),
   ROUTES.GUEST.IMAGE_UPLOAD(''),
 ];
+
+export const createSpaceUrl = (spaceId: string) =>
+  process.env.DOMAIN + ROUTES.MANAGER.SPACE_HOME(spaceId);

--- a/frontend/src/constants/routes.ts
+++ b/frontend/src/constants/routes.ts
@@ -22,6 +22,3 @@ export const HIGHLIGHT_PAGES: readonly string[] = [
   ROUTES.MANAGER.SPACE_HOME(''),
   ROUTES.GUEST.IMAGE_UPLOAD(''),
 ];
-
-export const createSpaceUrl = (spaceId: string) =>
-  process.env.DOMAIN + ROUTES.MANAGER.SPACE_HOME(spaceId);

--- a/frontend/src/hooks/useSpaceCodeFromPath.ts
+++ b/frontend/src/hooks/useSpaceCodeFromPath.ts
@@ -3,9 +3,13 @@ import { useLocation } from 'react-router-dom';
 const useSpaceCodeFromPath = () => {
   const { pathname } = useLocation();
 
-  const match = pathname.match(/^\/(?:upload|space)\/(\d+)$/);
+  const match = pathname.match(
+    /^\/(manager|guest)\/(space-home|image-upload)\/([^/]+)$/,
+  );
 
-  return match ? match[1] : null;
+  const spaceId = match ? match[3] : null;
+
+  return { spaceId };
 };
 
 export default useSpaceCodeFromPath;

--- a/frontend/src/hooks/useSpaceInfo.ts
+++ b/frontend/src/hooks/useSpaceInfo.ts
@@ -22,7 +22,6 @@ const useSpaceInfo = (spaceCode: string) => {
           throw new Error('스페이스 코드 정보를 불러오는데 실패했습니다.');
         }
 
-        console.log(response);
         const data = response.data;
         setSpaceInfo(data);
       } catch (error) {

--- a/frontend/src/pages/complete/DownloadCompletePage.tsx
+++ b/frontend/src/pages/complete/DownloadCompletePage.tsx
@@ -3,13 +3,14 @@ import { useNavigate } from 'react-router-dom';
 import MessageLayout from '../../components/layout/messageLayout/MessageLayout';
 import { COMPLETE } from '../../constants/messages';
 import { ROUTES } from '../../constants/routes';
+import useSpaceCodeFromPath from '../../hooks/useSpaceCodeFromPath';
 
 const DownloadCompletePage = () => {
+  const { spaceId } = useSpaceCodeFromPath();
   const navigate = useNavigate();
 
   const handleButtonClick = () => {
-    // TODO: 실제 매니저 스페이스 홈 경로로 변경 필요
-    navigate(ROUTES.MANAGER.SPACE_HOME);
+    navigate(ROUTES.MANAGER.SPACE_HOME(spaceId ?? ''));
   };
 
   return (

--- a/frontend/src/pages/complete/SpaceCreatedCompletePage.tsx
+++ b/frontend/src/pages/complete/SpaceCreatedCompletePage.tsx
@@ -3,13 +3,14 @@ import { useNavigate } from 'react-router-dom';
 import MessageLayout from '../../components/layout/messageLayout/MessageLayout';
 import { COMPLETE } from '../../constants/messages';
 import { ROUTES } from '../../constants/routes';
+import useSpaceCodeFromPath from '../../hooks/useSpaceCodeFromPath';
 
 const SpaceCreatedCompletePage = () => {
   const navigate = useNavigate();
+  const { spaceId } = useSpaceCodeFromPath();
 
   const handleButtonClick = () => {
-    // TODO: 실제 매니저 스페이스 홈 경로로 변경 필요
-    navigate(ROUTES.MANAGER.SPACE_HOME);
+    navigate(ROUTES.MANAGER.SPACE_HOME(spaceId ?? ''));
   };
 
   return (

--- a/frontend/src/pages/complete/UploadCompletePage.tsx
+++ b/frontend/src/pages/complete/UploadCompletePage.tsx
@@ -3,13 +3,14 @@ import { useNavigate } from 'react-router-dom';
 import MessageLayout from '../../components/layout/messageLayout/MessageLayout';
 import { COMPLETE } from '../../constants/messages';
 import { ROUTES } from '../../constants/routes';
+import useSpaceCodeFromPath from '../../hooks/useSpaceCodeFromPath';
 
 const UploadCompletePage = () => {
   const navigate = useNavigate();
+  const { spaceId } = useSpaceCodeFromPath();
 
   const handleButtonClick = () => {
-    // TODO: 실제 업로드 페이지 경로로 변경 필요
-    navigate(ROUTES.GUEST.IMAGE_UPLOAD);
+    navigate(ROUTES.GUEST.IMAGE_UPLOAD(spaceId ?? ''));
   };
 
   return (

--- a/frontend/src/pages/demo/DemoHome.tsx
+++ b/frontend/src/pages/demo/DemoHome.tsx
@@ -6,6 +6,7 @@ import { ROUTES } from '../../constants/routes';
 import * as S from './DemoHome.styles';
 
 const DemoHome = () => {
+  const MOCK_SPACE_ID = '0b117a24a4';
   const navigate = useNavigate();
   const testFunc = () => {
     try {
@@ -27,11 +28,11 @@ const DemoHome = () => {
       />
       <Button
         text="(GUEST) 스페이스 업로드 페이지"
-        onClick={() => navigate(ROUTES.GUEST.IMAGE_UPLOAD)}
+        onClick={() => navigate(ROUTES.GUEST.IMAGE_UPLOAD(MOCK_SPACE_ID))}
       />
       <Button
         text="(MANAGER) 스페이스 관리 페이지 이동"
-        onClick={() => navigate(ROUTES.MANAGER.SPACE_HOME)}
+        onClick={() => navigate(ROUTES.MANAGER.SPACE_HOME(MOCK_SPACE_ID))}
       />
       <Button text="테스트 에러 발생" onClick={testFunc} />
     </S.Wrapper>

--- a/frontend/src/pages/guest/imageUploadPage/ImageUploadPage.tsx
+++ b/frontend/src/pages/guest/imageUploadPage/ImageUploadPage.tsx
@@ -13,15 +13,16 @@ import useFileUpload from '../../../hooks/@common/useFileUpload';
 import useIntersectionObserver from '../../../hooks/@common/useIntersectionObserver';
 import useLeftTimer from '../../../hooks/@common/useLeftTimer';
 import { useToast } from '../../../hooks/@common/useToast';
+import useSpaceCodeFromPath from '../../../hooks/useSpaceCodeFromPath';
 import useSpaceInfo from '../../../hooks/useSpaceInfo';
 import { ScrollableBlurArea } from '../../../styles/@common/ScrollableBlurArea';
 import { theme } from '../../../styles/theme';
 import { goToTop } from '../../../utils/goToTop';
 import * as S from './ImageUploadPage.styles';
-import { mockSpaceData } from './mockSpaceData';
 
 const ImageUploadPage = () => {
-  const { spaceInfo } = useSpaceInfo(mockSpaceData.code);
+  const { spaceId } = useSpaceCodeFromPath();
+  const { spaceInfo } = useSpaceInfo(spaceId ?? '');
   const spaceName = spaceInfo?.name ?? '';
   const { showToast } = useToast();
   const {

--- a/frontend/src/pages/guest/sharePage/SharePage.tsx
+++ b/frontend/src/pages/guest/sharePage/SharePage.tsx
@@ -1,6 +1,6 @@
 import { ReactComponent as LinkIcon } from '@assets/icons/link.svg';
 import LinkImage from '@assets/images/rocket.png';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import Button from '../../../components/@common/buttons/button/Button';
 import IconLabelButton from '../../../components/@common/buttons/iconLabelButton/IconLabelButton';
 import HighlightText from '../../../components/@common/highlightText/HighlightText';
@@ -11,12 +11,13 @@ import { copyLinkToClipboard } from '../../../utils/copyLinkToClipboard';
 import * as S from './SharePage.styles';
 
 const SharePage = () => {
+  const navigate = useNavigate();
   const location = useLocation();
   const spaceCode = location.state;
   const { showToast } = useToast();
 
   const handleSpaceHomeButton = () => {
-    console.log('클릭');
+    navigate(`/space-home/${spaceCode}`);
   };
 
   return (

--- a/frontend/src/pages/guest/sharePage/SharePage.tsx
+++ b/frontend/src/pages/guest/sharePage/SharePage.tsx
@@ -17,7 +17,7 @@ const SharePage = () => {
   const { showToast } = useToast();
 
   const handleSpaceHomeButton = () => {
-    navigate(`/space-home/${spaceCode}`);
+    navigate(`/manager/space-home/${spaceCode}`);
   };
 
   return (

--- a/frontend/src/pages/manager/spaceHome/SpaceHome.tsx
+++ b/frontend/src/pages/manager/spaceHome/SpaceHome.tsx
@@ -17,15 +17,18 @@ import useDownload from '../../../hooks/useDownload';
 import usePhotoSelect from '../../../hooks/usePhotoSelect';
 import usePhotosBySpaceCode from '../../../hooks/usePhotosBySpaceCode';
 import usePhotosDelete from '../../../hooks/usePhotosDelete';
+import useSpaceCodeFromPath from '../../../hooks/useSpaceCodeFromPath';
 import useSpaceInfo from '../../../hooks/useSpaceInfo';
 import { ScrollableBlurArea } from '../../../styles/@common/ScrollableBlurArea';
 import { theme } from '../../../styles/theme';
 import { goToTop } from '../../../utils/goToTop';
-import { mockSpaceData } from './mockSpaceData';
 import * as S from './SpaceHome.styles';
 
 const SpaceHome = () => {
-  const { spaceInfo } = useSpaceInfo(mockSpaceData.code);
+  const { spaceId } = useSpaceCodeFromPath();
+  console.log(spaceId);
+  const { spaceInfo } = useSpaceInfo(spaceId ?? '');
+  console.log(spaceInfo);
   const spaceName = spaceInfo?.name ?? '';
   const { targetRef: hideBlurAreaTriggerRef, isIntersecting: isAtPageBottom } =
     useIntersectionObserver({});
@@ -50,7 +53,7 @@ const SpaceHome = () => {
     updatePhotos,
   } = usePhotosBySpaceCode({
     reObserve,
-    spaceCode: mockSpaceData.code,
+    spaceCode: spaceId ?? '',
   });
 
   const { isDownloading, downloadAll, selectDownload } = useDownload({

--- a/frontend/src/pages/manager/spaceHome/SpaceHome.tsx
+++ b/frontend/src/pages/manager/spaceHome/SpaceHome.tsx
@@ -26,9 +26,7 @@ import * as S from './SpaceHome.styles';
 
 const SpaceHome = () => {
   const { spaceId } = useSpaceCodeFromPath();
-  console.log(spaceId);
   const { spaceInfo } = useSpaceInfo(spaceId ?? '');
-  console.log(spaceInfo);
   const spaceName = spaceInfo?.name ?? '';
   const { targetRef: hideBlurAreaTriggerRef, isIntersecting: isAtPageBottom } =
     useIntersectionObserver({});

--- a/frontend/src/router/router.tsx
+++ b/frontend/src/router/router.tsx
@@ -23,11 +23,15 @@ const router = createBrowserRouter([
         element: <SpaceCreateFunnel />,
       },
       {
+        path: 'space-home/:spaceCode',
+        element: <SpaceHome />,
+      },
+      {
         // TODO : 데모 후 삭제
         path: 'manager',
         children: [
           {
-            path: 'space-home',
+            path: 'space-home/:spaceId',
             element: <SpaceHome />,
           },
         ],
@@ -37,7 +41,7 @@ const router = createBrowserRouter([
         path: 'guest',
         children: [
           {
-            path: 'image-upload',
+            path: 'image-upload/:spaceId',
             element: <ImageUploadPage />,
           },
           {

--- a/frontend/src/utils/copyLinkToClipboard.ts
+++ b/frontend/src/utils/copyLinkToClipboard.ts
@@ -1,7 +1,9 @@
-export const copyLinkToClipboard = async (copyText: string) => {
+import { createSpaceUrl } from '../constants/routes';
+
+export const copyLinkToClipboard = async (spaceId: string) => {
   // TODO : try catch 유틸 분리
   try {
-    await navigator.clipboard.writeText(copyText);
+    await navigator.clipboard.writeText(createSpaceUrl(spaceId));
   } catch (error) {
     console.log(error);
   }

--- a/frontend/src/utils/copyLinkToClipboard.ts
+++ b/frontend/src/utils/copyLinkToClipboard.ts
@@ -1,4 +1,4 @@
-import { createSpaceUrl } from '../constants/routes';
+import { createSpaceUrl } from './createSpaceUrl';
 
 export const copyLinkToClipboard = async (spaceId: string) => {
   // TODO : try catch 유틸 분리

--- a/frontend/src/utils/copyLinkToClipboard.ts
+++ b/frontend/src/utils/copyLinkToClipboard.ts
@@ -1,9 +1,9 @@
-import { createSpaceUrl } from './createSpaceUrl';
+import { createShareUrl } from './createSpaceUrl';
 
 export const copyLinkToClipboard = async (spaceId: string) => {
   // TODO : try catch 유틸 분리
   try {
-    await navigator.clipboard.writeText(createSpaceUrl(spaceId));
+    await navigator.clipboard.writeText(createShareUrl(spaceId));
   } catch (error) {
     console.log(error);
   }

--- a/frontend/src/utils/createSpaceUrl.ts
+++ b/frontend/src/utils/createSpaceUrl.ts
@@ -1,4 +1,4 @@
 import { ROUTES } from '../constants/routes';
 
-export const createSpaceUrl = (spaceId: string) =>
-  process.env.DOMAIN + ROUTES.MANAGER.SPACE_HOME(spaceId);
+export const createShareUrl = (spaceId: string) =>
+  process.env.DOMAIN + ROUTES.GUEST.IMAGE_UPLOAD(spaceId);

--- a/frontend/src/utils/createSpaceUrl.ts
+++ b/frontend/src/utils/createSpaceUrl.ts
@@ -1,0 +1,4 @@
+import { ROUTES } from '../constants/routes';
+
+export const createSpaceUrl = (spaceId: string) =>
+  process.env.DOMAIN + ROUTES.MANAGER.SPACE_HOME(spaceId);


### PR DESCRIPTION
## 연관된 이슈

- close #273

## 작업 내용
* createSpaceUrl 함수로 space 공유 링크 생성 -> copyToClipboard 유틸을 통해 링크 복사시 사용자의 클립보드로 공유링크 복사
* 스페이스 생성 후 완료 (공유) 화면에서 "내 스페이스로 이동" 시 spaceCode에 따른 manager/space-home 으로 이동
* demoPage에서 "(MANAGER) 스페이스 관리 페이지 이동" 누를시 특정 스페이스 코드의 관리 페이지로 이동
* demoPage에서 "(GUEST) 스페이스 업로드 페이지 이동" 누를시 특정 스페이스 코드의 업로드 페이지로 이동

(demoPage는 mock으로 0b117a24a4 라는 코드를 넣어둠)