### PR TITLE
refactor: 오픈 시간 이후에 생성 시 지금 당장 생성으로 대체

### DIFF
--- a/frontend/__test__/checkIsPastDateTime.test.ts
+++ b/frontend/__test__/checkIsPastDateTime.test.ts
@@ -2,7 +2,7 @@ import { checkIsPastDateTime } from '../src/utils/checkIsPastDateTime';
 
 beforeAll(() => {
   jest.useFakeTimers();
-  jest.setSystemTime(new Date('2025-07-31T10:00:00Z'));
+  jest.setSystemTime(new Date('2025-07-31T10:00:30Z'));
 });
 
 afterAll(() => {

--- a/frontend/src/pages/create/funnel/SpaceCreateFunnel.tsx
+++ b/frontend/src/pages/create/funnel/SpaceCreateFunnel.tsx
@@ -82,7 +82,10 @@ const SpaceCreateFunnel = () => {
         {step === 'check' && (
           <CheckSpaceInfoElement
             spaceInfo={spaceInfo}
-            onNext={() => goNextStep('fetch')}
+            onNext={(isImmediateOpen) => {
+              goNextStep('fetch');
+              setSpaceInfo((prev) => ({ ...prev, isImmediateOpen }));
+            }}
           />
         )}
         {step === 'fetch' && (

--- a/frontend/src/pages/create/funnelElements/CheckSpaceInfoElement.tsx
+++ b/frontend/src/pages/create/funnelElements/CheckSpaceInfoElement.tsx
@@ -7,7 +7,7 @@ import { formatDate } from '../../../utils/formatDate';
 import { formatTimer } from '../../../utils/formatTimer';
 import FunnelBasePage from '../funnel/FunnelBasePage/FunnelBasePage';
 
-interface CheckSpaceInfoPageProps extends FunnelElementProps {
+interface CheckSpaceInfoPageProps extends FunnelElementProps<boolean> {
   spaceInfo: SpaceFunnelInfo;
 }
 
@@ -18,6 +18,8 @@ const CheckSpaceInfoElement = ({
   const openedAt = `${spaceInfo.date}T${spaceInfo.time}`;
   const { date, time } = formatDate(openedAt);
   const { leftTime } = useLeftTimer({ targetTime: openedAt });
+  const formattedLeftTime = formatTimer(leftTime);
+  const isImmediateOpen = formattedLeftTime === '00:00:00';
 
   return (
     <FunnelBasePage
@@ -30,10 +32,10 @@ const CheckSpaceInfoElement = ({
         <LeftTimeInformationBox
           title={spaceInfo.name}
           openDate={{ date, time }}
-          leftTime={formatTimer(leftTime)}
+          leftTime={formattedLeftTime}
         />
       }
-      onNextButtonClick={() => onNext(JSON.stringify(spaceInfo))}
+      onNextButtonClick={() => onNext(isImmediateOpen)}
     />
   );
 };

--- a/frontend/src/utils/checkIsPastDateTime.ts
+++ b/frontend/src/utils/checkIsPastDateTime.ts
@@ -2,6 +2,10 @@ export const checkIsPastDateTime = (date: string, time: string) => {
   const kstDateString = `${date}T${time}:00+09:00`;
   const input = new Date(kstDateString);
 
-  const now = Date.now();
-  return input.getTime() < now;
+  const now = new Date();
+
+  input.setSeconds(0, 0);
+  now.setSeconds(0, 0);
+
+  return input.getTime() < now.getTime();
 };


### PR DESCRIPTION
## 연관된 이슈

- close #340 

## 작업 내용

### 조건부 스페이스 지금 당장 생성 대체

- 스페이스 생성 시 마지막 검증을 통해 막는 로직보단, 스페이스 생성 시 이미 지난 시간을 요청하는 경우 자동으로 지금 당장 시간으로 변경해주는 것이 사용성이 좋다고 판단
  - ex) (4시) 스페이스를 4시1분에 생성 -> 스페이스 확인 페이지에서 5분 대기 -> (4시 5분) 스페이스 생성 완료 버튼 클릭 -> 4시 5분 생성으로 자동 변경

### 스페이스 생성 시간 설정 제한 변경(나중에)
- As Is: 나중에를 누른 상황에서 현재 시간이 선택되지 않았음 (4시인 경우 4시 1분부터 선택 가능)
- To Be: 나중에를 누른 상황에서 현재 시간이 선택됨 (4시인 경우 4시가 선택됨)