### PR TITLE
feature: 스페이스를 사용할 수 없는 경우 컴포넌트 대체

### DIFF
--- a/frontend/src/components/@common/imageLayout/imageElement/fakeImageElement/FakeImageElement.styles.ts
+++ b/frontend/src/components/@common/imageLayout/imageElement/fakeImageElement/FakeImageElement.styles.ts
@@ -1,0 +1,7 @@
+import styled from '@emotion/styled';
+
+export const FakeImage = styled.div<{ $color: string }>`
+  width: 100%;
+  height: 100%;
+  background-color: ${({ $color }) => $color};
+`;

--- a/frontend/src/components/@common/imageLayout/imageElement/fakeImageElement/FakeImageElement.tsx
+++ b/frontend/src/components/@common/imageLayout/imageElement/fakeImageElement/FakeImageElement.tsx
@@ -1,0 +1,26 @@
+import { theme } from '../../../../../styles/theme';
+import * as C from '../ImageElement.common.styles';
+import * as S from './FakeImageElement.styles';
+
+interface FakeImageElementProps {
+  /** 사진의 색깔 */
+  color?: string;
+  /** 사진의 ratio */
+  ratio?: number;
+  /** 사진 하나의 너비 */
+  width?: string;
+}
+
+const FakeImageElement = ({
+  color = theme.colors.gray02,
+  ratio = 1,
+  width = '100%',
+}: FakeImageElementProps) => {
+  return (
+    <C.Wrapper tabIndex={0} $ratio={ratio} $width={width}>
+      <S.FakeImage $color={color} />
+    </C.Wrapper>
+  );
+};
+
+export default FakeImageElement;

--- a/frontend/src/components/@common/imageLayout/imageGrid/fakeImageGrid/FakeImageGrid.tsx
+++ b/frontend/src/components/@common/imageLayout/imageGrid/fakeImageGrid/FakeImageGrid.tsx
@@ -1,3 +1,4 @@
+import { theme } from '../../../../../styles/theme';
 import FakeImageElement from '../../imageElement/fakeImageElement/FakeImageElement';
 import * as S from '../ImageGrid.common.styles';
 
@@ -13,7 +14,7 @@ const FakeImageGrid = ({ photoLength, rowImageAmount }: FakeImageGridProps) => {
     <S.Wrapper $rowImageAmount={rowImageAmount}>
       {Array.from({ length: photoLength }).map((_, index) => (
         // biome-ignore lint/suspicious/noArrayIndexKey: 가짜 이미지는 index만 가지고 있음
-        <FakeImageElement key={index} />
+        <FakeImageElement key={index} color={theme.colors.gray03} />
       ))}
     </S.Wrapper>
   );

--- a/frontend/src/components/@common/imageLayout/imageGrid/fakeImageGrid/FakeImageGrid.tsx
+++ b/frontend/src/components/@common/imageLayout/imageGrid/fakeImageGrid/FakeImageGrid.tsx
@@ -1,0 +1,22 @@
+import FakeImageElement from '../../imageElement/fakeImageElement/FakeImageElement';
+import * as S from '../ImageGrid.common.styles';
+
+interface FakeImageGridProps {
+  /** 표시할 이미지의 개수 */
+  photoLength: number;
+  /** 한 줄당 이미지 개수 */
+  rowImageAmount: number;
+}
+
+const FakeImageGrid = ({ photoLength, rowImageAmount }: FakeImageGridProps) => {
+  return (
+    <S.Wrapper $rowImageAmount={rowImageAmount}>
+      {Array.from({ length: photoLength }).map((_, index) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: 가짜 이미지는 index만 가지고 있음
+        <FakeImageElement key={index} />
+      ))}
+    </S.Wrapper>
+  );
+};
+
+export default FakeImageGrid;

