### PR TITLE
refactor: 상세보기 모달 UI 개선

### DIFF
--- a/frontend/src/apis/services/photo.service.ts
+++ b/frontend/src/apis/services/photo.service.ts
@@ -39,6 +39,9 @@ export const photoService = {
   deletePhotos: (spaceCode: string, photoIds: PhotoIds) =>
     http.delete<void>(`/spaces/${spaceCode}/photos/selected`, photoIds, 'json'),
 
+  deletePhoto: (spaceCode: string, photoId: number) =>
+    http.delete<void>(`/spaces/${spaceCode}/photos/${photoId}`),
+
   getWithContent: (photoId: number) =>
     http.get<PhotoWithContent>(`/photos/${photoId}/content`),
 };

--- a/frontend/src/components/modal/PhotoModal.styles.ts
+++ b/frontend/src/components/modal/PhotoModal.styles.ts
@@ -1,7 +1,6 @@
 import { ReactComponent as SaveIcon } from '@assets/icons/download.svg';
 import { ReactComponent as TrashCanIcon } from '@assets/icons/trash-can.svg';
 import styled from '@emotion/styled';
-import { glow } from '../../animations/glow';
 import { theme } from '../../styles/theme';
 import { hexToRgba } from '../../utils/hexToRgba';
 
@@ -38,27 +37,19 @@ export const PhotoContainer = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 100%;
-  flex: 1 1 auto;
-  min-height: 0;
+  width: auto;
+  height: 320px;
+  background-color: transparent;
   overflow: hidden;
 `;
 
 export const Photo = styled.img`
-  width: auto;
-  height: auto;
+    width: auto;
+    height: 320px;
   max-width: min(100%, 320px);
-  max-height: min(100%, 480px);
+  max-height: min(100%, 320px);
   aspect-ratio: 1;
   object-fit: contain;
-  background: linear-gradient(
-    150deg,
-    ${({ theme }) => theme.colors.gray06} 40%,
-    ${({ theme }) => theme.colors.gray05} 50%,
-    ${({ theme }) => theme.colors.gray06} 60%
-  );
-  background-size: 300%;
-  animation: ${glow} 3s infinite linear;
   -webkit-user-drag: none;
   touch-action: pinch-zoom;
   -webkit-touch-callout: none;

--- a/frontend/src/components/modal/PhotoModal.styles.ts
+++ b/frontend/src/components/modal/PhotoModal.styles.ts
@@ -10,7 +10,13 @@ export const Wrapper = styled.div`
   flex-direction: column;
   align-items: center;
   gap: 20px;
-  max-width: 380px;
+  width: 100%;
+  max-width: min(
+    calc(100vw - 32px), 
+    calc(${({ theme }) => theme.layout.width} - 32px)
+  );
+  max-height: 80vh;
+  overflow: hidden;
 `;
 
 export const FromContainer = styled.div`
@@ -30,24 +36,20 @@ export const FromMessage = styled.span`
 
 export const PhotoContainer = styled.div`
   display: flex;
-  flex-direction: row;
   justify-content: center;
   align-items: center;
   width: 100%;
-  min-width: 240px;
-  min-height: 330px;
-  aspect-ratio: 1;
-  object-fit: contain;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
 `;
 
 export const Photo = styled.img`
-  display: block;
-  min-width: 100px;
-  min-height: 100px;
-  max-width: 100%;
-  max-height: 100%;
   width: auto;
   height: auto;
+  max-width: min(100%, 320px);
+  max-height: min(100%, 480px);
+  aspect-ratio: 1;
   object-fit: contain;
   background: linear-gradient(
     150deg,
@@ -58,10 +60,8 @@ export const Photo = styled.img`
   background-size: 300%;
   animation: ${glow} 3s infinite linear;
   -webkit-user-drag: none;
-  -khtml-user-drag: none;
-  -moz-user-drag: none;
-  -o-user-drag: none;
-  overflow: hidden;
+  touch-action: pinch-zoom;
+  -webkit-touch-callout: none;
   &:active {
     opacity: 0.9;
   }
@@ -69,7 +69,6 @@ export const Photo = styled.img`
 
 export const ButtonContainer = styled.div<{ $isManagerMode: boolean }>`
   display: flex;
-  flex-direction: row;
   align-items: center;
   width: 106px;
   height: auto;

