### PR TITLE
fix: 삭제후 동일 사진 업로드 불가 문제 해결

### DIFF
--- a/frontend/src/components/uploadBox/UploadBox.tsx
+++ b/frontend/src/components/uploadBox/UploadBox.tsx
@@ -34,6 +34,11 @@ const UploadBox = ({
     handleDrop,
   } = useDrag({ onDrop });
 
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    onChange(event);
+    event.target.value = '';
+  };
+
   return (
     <S.Wrapper
       htmlFor="file-input"
@@ -53,7 +58,7 @@ const UploadBox = ({
         type="file"
         multiple
         hidden
-        onChange={onChange}
+        onChange={handleChange}
         accept="image/*"
         disabled={disabled}
       />


### PR DESCRIPTION
## 연관된 이슈

- close #321 

## 작업 내용

- 삭제후 동일 사진 업로드 가능하도록 수정하였습니다.

#### 문제 배경
1. A 사진을 올린다.
2. A 사진을 삭제한다.
3. A 사진을 다시 올린다. ---->>> 가 안됨

#### 문제 원인
input으로서 파일 업로드를 하고 있는데, input입장에서는 같은 파일을 올리는 것이기 때문에 변화가 없다고 판단하고, `onChange`를 발생시키지 않음

#### 문제 해결
input의 value를 초기화해줌