### PR TITLE
feat: 카카오 정보 접근 시 jwt 시그니처 검증

### DIFF
--- a/backend/forgather/build.gradle
+++ b/backend/forgather/build.gradle
@@ -44,6 +44,11 @@ dependencies {
 
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 }
 
 tasks.named('test') {

--- a/backend/forgather/src/main/java/com/forgather/global/auth/client/KakaoAuthClient.java
+++ b/backend/forgather/src/main/java/com/forgather/global/auth/client/KakaoAuthClient.java
@@ -1,22 +1,37 @@
 package com.forgather.global.auth.client;
 
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.PublicKey;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
 import com.forgather.global.config.KakaoProperties;
-
-import lombok.RequiredArgsConstructor;
 
 /**
  * 카카오 인증 관련 클라이언트
  * https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#request-token
  */
 @Component
-@RequiredArgsConstructor
 public class KakaoAuthClient {
+
+    private static final String KAKAO_JWKS_URL = "https://kauth.kakao.com/.well-known/jwks.json";
 
     private final RestClient restClient;
     private final KakaoProperties kakaoProperties;
+
+    private List<Map<String, Object>> keys;
+
+    public KakaoAuthClient(RestClient restClient, KakaoProperties kakaoProperties) {
+        this.restClient = restClient;
+        this.kakaoProperties = kakaoProperties;
+        updateKakaoKeys();
+    }
 
     public String getKakaoLoginUrl() {
         StringBuilder urlBuilder = new StringBuilder("https://kauth.kakao.com/oauth/authorize");
@@ -34,8 +49,51 @@ public class KakaoAuthClient {
         urlBuilder.append("&code=").append(authorizationCode);
 
         return restClient.post()
-                .uri(urlBuilder.toString())
-                .retrieve()
-                .body(KakaoTokenDto.FullToken.class);
+            .uri(urlBuilder.toString())
+            .retrieve()
+            .body(KakaoTokenDto.FullToken.class);
+    }
+
+    public PublicKey getKakaoPublicKey(String kid) {
+        try {
+            if (keys == null) {
+                throw new IllegalStateException("카카오 공개 키가 아직 로드되지 않았습니다. 먼저 requestKeys()를 호출해야 합니다.");
+            }
+
+            for (Map<String, Object> key : keys) {
+                if (kid.equals(key.get("kid"))) {
+                    String n = (String)key.get("n");
+                    String e = (String)key.get("e");
+
+                    byte[] nBytes = Base64.getUrlDecoder().decode(n);
+                    byte[] eBytes = Base64.getUrlDecoder().decode(e);
+
+                    BigInteger modulus = new BigInteger(1, nBytes);
+                    BigInteger exponent = new BigInteger(1, eBytes);
+
+                    RSAPublicKeySpec spec = new RSAPublicKeySpec(modulus, exponent);
+                    KeyFactory factory = KeyFactory.getInstance("RSA");
+                    return factory.generatePublic(spec);
+                }
+            }
+            throw new IllegalArgumentException("Public key not found for kid: " + kid);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to get Kakao public key", e);
+        }
+    }
+
+    public void updateKakaoKeys() {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> jws = restClient.get()
+            .uri(KAKAO_JWKS_URL)
+            .retrieve()
+            .body(Map.class);
+        if (jws == null) {
+            throw new RuntimeException("Failed to fetch JWKS from Kakao");
+        }
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> keys = (List<Map<String, Object>>)jws.get("keys");
+        this.keys = keys;
     }
 }

--- a/backend/forgather/src/main/java/com/forgather/global/auth/client/KakaoTokenDto.java
+++ b/backend/forgather/src/main/java/com/forgather/global/auth/client/KakaoTokenDto.java
@@ -2,6 +2,9 @@ package com.forgather.global.auth.client;
 
 import static com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
 
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 public class KakaoTokenDto {
@@ -36,8 +39,9 @@ public class KakaoTokenDto {
 
     @JsonNaming(SnakeCaseStrategy.class)
     public record IdToken(
-        // ID 토큰이 발급된 앱의 앱 키
-        String aud,
+        // ID 토큰이 발급된 앱의 앱 키 (문자열 또는 배열)
+        @JsonProperty("aud")
+        Object aud,
 
         // ID 토큰에 해당하는 사용자의 회원번호
         String sub,
@@ -60,5 +64,14 @@ public class KakaoTokenDto {
         // 프로필 미리보기 이미지 URL
         String picture
     ) {
+
+        public String getAudience() {
+            if (aud instanceof String) {
+                return (String) aud;
+            } else if (aud instanceof List<?> audList && !audList.isEmpty()) {
+                return (String) audList.get(0);
+            }
+            return null;
+        }
     }
 }

--- a/backend/forgather/src/main/java/com/forgather/global/auth/scheduler/KakaoPublicKeyScheduler.java
+++ b/backend/forgather/src/main/java/com/forgather/global/auth/scheduler/KakaoPublicKeyScheduler.java
@@ -1,0 +1,20 @@
+package com.forgather.global.auth.scheduler;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.forgather.global.auth.client.KakaoAuthClient;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoPublicKeyScheduler {
+
+    private final KakaoAuthClient kakaoAuthClient;
+
+    @Scheduled(cron = "0 0 3 * * *") // 매일 새벽 3시 실행
+    public void updateKakaoPublicKeys() {
+        kakaoAuthClient.updateKakaoKeys();
+    }
+}

--- a/backend/forgather/src/main/java/com/forgather/global/auth/scheduler/RefreshTokenRemoveScheduler.java
+++ b/backend/forgather/src/main/java/com/forgather/global/auth/scheduler/RefreshTokenRemoveScheduler.java
@@ -1,4 +1,4 @@
-package com.forgather.global.auth.client.scheduler;
+package com.forgather.global.auth.scheduler;
 
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;

--- a/backend/forgather/src/main/java/com/forgather/global/auth/util/JwtParser.java
+++ b/backend/forgather/src/main/java/com/forgather/global/auth/util/JwtParser.java
@@ -1,17 +1,13 @@
 package com.forgather.global.auth.util;
 
-import java.math.BigInteger;
-import java.security.KeyFactory;
 import java.security.PublicKey;
-import java.security.spec.RSAPublicKeySpec;
 import java.util.Base64;
-import java.util.List;
 import java.util.Map;
 
 import org.springframework.stereotype.Component;
-import org.springframework.web.client.RestClient;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.forgather.global.auth.client.KakaoAuthClient;
 import com.forgather.global.auth.client.KakaoTokenDto;
 
 import io.jsonwebtoken.Claims;
@@ -22,9 +18,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class JwtParser {
 
-    private final RestClient restClient;
     private final ObjectMapper objectMapper;
-    private static final String KAKAO_JWKS_URL = "https://kauth.kakao.com/.well-known/jwks.json";
+    private final KakaoAuthClient kakaoAuthClient;
 
     public KakaoTokenDto.IdToken parseIdToken(String idToken) {
         try {
@@ -42,7 +37,7 @@ public class JwtParser {
                 throw new IllegalArgumentException("Missing kid in JWT header");
             }
 
-            PublicKey publicKey = getKakaoPublicKey(kid);
+            PublicKey publicKey = kakaoAuthClient.getKakaoPublicKey(kid);
             
             Claims claims = Jwts.parser()
                     .verifyWith(publicKey)
@@ -53,45 +48,6 @@ public class JwtParser {
             return objectMapper.convertValue(claims, KakaoTokenDto.IdToken.class);
         } catch (Exception e) {
             throw new RuntimeException("Failed to parse and verify JWT", e);
-        }
-    }
-
-    private PublicKey getKakaoPublicKey(String kid) {
-        try {
-            @SuppressWarnings("unchecked")
-            Map<String, Object> jwks = restClient.get()
-                    .uri(KAKAO_JWKS_URL)
-                    .retrieve()
-                    .body(Map.class);
-            if (jwks == null) {
-                throw new RuntimeException("Failed to fetch JWKS from Kakao");
-            }
-            
-            @SuppressWarnings("unchecked")
-            List<Map<String, Object>> keys = (List<Map<String, Object>>) jwks.get("keys");
-            if (keys == null) {
-                throw new RuntimeException("No keys found in JWKS response");
-            }
-
-            for (Map<String, Object> key : keys) {
-                if (kid.equals(key.get("kid"))) {
-                    String n = (String) key.get("n");
-                    String e = (String) key.get("e");
-
-                    byte[] nBytes = Base64.getUrlDecoder().decode(n);
-                    byte[] eBytes = Base64.getUrlDecoder().decode(e);
-
-                    BigInteger modulus = new BigInteger(1, nBytes);
-                    BigInteger exponent = new BigInteger(1, eBytes);
-
-                    RSAPublicKeySpec spec = new RSAPublicKeySpec(modulus, exponent);
-                    KeyFactory factory = KeyFactory.getInstance("RSA");
-                    return factory.generatePublic(spec);
-                }
-            }
-            throw new IllegalArgumentException("Public key not found for kid: " + kid);
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to get Kakao public key", e);
         }
     }
 }

--- a/backend/forgather/src/main/java/com/forgather/global/auth/util/JwtParser.java
+++ b/backend/forgather/src/main/java/com/forgather/global/auth/util/JwtParser.java
@@ -1,35 +1,97 @@
 package com.forgather.global.auth.util;
 
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.PublicKey;
+import java.security.spec.RSAPublicKeySpec;
 import java.util.Base64;
+import java.util.List;
+import java.util.Map;
 
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.forgather.global.auth.client.KakaoTokenDto;
 
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
 import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
 public class JwtParser {
 
+    private final RestClient restClient;
     private final ObjectMapper objectMapper;
+    private static final String KAKAO_JWKS_URL = "https://kauth.kakao.com/.well-known/jwks.json";
 
-    /**
-     * TODO
-     * jwt 검증 필요.
-     *
-     * // 카카오 공개 키 가져오기 (JWK)
-     * GET https://kauth.kakao.com/.well-known/jwks.json
-     * → JWT의 kid 헤더를 기반으로 해당 키를 찾아 사용
-     */
     public KakaoTokenDto.IdToken parseIdToken(String idToken) {
         try {
-            String payload = idToken.split("\\.")[1];
-            String decodedPayload = new String(Base64.getDecoder().decode(payload));
-            return objectMapper.readValue(decodedPayload, KakaoTokenDto.IdToken.class);
+            String[] parts = idToken.split("\\.");
+            if (parts.length != 3) {
+                throw new IllegalArgumentException("Invalid JWT format");
+            }
+
+            String header = new String(Base64.getUrlDecoder().decode(parts[0]));
+            @SuppressWarnings("unchecked")
+            Map<String, Object> headerMap = objectMapper.readValue(header, Map.class);
+            String kid = (String) headerMap.get("kid");
+
+            if (kid == null) {
+                throw new IllegalArgumentException("Missing kid in JWT header");
+            }
+
+            PublicKey publicKey = getKakaoPublicKey(kid);
+            
+            Claims claims = Jwts.parser()
+                    .verifyWith(publicKey)
+                    .build()
+                    .parseSignedClaims(idToken)
+                    .getPayload();
+
+            return objectMapper.convertValue(claims, KakaoTokenDto.IdToken.class);
         } catch (Exception e) {
-            throw new RuntimeException("Failed to parse JWT", e);
+            throw new RuntimeException("Failed to parse and verify JWT", e);
+        }
+    }
+
+    private PublicKey getKakaoPublicKey(String kid) {
+        try {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> jwks = restClient.get()
+                    .uri(KAKAO_JWKS_URL)
+                    .retrieve()
+                    .body(Map.class);
+            if (jwks == null) {
+                throw new RuntimeException("Failed to fetch JWKS from Kakao");
+            }
+            
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> keys = (List<Map<String, Object>>) jwks.get("keys");
+            if (keys == null) {
+                throw new RuntimeException("No keys found in JWKS response");
+            }
+
+            for (Map<String, Object> key : keys) {
+                if (kid.equals(key.get("kid"))) {
+                    String n = (String) key.get("n");
+                    String e = (String) key.get("e");
+
+                    byte[] nBytes = Base64.getUrlDecoder().decode(n);
+                    byte[] eBytes = Base64.getUrlDecoder().decode(e);
+
+                    BigInteger modulus = new BigInteger(1, nBytes);
+                    BigInteger exponent = new BigInteger(1, eBytes);
+
+                    RSAPublicKeySpec spec = new RSAPublicKeySpec(modulus, exponent);
+                    KeyFactory factory = KeyFactory.getInstance("RSA");
+                    return factory.generatePublic(spec);
+                }
+            }
+            throw new IllegalArgumentException("Public key not found for kid: " + kid);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to get Kakao public key", e);
         }
     }
 }


### PR DESCRIPTION
## 작업 내용

기존에는 카카오 로그인 시 반환되는 id_token jwt의 시그니처를 검증하지 않고 페이로드를 그대로 가져와 사용하고 있습니다.
카카오의 공개키를 가져와 id_token을 검증하도록 수정했습니다.


---
참고 내용

### 1. 공개키 획득 과정

JWKS 엔드포인트에서 키 조회 (JwtParser.java:62-65):
https://kauth.kakao.com/.well-known/jwks.json
- Kakao가 공개적으로 제공하는 키 저장소
- 여러 개의 RSA 공개키들을 JSON 형태로 제공
- 각 키는 고유한 kid(Key ID)를 가짐

RSA 공개키 복원 (JwtParser.java:74-82):
1. JWT 헤더의 kid와 일치하는 키 찾기
2. JWK 형식의 n(modulus), e(exponent) 추출
3. Base64URL 디코딩 → 바이트 배열 → BigInteger 변환
4. RSAPublicKeySpec 생성 → Java PublicKey 객체 생성

### 2. 시그니처 검증 메커니즘

JWT 구조:
헤더.페이로드.시그니처

검증 과정 (JwtParser.java:46-50):
1. JJWT 라이브러리 사용: Jwts.parser().verifyWith(publicKey)
2. 내부 동작:
  - 헤더.페이로드 부분을 SHA256으로 해시
  - 시그니처를 공개키로 복호화
  - 두 값이 일치하는지 확인

### 3. 암호학적 원리

RSA 디지털 서명:
- Kakao가 개인키로 서명 생성: signature = RSA_sign(private_key, 
hash(header.payload))
- 클라이언트가 공개키로 검증: RSA_verify(public_key, signature, 
hash(header.payload))
- 개인키는 Kakao만 소유, 공개키는 모두가 접근 가능
