### PR TITLE
feature: 사진 삭제 시 썸네일 삭제

### DIFF
--- a/backend/forgather/src/main/java/com/forgather/domain/space/repository/PhotoRepository.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/space/repository/PhotoRepository.java
@@ -5,9 +5,6 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import com.forgather.domain.space.model.Photo;
 import com.forgather.domain.space.model.Space;
@@ -24,12 +21,4 @@ public interface PhotoRepository extends JpaRepository<Photo, Long> {
     List<Photo> findAllBySpace(Space space);
 
     List<Photo> findAllByIdIn(List<Long> photoIds);
-
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("""
-        DELETE FROM SpaceContent sc
-        WHERE sc.space = :space
-          AND sc.id IN :photoIds
-        """)
-    void deleteBySpaceAndPhotoIds(@Param("space") Space space, @Param("photoIds") List<Long> photoIds);
 }

--- a/backend/forgather/src/main/java/com/forgather/domain/space/service/AwsS3Cloud.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/space/service/AwsS3Cloud.java
@@ -39,7 +39,7 @@ public class AwsS3Cloud {
     private static final String THUMBNAILS_INNER_PATH = "thumbnails";
     private static final String MOBILE_THUMBNAIL_SIZE = "x800";
     private static final String DESKTOP_THUMBNAIL_SIZE = "x1080";
-    private static final String THUMBNAIL_EXTENSION = ".webp";
+    private static final String THUMBNAIL_EXTENSION = "webp";
 
     private final S3Client s3Client;
     private final S3Properties s3Properties;
@@ -140,7 +140,7 @@ public class AwsS3Cloud {
         String[] tokens = StringUtils.getFilename(contentPath).split("\\.");
         String fileName = tokens[0];
 
-        return String.format("%s/%s/%s_%s%s", contentDirectory, THUMBNAILS_INNER_PATH, fileName, thumbnailSize,
+        return String.format("%s/%s/%s_%s.%s", contentDirectory, THUMBNAILS_INNER_PATH, fileName, thumbnailSize,
             THUMBNAIL_EXTENSION);
     }
 

--- a/backend/forgather/src/main/java/com/forgather/domain/space/service/AwsS3Cloud.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/space/service/AwsS3Cloud.java
@@ -153,5 +153,10 @@ public class AwsS3Cloud {
             .delete(Delete.builder().objects(deleteObjects).build())
             .build();
         s3Client.deleteObjects(deleteRequest);
+
+        logger.log()
+            .event("S3 삭제 완료")
+            .value("deletedSize", String.valueOf(deletePaths.size()))
+            .info();
     }
 }

--- a/backend/forgather/src/main/java/com/forgather/domain/space/service/PhotoService.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/space/service/PhotoService.java
@@ -121,6 +121,7 @@ public class PhotoService {
         Space space = spaceRepository.getUnexpiredSpaceByCode(spaceCode);
         Photo photo = photoRepository.getById(photoId);
         photo.validateSpace(space);
+
         photoRepository.delete(photo);
         awsS3Cloud.deleteContent(photo.getPath());
     }
@@ -128,13 +129,13 @@ public class PhotoService {
     @Transactional
     public void deleteSelected(String spaceCode, DeletePhotosRequest request) {
         Space space = spaceRepository.getUnexpiredSpaceByCode(spaceCode);
-        List<Long> photoIds = request.photoIds();
-        List<Photo> photos = photoRepository.findAllByIdIn(photoIds);
+        List<Photo> photos = photoRepository.findAllByIdIn(request.photoIds());
         photos.forEach(photo -> photo.validateSpace(space));
         List<String> paths = photos.stream()
             .map(Photo::getPath)
             .toList();
-        photoRepository.deleteBySpaceAndPhotoIds(space, photoIds);
+
+        photoRepository.deleteAll(photos);
         awsS3Cloud.deleteSelectedContents(paths);
     }
 }


### PR DESCRIPTION
## 연관된 이슈

- close #335 

## 작업 내용
- 썸네일 사진도 함께 삭제
  -  원본 사진 + 썸네일 사진 2장(모바일, 데스크탑)
- `@Query`를 사용한 bulk delete에서 `deleteAll()`로 변경
  - 성능 차이가 없음. 지연 쓰기로 인해 가장 비용이 큰 I/O 작업은 많이 일어나지 않아 나가는 쿼리의 for문을 통해 delete쿼리를 날려 나가는 쿼리 수만 많아보이지. 성능 상 차이는 없음
  - 오히려 `deleteAll()`이 더 안정적
- S3 삭제 로직 변경
  - `S3Client#deleteObjects`는 1,000건 까지 삭제 가능 -> 1,001건 부터 삭제 요청이 실패 -> 1,000건 넘어가면 나누어 삭제