### PR TITLE
refactor: 사진 단일 다운로드를 zip 대신 이미지로 변경

### DIFF
--- a/frontend/src/apis/http.ts
+++ b/frontend/src/apis/http.ts
@@ -50,7 +50,11 @@ const request = async <T>(
 
   const contentType = response.headers.get('content-type');
 
-  if (contentType?.includes('application/zip')) {
+  if (
+    contentType?.includes('application/zip') ||
+    contentType?.includes('image/') ||
+    contentType?.includes('application/octet-stream')
+  ) {
     const blob = await response.blob();
     return {
       success: response.ok,

--- a/frontend/src/apis/services/photo.service.ts
+++ b/frontend/src/apis/services/photo.service.ts
@@ -36,6 +36,9 @@ export const photoService = {
   downloadPhotos: (spaceCode: string, photoIds: PhotoIds) =>
     http.post<Blob>(`/spaces/${spaceCode}/photos/download/selected`, photoIds),
 
+  downloadSinglePhoto: (spaceCode: string, photoId: number) =>
+    http.post<Blob>(`/spaces/${spaceCode}/photos/download/${photoId}`, photoId),
+
   deletePhotos: (spaceCode: string, photoIds: PhotoIds) =>
     http.delete<void>(`/spaces/${spaceCode}/photos/selected`, photoIds, 'json'),
 

--- a/frontend/src/hooks/useDownload.ts
+++ b/frontend/src/hooks/useDownload.ts
@@ -58,6 +58,24 @@ const useDownload = ({
     });
   };
 
+  const downloadSingle = async (photoId: number) => {
+    await tryTask({
+      task: async () => {
+        await handleDownload(() =>
+          photoService.downloadSinglePhoto(spaceCode, photoId),
+        );
+      },
+      errorActions: ['toast', 'console'],
+      context: {
+        toast: {
+          text: '다운로드에 실패했습니다. 다시 시도해 주세요.',
+          type: 'error',
+        },
+      },
+      shouldLogToSentry: true,
+    });
+  };
+
   const downloadAll = async () => {
     await tryTask({
       task: async () => {
@@ -95,7 +113,8 @@ const useDownload = ({
       shouldLogToSentry: true,
     });
   };
-  return { isDownloading, downloadAll, selectDownload };
+
+  return { isDownloading, downloadAll, selectDownload, downloadSingle };
 };
 
 export default useDownload;

--- a/frontend/src/hooks/useDownload.ts
+++ b/frontend/src/hooks/useDownload.ts
@@ -19,13 +19,22 @@ const useDownload = ({
   const [isDownloading, setIsDownloading] = useState(false);
   const { tryTask } = useError();
 
-  const downloadBlob = (blob: Blob) => {
+  const downloadBlob = (blob: Blob, fileName?: string) => {
     const url = URL.createObjectURL(blob);
 
     const a = document.createElement('a');
     document.body.appendChild(a);
     a.href = url;
-    a.download = `${spaceName}.zip`;
+    
+    if (fileName) {
+      a.download = fileName;
+    } else if (blob.type.includes('image/')) {
+      const extension = blob.type.split('/')[1];
+      a.download = `photo.${extension}`;
+    } else {
+      a.download = `${spaceName}.zip`;
+    }
+    
     a.click();
 
     document.body.removeChild(a);
@@ -99,6 +108,7 @@ const useDownload = ({
 
   const handleDownload = async (
     fetchFunction: () => Promise<ApiResponse<unknown>>,
+    fileName?: string,
   ) => {
     const response = await fetchFunction();
     if (!response) return;
@@ -107,7 +117,7 @@ const useDownload = ({
     await tryTask({
       task: () => {
         validateDownloadFormat(blob);
-        downloadBlob(blob as Blob);
+        downloadBlob(blob as Blob, fileName);
       },
       errorActions: ['console'],
       shouldLogToSentry: true,

--- a/frontend/src/pages/manager/spaceHome/SpaceHome.tsx
+++ b/frontend/src/pages/manager/spaceHome/SpaceHome.tsx
@@ -80,17 +80,18 @@ const SpaceHome = () => {
 
   const navigate = useNavigate();
 
-  const { isDownloading, downloadAll, selectDownload } = useDownload({
-    spaceCode: spaceCode ?? '',
-    spaceName,
-    onDownloadSuccess: () => {
-      navigate(ROUTES.COMPLETE.DOWNLOAD, {
-        state: {
-          spaceCode: spaceCode ?? '',
-        },
-      });
-    },
-  });
+  const { isDownloading, downloadAll, selectDownload, downloadSingle } =
+    useDownload({
+      spaceCode: spaceCode ?? '',
+      spaceName,
+      onDownloadSuccess: () => {
+        navigate(ROUTES.COMPLETE.DOWNLOAD, {
+          state: {
+            spaceCode: spaceCode ?? '',
+          },
+        });
+      },
+    });
 
   const {
     isSelectMode,
@@ -124,7 +125,7 @@ const SpaceHome = () => {
   };
 
   const downloadPhotoWithTracking = async (photoId: number) => {
-    await selectDownload([photoId]);
+    await downloadSingle(photoId);
     track.button('single_download_button', {
       page: 'space_home',
       section: 'photo_modal',


### PR DESCRIPTION
## 연관된 이슈

- close #390

## 작업 내용

### 영상

기존에는 단일 다운로드도 zip으로 다운받도록 되어있었습니다.
이번 리팩토링으로 개별 이미지 파일로 다운할 수 있도록 개선되었습니다. 

https://github.com/user-attachments/assets/a92ff02e-fef3-4f37-bc42-026fd256582e


### http.ts

단일 사진 다운로드 시, 서버가 반환하는 이미지 바이너리 데이터를 JSON으로 파싱하려다 오류가 발생했습니다.
이를 해결하기 위해, http.ts에서 이미지 타입 응답을 Blob으로 처리하도록 수정하고, `useDownload.ts`에서 중복 코드를 제거하며 파일 타입에 따른 적절한 파일명을 설정하도록 개선했습니다.

### useDownload.ts

1. downloadBlob 함수 생성: 파일명을 선택적으로 받을 수 있도록 수정하고, 이미지 타입일 경우 적절한 확장자 설정
2. handleDownload 함수: 파일명을 전달할 수 있도록 파라미터 추가


