### PR TITLE
fix: overlay 및 만료/생성이전 페이지에서 스크롤 막기

### DIFF
--- a/frontend/src/components/@common/overlay/Overlay.tsx
+++ b/frontend/src/components/@common/overlay/Overlay.tsx
@@ -1,5 +1,6 @@
 import type React from 'react';
 import type { PropsWithChildren } from 'react';
+import useScrollLock from '../../../hooks/@common/useScrollLock';
 import * as S from '../../../styles/@common/BackDrop.styles';
 
 interface OverlayProps extends PropsWithChildren {
@@ -7,6 +8,8 @@ interface OverlayProps extends PropsWithChildren {
 }
 
 const Overlay = ({ onBackdropClick, children }: OverlayProps) => {
+  useScrollLock();
+
   const handleBackDropClick = () => {
     onBackdropClick?.();
   };

--- a/frontend/src/components/layout/statusLayout/StatusLayout.tsx
+++ b/frontend/src/components/layout/statusLayout/StatusLayout.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import useScrollLock from '../../../hooks/@common/useScrollLock';
 import * as C from '../../../styles/@common/BackDrop.styles';
 import * as S from './StatusLayout.styles';
 
@@ -13,8 +14,9 @@ interface StatusBackdropProps {
 }
 
 const StatusLayout = ({ image, element }: StatusBackdropProps) => {
+  useScrollLock();
   return (
-    <C.BackDrop>
+    <C.BackDrop onTouchMove={(e) => e.preventDefault()}>
       <S.Wrapper>
         <S.Icon src={image.src} alt={image.alt} />
         {element}

--- a/frontend/src/hooks/@common/useScrollLock.ts
+++ b/frontend/src/hooks/@common/useScrollLock.ts
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+
+const useScrollLock = () => {
+  useEffect(() => {
+    document.body.classList.add('scroll-lock');
+    return () => {
+      document.body.classList.remove('scroll-lock');
+    };
+  }, []);
+};
+
+export default useScrollLock;

--- a/frontend/src/pages/manager/spaceHome/SpaceHome.tsx
+++ b/frontend/src/pages/manager/spaceHome/SpaceHome.tsx
@@ -36,7 +36,7 @@ const SpaceHome = () => {
   const { spaceInfo } = useSpaceInfo(spaceId ?? '');
   const isEarlyTime = checkIsEarlyDate((spaceInfo?.openedAt as string) ?? '');
   // TODO: NoData 시 표시할 Layout 필요
-  const isNoData = !spaceInfo;
+  const _isNoData = !spaceInfo;
   const isSpaceExpired = spaceInfo?.isExpired;
   const spaceName = spaceInfo?.name ?? '';
   const { targetRef: hideBlurAreaTriggerRef, isIntersecting: isAtPageBottom } =

--- a/frontend/src/styles/global.ts
+++ b/frontend/src/styles/global.ts
@@ -43,5 +43,12 @@ export const global = css`
   }
   .scroll-lock {
     overflow: hidden;
+    position: fixed;
+    width: 100%;
+    top: 0;
+    left: 0;
+    right: 0;
+    overscroll-behavior: none;
+    touch-action: none;
   }
 `;

--- a/frontend/src/styles/global.ts
+++ b/frontend/src/styles/global.ts
@@ -41,4 +41,7 @@ export const global = css`
       cursor: default;
     }
   }
+  .scroll-lock {
+    overflow: hidden;
+  }
 `;


### PR DESCRIPTION
## 연관된 이슈

- close #329

## 작업 내용
<img width="200" alt="image" src="https://github.com/user-attachments/assets/4bf7ecd9-61e3-4d35-9281-d8baefefe9f2" />

* useScrollLock 훅 생성 - 스크롤을 막고 싶은 컴포넌트 단에서 호출하여 사용 가능
* Overlay 컴포넌트 및 StatusLayout 호출시 스크롤 막음
: Backdrop 위에서 스크롤이 되면서 발생하는 문제 해결