### PR TITLE
feat: 예외 관련 로그 레벨 분리 

### DIFF
--- a/backend/forgather/src/main/java/com/forgather/global/exception/GlobalExceptionHandler.java
+++ b/backend/forgather/src/main/java/com/forgather/global/exception/GlobalExceptionHandler.java
@@ -1,10 +1,10 @@
 package com.forgather.global.exception;
 
-import java.util.Optional;
-
+import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import com.forgather.global.logging.Logger;
 
@@ -16,13 +16,32 @@ public class GlobalExceptionHandler {
 
     private final Logger logger;
 
-    @ExceptionHandler({IllegalArgumentException.class, IllegalStateException.class})
+    @ExceptionHandler({IllegalArgumentException.class, IllegalStateException.class,
+        InvalidDataAccessApiUsageException.class})
     public ResponseEntity<ErrorResponse> handleIllegalException(RuntimeException e) {
         var errorResponse = ErrorResponse.from(e.getMessage());
         logger.log()
-            .message(Optional.ofNullable(e.getCause()).map(Object::toString).orElse("no cause"))
-            .error();
+            .message(e.getClass() + ": " + e.getMessage())
+            .info();
         return ResponseEntity.badRequest().body(errorResponse);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        var errorResponse = ErrorResponse.from(e.getMessage());
+        logger.log()
+            .message(e.getClass() + ": " + e.getMessage())
+            .error();
+        return ResponseEntity.internalServerError().body(errorResponse);
+    }
+
+    // 정적 리소스를 찾지 못해서 발생하는 예외는, WARN 레벨로 로깅. (favicon 때문에 항상 뜸)
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNoResourceFoundException(NoResourceFoundException e) {
+        logger.log()
+            .message(e.getClass() + ": " + e.getMessage())
+            .warn();
+        return ResponseEntity.notFound().build();
     }
 
     public record ErrorResponse(


### PR DESCRIPTION
## 작업 내용
- 예상하지 못한 예외는 ERROR 레벨로 처리
- 예상 예외(Illegal...) 은 INFO 레벨로 처리
- 정적 리소스 예외는 WARN 레벨로 처리

+ ERROR 레벨만 Cloudwatch 경보되도록 설정함.