--- a/frontend/src/components/modal/PhotoModal.styles.ts
+++ b/frontend/src/components/modal/PhotoModal.styles.ts
@@ -10,10 +10,7 @@ export const Wrapper = styled.div`
   align-items: center;
   gap: 20px;
   width: 100%;
-  max-width: min(
-    calc(100vw - 32px), 
-    calc(${({ theme }) => theme.layout.width} - 32px)
-  );
+  max-width: min(calc(100vw - 32px), calc(${({ theme }) => theme.layout.width} - 32px));
   max-height: 80vh;
   overflow: hidden;
 `;
@@ -44,8 +41,8 @@ export const PhotoContainer = styled.div`
 `;
 
 export const Photo = styled.img`
-    width: auto;
-    height: 320px;
+  width: auto;
+  height: 320px;
   max-width: min(100%, 320px);
   max-height: min(100%, 320px);
   aspect-ratio: 1;

--- a/frontend/src/components/modal/PhotoModal.tsx
+++ b/frontend/src/components/modal/PhotoModal.tsx
@@ -35,7 +35,7 @@ interface ManagerPhotoModalProps extends BaseModalProps {
   /** 다운로드 핸들러 */
   onDownload?: () => void;
   /** 삭제 핸들러 */
-  onDelete?: (photoId: number) => void;
+  onDelete?: () => void;
 }
 
 type PhotoModalProps = GuestPhotoModalProps | ManagerPhotoModalProps;
@@ -136,7 +136,7 @@ const PhotoModal = (props: PhotoModalProps) => {
         console.error('모달 오류:', error);
       }
     } else if (mode === 'manager' && props.onDelete) {
-      props.onDelete(props.photoId);
+      props.onDelete();
       onClose?.();
     }
   };
@@ -157,15 +157,19 @@ const PhotoModal = (props: PhotoModalProps) => {
         </S.FromContainer>
       )}
       <S.PhotoContainer>
-        <S.Photo
-          src={displayPath}
-          alt={photo?.originalName || 'Image'}
-          onError={(e) => {
-            setImageLoadError(true);
-            const img = e.target as HTMLImageElement;
-            img.onerror = null;
-          }}
-        />
+        {displayPath ? (
+          <S.Photo
+            src={displayPath}
+            alt={photo?.originalName || 'Image'}
+            onError={(e) => {
+              setImageLoadError(true);
+              const img = e.target as HTMLImageElement;
+              img.onerror = null;
+            }}
+          />
+        ) : (
+          <div style={{ width: '100%', height: '100%', backgroundColor: '#f0f0f0' }} />
+        )}
       </S.PhotoContainer>
       <S.ButtonContainer $isManagerMode={isManagerMode}>
         <IconLabelButton

--- a/frontend/src/components/modal/PhotoModal.tsx
+++ b/frontend/src/components/modal/PhotoModal.tsx
@@ -64,16 +64,8 @@ const PhotoModal = (props: PhotoModalProps) => {
         photoService.getById(managerSpaceCode, managerPhotoId),
       );
 
-      console.log('📡 API Response:', response);
-
       if (response.success && response.data) {
         const data = response.data;
-        console.log('📸 Photo data:', {
-          id: data.id,
-          path: data.path,
-          originalName: data.originalName,
-          fullData: data,
-        });
 
         if (!data) {
           console.warn(DEBUG_MESSAGES.NO_RESPONSE);
@@ -90,16 +82,10 @@ const PhotoModal = (props: PhotoModalProps) => {
           const fileName = data.path;
           if (fileName) {
             imageUrl = buildOriginalImageUrl(managerSpaceCode, fileName);
-            console.log('🔨 Built image URL:', {
-              originalPath: data.path,
-              parsedFileName: fileName,
-              builtUrl: imageUrl,
-            });
           } else {
             console.error('❌ Failed to parse image path:', data.path);
           }
         }
-        console.log('Final image URL:', imageUrl);
         setDisplayPath(imageUrl);
       } else {
         console.error('API call failed:', response);

--- a/frontend/src/components/modal/PhotoModal.tsx
+++ b/frontend/src/components/modal/PhotoModal.tsx
@@ -115,28 +115,29 @@ const PhotoModal = (props: PhotoModalProps) => {
   }, [mode, guestPreviewPath]);
 
   const handleDelete = async () => {
-    try {
-      const result = await overlay(
-        <ConfirmModal
-          description="정말 삭제하시겠어요?"
-          confirmText="삭제"
-          cancelText="취소"
-        />,
-        {
-          clickOverlayClose: true,
-        },
-      );
+    if (mode === 'guest' && props.onDelete) {
+      try {
+        const result = await overlay(
+          <ConfirmModal
+            description="정말 삭제하시겠어요?"
+            confirmText="삭제"
+            cancelText="취소"
+          />,
+          {
+            clickOverlayClose: true,
+          },
+        );
 
-      if (result) {
-        if (mode === 'guest' && props.onDelete) {
+        if (result) {
           props.onDelete(props.previewFile.id);
-        } else if (mode === 'manager' && props.onDelete) {
-          props.onDelete(props.photoId);
+          onClose?.();
         }
-        onClose?.();
+      } catch (error) {
+        console.error('모달 오류:', error);
       }
-    } catch (error) {
-      console.error('모달 오류:', error);
+    } else if (mode === 'manager' && props.onDelete) {
+      props.onDelete(props.photoId);
+      onClose?.();
     }
   };
 

--- a/frontend/src/components/modal/PhotoModal.tsx
+++ b/frontend/src/components/modal/PhotoModal.tsx
@@ -35,7 +35,7 @@ interface ManagerPhotoModalProps extends BaseModalProps {
   /** 다운로드 핸들러 */
   onDownload?: () => void;
   /** 삭제 핸들러 */
-  onDelete?: () => void;
+  onDelete?: () => undefined | Promise<boolean>;
 }
 
 type PhotoModalProps = GuestPhotoModalProps | ManagerPhotoModalProps;
@@ -136,8 +136,10 @@ const PhotoModal = (props: PhotoModalProps) => {
         console.error('모달 오류:', error);
       }
     } else if (mode === 'manager' && props.onDelete) {
-      props.onDelete();
-      onClose?.();
+      const result = await props.onDelete();
+      if (result) {
+        onClose?.();
+      }
     }
   };
 
@@ -168,7 +170,13 @@ const PhotoModal = (props: PhotoModalProps) => {
             }}
           />
         ) : (
-          <div style={{ width: '100%', height: '100%', backgroundColor: '#f0f0f0' }} />
+          <div
+            style={{
+              width: '100%',
+              height: '100%',
+              backgroundColor: '#f0f0f0',
+            }}
+          />
         )}
       </S.PhotoContainer>
       <S.ButtonContainer $isManagerMode={isManagerMode}>

--- a/frontend/src/hooks/useDownload.ts
+++ b/frontend/src/hooks/useDownload.ts
@@ -42,21 +42,24 @@ const useDownload = ({ spaceCode, spaceName }: UseDownloadProps) => {
       });
       return;
     }
-    await handleDownload(() =>
-      photoService.downloadPhotos(spaceCode, {
-        photoIds: photoIds,
-      }),
+    await handleDownload(
+      () =>
+        photoService.downloadPhotos(spaceCode, {
+          photoIds: photoIds,
+        }),
+      false,
     );
   };
 
   const downloadAll = async () => {
     setIsDownloading(true);
-    await handleDownload(() => photoService.downloadAll(spaceCode));
+    await handleDownload(() => photoService.downloadAll(spaceCode), true);
     setIsDownloading(false);
   };
 
   const handleDownload = async (
     fetchFunction: () => Promise<ApiResponse<unknown>>,
+    shouldNavigate = false,
   ) => {
     try {
       const response = await safeApiCall(fetchFunction);
@@ -67,11 +70,14 @@ const useDownload = ({ spaceCode, spaceName }: UseDownloadProps) => {
           throw new Error(DEBUG_MESSAGES.NO_BLOB_INSTANCE);
         }
         downloadBlob(blob);
-        navigate(ROUTES.COMPLETE.DOWNLOAD, {
-          state: {
-            spaceCode,
-          },
-        });
+
+        if (shouldNavigate) {
+          navigate(ROUTES.COMPLETE.DOWNLOAD, {
+            state: {
+              spaceCode,
+            },
+          });
+        }
       } else {
         if (
           !response.error?.toLowerCase().includes(NETWORK.DEFAULT.toLowerCase())

--- a/frontend/src/hooks/usePhotosDelete.ts
+++ b/frontend/src/hooks/usePhotosDelete.ts
@@ -1,4 +1,3 @@
-// import { photoService } from '../apis/services/photo.service';
 import React, { useState } from 'react';
 import { photoService } from '../apis/services/photo.service';
 import ConfirmModal from '../components/modal/ConfirmModal';

--- a/frontend/src/hooks/usePhotosDelete.ts
+++ b/frontend/src/hooks/usePhotosDelete.ts
@@ -78,7 +78,33 @@ const usePhotosDelete = ({
     }
   };
 
-  return { submitDeletePhotos, isDeleting };
+  const deleteSinglePhoto = async (photoId: number) => {
+    try {
+      const result = await overlay(
+        React.createElement(ConfirmModal, {
+          description: `정말 삭제하시겠어요?`,
+          confirmText: '삭제',
+          cancelText: '취소',
+        }),
+        {
+          clickOverlayClose: true,
+        },
+      );
+
+      if (result) {
+        await fetchDeletePhotos([photoId]);
+        showToast({
+          text: `사진을 삭제했습니다.`,
+          type: 'info',
+        });
+        await fetchPhotosList();
+      }
+    } catch (error) {
+      console.error('모달 오류:', error);
+    }
+  };
+
+  return { submitDeletePhotos, deleteSinglePhoto, isDeleting };
 };
 
 export default usePhotosDelete;

--- a/frontend/src/pages/manager/spaceHome/SpaceHome.tsx
+++ b/frontend/src/pages/manager/spaceHome/SpaceHome.tsx
@@ -3,7 +3,6 @@ import { useEffect, useState } from 'react';
 import { ReactComponent as SaveIcon } from '../../../@assets/icons/download.svg';
 import { ReactComponent as SettingSvg } from '../../../@assets/icons/setting.svg';
 import { ReactComponent as ArrowUpSvg } from '../../../@assets/icons/upwardArrow.svg';
-import { photoService } from '../../../apis/services/photo.service';
 import FloatingActionButton from '../../../components/@common/buttons/floatingActionButton/FloatingActionButton';
 import FloatingIconButton from '../../../components/@common/buttons/floatingIconButton/FloatingIconButton';
 import SpaceManagerImageGrid from '../../../components/@common/imageLayout/imageGrid/spaceManagerImageGrid/SpaceManagerImageGrid';
@@ -16,7 +15,6 @@ import { INFORMATION } from '../../../constants/messages';
 import { useOverlay } from '../../../contexts/OverlayProvider';
 import useIntersectionObserver from '../../../hooks/@common/useIntersectionObserver';
 import useLeftTimer from '../../../hooks/@common/useLeftTimer';
-import { useToast } from '../../../hooks/@common/useToast';
 import useDownload from '../../../hooks/useDownload';
 import usePhotoSelect from '../../../hooks/usePhotoSelect';
 import usePhotosBySpaceCode from '../../../hooks/usePhotosBySpaceCode';
@@ -54,7 +52,6 @@ const SpaceHome = () => {
   });
 
   const overlay = useOverlay();
-  const { showToast } = useToast();
 
   const {
     photosList,
@@ -85,34 +82,13 @@ const SpaceHome = () => {
     toggleAllSelected,
   } = usePhotoSelect({ photosList: photosList ?? [] });
 
-  const { submitDeletePhotos, isDeleting } = usePhotosDelete({
+  const { submitDeletePhotos, deleteSinglePhoto, isDeleting } = usePhotosDelete({
     spaceCode: spaceId ?? '',
     toggleSelectMode,
     updatePhotos,
     fetchPhotosList,
     extractUnselectedPhotos,
   });
-
-  const handleSinglePhotoDelete = async (photoId: number) => {
-    try {
-      await photoService.deletePhotos(spaceId ?? '', {
-        photoIds: [photoId],
-      });
-      showToast({
-        text: '사진을 삭제했습니다.',
-        type: 'info',
-      });
-      const updatedPhotos =
-        photosList?.filter((photo) => photo.id !== photoId) || [];
-      updatePhotos(updatedPhotos);
-    } catch (error) {
-      showToast({
-        text: '삭제에 실패했습니다. 다시 시도해 주세요.',
-        type: 'error',
-      });
-      console.error('삭제 실패:', error);
-    }
-  };
 
   const openPhotoModal = async (photoId: number) => {
     await overlay(
@@ -124,7 +100,7 @@ const SpaceHome = () => {
         onDownload={() => {
           selectDownload([photoId]);
         }}
-        onDelete={handleSinglePhotoDelete}
+        onDelete={() => deleteSinglePhoto(photoId)}
       />,
       {
         clickOverlayClose: true,

--- a/frontend/src/pages/manager/spaceHome/SpaceHome.tsx
+++ b/frontend/src/pages/manager/spaceHome/SpaceHome.tsx
@@ -34,7 +34,7 @@ const SpaceHome = () => {
   const { spaceInfo } = useSpaceInfo(spaceId ?? '');
   const isEarlyTime = checkIsEarlyDate((spaceInfo?.openedAt as string) ?? '');
   // TODO: NoData 시 표시할 Layout 필요
-  const isNoData = !spaceInfo;
+  const _isNoData = !spaceInfo;
   const isSpaceExpired = spaceInfo?.isExpired;
   const spaceName = spaceInfo?.name ?? '';
   const { targetRef: hideBlurAreaTriggerRef, isIntersecting: isAtPageBottom } =
@@ -82,13 +82,16 @@ const SpaceHome = () => {
     toggleAllSelected,
   } = usePhotoSelect({ photosList: photosList ?? [] });
 
-  const { submitDeletePhotos, deleteSinglePhoto, isDeleting } = usePhotosDelete({
-    spaceCode: spaceId ?? '',
-    toggleSelectMode,
-    updatePhotos,
-    fetchPhotosList,
-    extractUnselectedPhotos,
-  });
+  const { submitDeletePhotos, deleteSinglePhoto, isDeleting } = usePhotosDelete(
+    {
+      spaceCode: spaceId ?? '',
+      toggleSelectMode,
+      updatePhotos,
+      fetchPhotosList,
+      extractUnselectedPhotos,
+      photosList,
+    },
+  );
 
   const openPhotoModal = async (photoId: number) => {
     await overlay(

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -88,9 +88,9 @@ export const theme = {
     scrollableArea: 3,
     topActionButton: 4,
     loadingSpinner: 5,
+    floatingActionButton: 6,
     backdrop: 100,
     backdropContainer: 101,
-    floatingActionButton: 400,
     toast: 500,
   },
   layout: {

--- a/frontend/src/types/api.type.ts
+++ b/frontend/src/types/api.type.ts
@@ -26,3 +26,7 @@ export interface PhotoListResponse {
 export interface PhotoIds {
   photoIds: number[];
 }
+
+export interface PhotoId {
+  photoId: number;
+}


### PR DESCRIPTION
## 연관된 이슈

- close #315 

## 작업 내용

지난주 QA를 진행한 후 발견한 상세 모달 및 overlay 관련 이슈를 묶어 해결했습니다.

### 1. 모달창 최대 크기 제한
- 이미지가 세로로 길 때 화면을 넘어가는 문제 해결

### 2. 뒤로가기시 모달창 닫히도록 처리
- window.history의 `pushState`, `popstate`를 활용

### 3. 모두 저장하기 클릭 시에만 라우터 이동하도록 처리
- 단일 다운로드, 선택 다운로드 시에는 라우터 이동 X

### 4. 스켈레톤 UI 제거
- `background-color: transparent;`속성을 추가해 배경을 투명하게 변경

### 5. 모달이 중복으로 생성될 때 여러 모달을 관리하는 로직 추가
- `상세보기 모달` 위에 `삭제 확인` 모달이 떠야하는 경우
- 기존에는 모달이 한개씩만 보여지도록 구현되어 있어서, `상세보기 모달`이 닫힌 후 `삭제 확인` 모달이 보이는 이슈가 존재
- 모달에 id를 부여해 스택으로 관리 

### 6. 단일 삭제 함수 `deleteSinglePhoto` 생성 및 매니저 모드에서 활용 
- 선택 삭제와 단일 삭제는 API 엔드포인트가 별개
- 선택 모드에서는 선택 모드로 진입하기 위해 토글 관련 로직이 필요
- 단일 삭제와 복수 삭제는 비즈니스 로직이 달라 별도 함수로 분리함


## 영상

### 업로드

https://github.com/user-attachments/assets/a23d342b-5142-43de-be5c-ed5d05aa241a

### 매니저 

https://github.com/user-attachments/assets/9d9310a4-e827-46b7-b347-d9688f703d8d