--- a/frontend/src/pages/guest/imageUploadPage/ImageUploadPage.tsx
+++ b/frontend/src/pages/guest/imageUploadPage/ImageUploadPage.tsx
@@ -29,12 +29,11 @@ import * as S from './ImageUploadPage.styles';
 const ImageUploadPage = () => {
   const { spaceCode } = useSpaceCodeFromPath();
   const { spaceInfo } = useSpaceInfo(spaceCode ?? '');
+  const isNoData = !spaceInfo;
   const isSpaceExpired = spaceInfo?.isExpired;
-  // TODO: NoData 시 표시할 Layout 필요
-  const _isNoData = !spaceInfo;
-
   const isEarlyTime =
     spaceInfo?.openedAt && checkIsEarlyDate(spaceInfo.openedAt);
+  const shouldShowFakeUploadBox = isNoData || isEarlyTime || isSpaceExpired;
 
   const spaceName = spaceInfo?.name ?? '';
   const { showToast } = useToast();
@@ -125,14 +124,27 @@ const ImageUploadPage = () => {
       <S.ScrollTopAnchor ref={scrollTopTriggerRef} />
       <SpaceHeader title={spaceName} timer={leftTime} />
       <S.UploadContainer $hasImages={hasImages}>
-        <UploadBox
-          mainText={`함께한 순간을 올려주세요.${hasImages ? '' : '\n사진만 올릴 수 있습니다.'}`}
-          uploadLimitText={hasImages ? '' : '한 번에 500장까지 올릴 수 있어요'}
-          iconSize={hasImages ? 60 : 100}
-          onChange={handleFilesUploadClick}
-          onDrop={handleFilesDrop}
-          disabled={isUploading}
-        />
+        {shouldShowFakeUploadBox ? (
+          <UploadBox
+            mainText={''}
+            uploadLimitText={''}
+            iconSize={hasImages ? 60 : 100}
+            onChange={handleFilesUploadClick}
+            onDrop={handleFilesDrop}
+            disabled={true}
+          />
+        ) : (
+          <UploadBox
+            mainText={`함께한 순간을 올려주세요.${hasImages ? '' : '\n사진만 올릴 수 있습니다.'}`}
+            uploadLimitText={
+              hasImages ? '' : '한 번에 500장까지 올릴 수 있어요'
+            }
+            iconSize={hasImages ? 60 : 100}
+            onChange={handleFilesUploadClick}
+            onDrop={handleFilesDrop}
+            disabled={isUploading}
+          />
+        )}
       </S.UploadContainer>
 
       {hasImages && (

--- a/frontend/src/stories/FakeImageElement.stories.tsx
+++ b/frontend/src/stories/FakeImageElement.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
+import FakeImageElement from '../components/@common/imageLayout/imageElement/fakeImageElement/FakeImageElement';
+
+const meta: Meta<typeof FakeImageElement> = {
+  title: 'Components/ImageLayout/FakeImageElement',
+  component: FakeImageElement,
+  parameters: {
+    layout: 'centered',
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { color: '#000', ratio: 1, width: '100%' },
+};

--- a/frontend/src/stories/FakeImageGrid.stories.tsx
+++ b/frontend/src/stories/FakeImageGrid.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
+import FakeImageGrid from '../components/@common/imageLayout/imageGrid/fakeImageGrid/FakeImageGrid';
+
+const meta: Meta<typeof FakeImageGrid> = {
+  title: 'Components/ImageLayout/FakeImageGrid',
+  component: FakeImageGrid,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    rowImageAmount: 3,
+    photoLength: 3,
+  },
+};


### PR DESCRIPTION
## 연관된 이슈

- close #302

## 작업 내용

### FakeImageGrid, FakeImageElement 생성

- 이미지 그리드 대신 스타일만 입힌 FakeImageGrid, FakeImageElement 컴포넌트 생성

<img width="1650" height="1182" alt="image" src="https://github.com/user-attachments/assets/7027fee9-6dc1-4f4a-b04d-7392cd93c6be" />

### 스페이스를 사용할 수 없는 경우 업로드 박스를 대체

- 사용자가 억지로 전면 오버레이를 삭제한 경우 업로드 박스를 클릭해 업로드를 할 수 있음
- 업로드를 할 수 없는 박스로 대체
  - `const shouldShowFakeUploadBox = isNoData || isEarlyTime || isSpaceExpired;`
```tsx
{shouldShowFakeUploadBox ? (
  <UploadBox
    mainText={''}
    uploadLimitText={''}
    ...
    disabled={true} // 비활성화
  />
) : (
  <UploadBox
    mainText={`함께한 순간을 올려주세요.${hasImages ? '' : '\n사진만 올릴 수 있습니다.'}`}
    uploadLimitText={
      hasImages ? '' : '한 번에 500장까지 올릴 수 있어요'
    }
    ...
    disabled={isUploading}
  />
)}
```

### 논의 사항: FakeImageGrid를 만들었지만 사용하지 않음

- FakeImageGrid를 구현했지만 적용하려다 아래 이유로 아직 실제코드에 적용하지 않았습니다.
- 이에 대해 굳이 사용해야 할까 의견을 묻고 싶습니다! 🤔
  - 다음과 같이 FakeImageGrid가 없어도 이미지가 자동으로 삭제되기 때문에 실제 코드에 적용할 필요가 없어졌다고 판단
  - **이전엔 만료된 스페이스의 사진 조회에 에러가 발생하지 않지만, API 응답값의 변경으로 사진 조회에 400 에러가 발생하기 때문**
<img width="1030" height="952" alt="image" src="https://github.com/user-attachments/assets/e98b9137-d94f-4c12-b309-ea6107362fa1" />
