### PR TITLE
feature: 500 에러시 stacktrace 로깅

### DIFF
--- a/backend/forgather/src/main/java/com/forgather/global/exception/GlobalExceptionHandler.java
+++ b/backend/forgather/src/main/java/com/forgather/global/exception/GlobalExceptionHandler.java
@@ -30,8 +30,8 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleException(Exception e) {
         var errorResponse = ErrorResponse.from(e.getMessage());
         logger.log()
-            .message(e.getClass() + ": " + e.getMessage())
-            .error();
+            .message("500 Internal Server Error")
+            .error(e);
         return ResponseEntity.internalServerError().body(errorResponse);
     }
 

--- a/backend/forgather/src/main/java/com/forgather/global/logging/Logger.java
+++ b/backend/forgather/src/main/java/com/forgather/global/logging/Logger.java
@@ -65,6 +65,11 @@ public class Logger {
             log.error(logFormatter.formatSegments(segments));
         }
 
+        public void error(Throwable throwable) {
+            addRequestInformation();
+            log.error(logFormatter.formatSegments(segments), throwable);
+        }
+
         private void addRequestInformation() {
             segments.add(logFormatter.formatRequestInformation());
         }


### PR DESCRIPTION
## 작업 내용
- 500 에러 발생 시, Stacktrace가 이쁘게 로깅되도록 함.

## 로그 예시
```
2025-08-12T14:06:19.978+09:00 ERROR 66116 --- [forgather] [nio-8080-exec-1] com.forgather.global.logging.Logger      : [message:500 Internal Server Error] [traceId:09acb580] [uri:/spaces/1f7459043/photos] [ip:0:0:0:0:0:0:0:1] [userAgent:Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36]

org.springframework.dao.InvalidDataAccessApiUsageException: 존재하지 않는 스페이스입니다. 스페이스 코드: 1f7459043
	at org.springframework.orm.jpa.EntityManagerFactoryUtils.convertJpaAccessExceptionIfPossible(EntityManagerFactoryUtils.java:371) ~[spring-orm-6.2.8.jar:6.2.8]
	at org.springframework.orm.jpa.vendor.HibernateJpaDialect.translateExceptionIfPossible(HibernateJpaDialect.java:246) ~[spring-orm-6.2.8.jar:6.2.8]
	at org.springframework.orm.jpa.AbstractEntityManagerFactoryBean.translateExceptionIfPossible(AbstractEntityManagerFactoryBean.java:560) ~[spring-orm-6.2.8.jar:6.2.8]
	at org.springframework.dao.support.ChainedPersistenceExceptionTranslator.translateExceptionIfPossible(ChainedPersistenceExceptionTranslator.java:61) ~[spring-tx-6.2.8.jar:6.2.8]
	at org.springframework.dao.support.DataAccessUtils.translateIfNecessary(DataAccessUtils.java:343) ~[spring-tx-6.2.8.jar:6.2.8]
	at org.springframework.dao.support.PersistenceExceptionTranslationInterceptor.invoke(PersistenceExceptionTranslationInterceptor.java:160) ~[spring-tx-6.2.8.jar:6.2.8]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184) ~[spring-aop-6.2.8.jar:6.2.8]
	at org.springframework.data.jpa.repository.support.CrudMethodMetadataPostProcessor$CrudMethodMetadataPopulatingMethodInterceptor.invoke(CrudMethodMetadataPostProcessor.java:165) ~[spring-data-jpa-3.4.7.jar:3.4.7]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184) ~[spring-aop-6.2.8.jar:6.2.8]
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:223) ~[spring-aop-6.2.8.jar:6.2.8]
	at jdk.proxy2/jdk.proxy2.$Proxy180.getByCode(Unknown Source) ~[na:na]
	at com.forgather.domain.space.repository.SpaceRepository.getUnexpiredSpaceByCode(SpaceRepository.java:20) ~[main/:na]
	at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:733) ~[na:na]
...(이후 생략)
```