### PR TITLE
fix: 이미지 업로드 페이지에서 스크롤 되는 문제 해결

### DIFF
--- a/frontend/src/pages/guest/imageUploadPage/ImageUploadPage.styles.ts
+++ b/frontend/src/pages/guest/imageUploadPage/ImageUploadPage.styles.ts
@@ -6,7 +6,7 @@ export const Wrapper = styled.div<{ $hasImages: boolean }>`
   width: 100%;
   height: 100%;
   min-height: ${({ theme }) =>
-    `calc(100dvh - ${parseInt(theme.layout.padding.topBottom) * 2}px - ${theme.layout.headerHeight})`};
+    `calc(100dvh - ${parseInt(theme.layout.padding.topBottom) * 2}px)`};
   border-radius: 12px;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## 연관된 이슈

- close #403

## 작업 내용
<img width="200" alt="image" src="https://github.com/user-attachments/assets/3cf9c89f-c7f0-4749-a8bb-9e48532f5f63" />

* 헤더를 제거했으나, 기존에 height 계산 시 헤더 높이를 빼던 로직을 그대로 유지하고 있었음
* 해당 부분을 반영하여 height 계산 로직 수정 완료