### PR TITLE
feature: Web Share API 연동

### DIFF
--- a/frontend/src/constants/messages.ts
+++ b/frontend/src/constants/messages.ts
@@ -14,6 +14,10 @@ export const INFORMATION = {
     DESCRIPTION: '스페이스 링크를 공유해 보세요',
     HIGHLIGHT_TEXT: '스페이스 링크',
   },
+  SHARE_LINK_API: {
+    TITLE: '스페이스 업로드 링크 공유',
+    TEXT: '스페이스에 사진을 업로드 할 수 있는 링크를 공유했어요!',
+  },
   SHARE_WARNING: {
     DESCRIPTION: `내 스페이스 관리 페이지에서도\n스페이스 링크를 확인할 수 있어요`,
     HIGHLIGHT_TEXT: '스페이스 링크',

--- a/frontend/src/constants/messages.ts
+++ b/frontend/src/constants/messages.ts
@@ -16,7 +16,8 @@ export const INFORMATION = {
   },
   SHARE_LINK_API: {
     TITLE: '스페이스 업로드 링크 공유',
-    TEXT: '스페이스에 사진을 업로드 할 수 있는 링크를 공유했어요!',
+    CREATE_TEXT: (spaceName: string) =>
+      `${spaceName}에 사진을 업로드 할 수 있는 링크를 공유했어요!`,
   },
   SHARE_WARNING: {
     DESCRIPTION: `내 스페이스 관리 페이지에서도\n스페이스 링크를 확인할 수 있어요`,

--- a/frontend/src/hooks/useDownload.ts
+++ b/frontend/src/hooks/useDownload.ts
@@ -52,7 +52,7 @@ const useDownload = ({
     window.URL.revokeObjectURL(url);
   };
 
-  const selectDownload = async (
+  const downloadSelected = async (
     photoIds: number[],
     fileName?: string,
     mode?: DownloadMode,
@@ -158,7 +158,12 @@ const useDownload = ({
     });
   };
 
-  return { isDownloading, downloadAll, selectDownload, downloadSingle };
+  return {
+    isDownloading,
+    downloadAll,
+    downloadSelected,
+    downloadSingle,
+  };
 };
 
 export default useDownload;

--- a/frontend/src/hooks/useDownload.ts
+++ b/frontend/src/hooks/useDownload.ts
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { photoService } from '../apis/services/photo.service';
 import type { ApiResponse } from '../types/api.type';
+import { checkIsIos } from '../utils/checkIsIos';
 import { validateDownloadFormat } from '../validators/fetch.validator';
 import { checkSelectedPhotoExist } from '../validators/photo.validator';
 import useError from './@common/useError';
@@ -22,6 +23,8 @@ const useDownload = ({
   const [isDownloading, setIsDownloading] = useState(false);
   const { tryTask, tryFetch } = useError();
   const { share } = useWebShareAPI();
+
+  const downloadMode: DownloadMode = checkIsIos() ? 'share' : 'download';
 
   const getDownloadName = (
     fileName: string | undefined,
@@ -158,6 +161,7 @@ const useDownload = ({
   };
 
   return {
+    downloadMode,
     isDownloading,
     downloadAll,
     downloadSelected,

--- a/frontend/src/hooks/useDownload.ts
+++ b/frontend/src/hooks/useDownload.ts
@@ -150,9 +150,8 @@ const useDownload = ({
             { type: blob.type },
           );
           await share({ files: [file] });
-        } else {
-          downloadBlob(blob, fileName);
         }
+        if (mode === 'download') downloadBlob(blob, fileName);
       },
       errorActions: ['console'],
     });

--- a/frontend/src/hooks/useDownload.ts
+++ b/frontend/src/hooks/useDownload.ts
@@ -110,7 +110,6 @@ const useDownload = ({
   const downloadAll = async (fileName?: string, mode?: DownloadMode) => {
     await tryFetch({
       task: async () => {
-        setIsDownloading(true);
         await handleDownload(
           () => photoService.downloadAll(spaceCode),
           fileName,
@@ -124,9 +123,6 @@ const useDownload = ({
           text: '다운로드에 실패했습니다. 다시 시도해 주세요.',
           type: 'error',
         },
-      },
-      onFinally: () => {
-        setIsDownloading(false);
       },
     });
   };
@@ -142,6 +138,7 @@ const useDownload = ({
 
     tryTask({
       task: async () => {
+        setIsDownloading(true);
         validateDownloadFormat(blob);
         if (mode === 'share') {
           const file = new File(
@@ -154,6 +151,9 @@ const useDownload = ({
         if (mode === 'download') downloadBlob(blob, fileName);
       },
       errorActions: ['console'],
+      onFinally: () => {
+        setIsDownloading(false);
+      },
     });
   };
 

--- a/frontend/src/hooks/useWebShareAPI.ts
+++ b/frontend/src/hooks/useWebShareAPI.ts
@@ -1,0 +1,3 @@
+const useWebShareAPI = () => {};
+
+export default useWebShareAPI;

--- a/frontend/src/hooks/useWebShareAPI.ts
+++ b/frontend/src/hooks/useWebShareAPI.ts
@@ -1,3 +1,9 @@
+import {
+  validateCanShareFile,
+  validateCanWebShare,
+} from '../validators/share.validator';
+import useError from './@common/useError';
+
 interface ShareOptions {
   title?: string;
   text?: string;
@@ -6,28 +12,21 @@ interface ShareOptions {
 }
 
 const useWebShareAPI = () => {
-  const handleWebShare = async ({ title, text, url, files }: ShareOptions) => {
-    if (!navigator.canShare) {
-      console.warn('Web Share API를 지원하지 않습니다.');
-      return false;
-    }
+  const { tryFetch } = useError();
 
-    if (files && !navigator.canShare({ files })) {
-      console.warn('파일 중 공유를 할 수 없는 파일이 있습니다.');
-      return false;
-    }
-
-    // TODO: tryTask로 변환
-    try {
-      await navigator.share({ title, text, url, files });
-      return true;
-    } catch (err) {
-      console.error('공유 취소 또는 오류:', err);
-      return false;
-    }
+  const share = async ({ title, text, url, files }: ShareOptions) => {
+    await tryFetch({
+      task: async () => {
+        validateCanWebShare();
+        validateCanShareFile(files);
+        await navigator.share({ title, text, url, files });
+      },
+      errorActions: ['toast'],
+      context: { toast: { text: '사진 공유 중 문제가 발생했어요.' } },
+    });
   };
 
-  return { handleWebShare };
+  return { share };
 };
 
 export default useWebShareAPI;

--- a/frontend/src/hooks/useWebShareAPI.ts
+++ b/frontend/src/hooks/useWebShareAPI.ts
@@ -1,3 +1,33 @@
-const useWebShareAPI = () => {};
+interface ShareOptions {
+  title?: string;
+  text?: string;
+  url?: string;
+  files?: File[];
+}
+
+const useWebShareAPI = () => {
+  const handleWebShare = async ({ title, text, url, files }: ShareOptions) => {
+    if (!navigator.canShare) {
+      console.warn('Web Share API를 지원하지 않습니다.');
+      return false;
+    }
+
+    if (files && !navigator.canShare({ files })) {
+      console.warn('파일 중 공유를 할 수 없는 파일이 있습니다.');
+      return false;
+    }
+
+    // TODO: tryTask로 변환
+    try {
+      await navigator.share({ title, text, url, files });
+      return true;
+    } catch (err) {
+      console.error('공유 취소 또는 오류:', err);
+      return false;
+    }
+  };
+
+  return { handleWebShare };
+};
 
 export default useWebShareAPI;

--- a/frontend/src/hooks/useWebShareAPI.ts
+++ b/frontend/src/hooks/useWebShareAPI.ts
@@ -22,7 +22,7 @@ const useWebShareAPI = () => {
         await navigator.share({ title, text, url, files });
       },
       errorActions: ['toast'],
-      context: { toast: { text: '사진 공유 중 문제가 발생했어요.' } },
+      context: { toast: { text: '공유가 취소되었어요.' } },
     });
   };
 

--- a/frontend/src/pages/create/funnelElements/CheckSpaceInfoElement.tsx
+++ b/frontend/src/pages/create/funnelElements/CheckSpaceInfoElement.tsx
@@ -46,7 +46,9 @@ const CheckSpaceInfoElement = ({
     if (!spaceCode) return;
 
     onNext(isImmediateOpen);
-    navigate(ROUTES.GUEST.SHARE, { state: spaceCode });
+    navigate(ROUTES.GUEST.SHARE, {
+      state: { name: spaceInfo.name, spaceCode },
+    });
   };
 
   return (

--- a/frontend/src/pages/guest/sharePage/SharePage.tsx
+++ b/frontend/src/pages/guest/sharePage/SharePage.tsx
@@ -6,6 +6,7 @@ import IconLabelButton from '../../../components/@common/buttons/iconLabelButton
 import HighlightText from '../../../components/@common/highlightText/HighlightText';
 import InfoBox from '../../../components/@common/infoBox/InfoBox';
 import { INFORMATION } from '../../../constants/messages';
+import { ROUTES } from '../../../constants/routes';
 import useError from '../../../hooks/@common/useError';
 import { useToast } from '../../../hooks/@common/useToast';
 import { theme } from '../../../styles/theme';
@@ -22,6 +23,9 @@ const SharePage = () => {
 
   const handleSpaceHomeButton = () => {
     navigate(`/manager/space-home/${spaceCode}`);
+  };
+  const handleMainButton = () => {
+    navigate(ROUTES.MAIN);
   };
 
   const copyShareLink = () => {
@@ -69,18 +73,22 @@ const SharePage = () => {
           highlightTextArray={[INFORMATION.SHARE_WARNING.HIGHLIGHT_TEXT]}
         />
       </S.TopContainer>
-      <S.BottomContainer>
-        <S.ShareContainer>
-          <p>친구에게도 알려 주세요</p>
-          <S.IconLabelButtonContainer>
-            <IconLabelButton
-              icon={<LinkIcon fill={theme.colors.white} width="20px" />}
-              onClick={handleCopyLink}
-            />
-          </S.IconLabelButtonContainer>
-        </S.ShareContainer>
-        <Button text="나의 스페이스로 이동" onClick={handleSpaceHomeButton} />
-      </S.BottomContainer>
+      {spaceCode ? (
+        <S.BottomContainer>
+          <S.ShareContainer>
+            <S.ShareLabel>친구에게도 알려 주세요</S.ShareLabel>
+            <S.IconLabelButtonContainer>
+              <IconLabelButton
+                icon={<LinkIcon fill={theme.colors.white} width="20px" />}
+                onClick={handleCopyLink}
+              />
+            </S.IconLabelButtonContainer>
+          </S.ShareContainer>
+          <Button text="나의 스페이스로 이동" onClick={handleSpaceHomeButton} />
+        </S.BottomContainer>
+      ) : (
+        <Button text="메인 페이지로 이동" onClick={handleMainButton} />
+      )}
     </S.Wrapper>
   );
 };

--- a/frontend/src/pages/guest/sharePage/SharePage.tsx
+++ b/frontend/src/pages/guest/sharePage/SharePage.tsx
@@ -27,6 +27,7 @@ const SharePage = () => {
   const handleSpaceHomeButton = () => {
     navigate(`/manager/space-home/${spaceCode}`);
   };
+
   const handleMainButton = () => {
     navigate(ROUTES.MAIN);
   };

--- a/frontend/src/pages/guest/sharePage/SharePage.tsx
+++ b/frontend/src/pages/guest/sharePage/SharePage.tsx
@@ -1,4 +1,5 @@
 import { ReactComponent as LinkIcon } from '@assets/icons/link.svg';
+import { ReactComponent as ShareIcon } from '@assets/icons/share.svg';
 import LinkImage from '@assets/images/rocket.png';
 import { useLocation, useNavigate } from 'react-router-dom';
 import Button from '../../../components/@common/buttons/button/Button';
@@ -9,6 +10,7 @@ import { INFORMATION } from '../../../constants/messages';
 import { ROUTES } from '../../../constants/routes';
 import useError from '../../../hooks/@common/useError';
 import { useToast } from '../../../hooks/@common/useToast';
+import useWebShareAPI from '../../../hooks/useWebShareAPI';
 import { theme } from '../../../styles/theme';
 import { copyLinkToClipboard } from '../../../utils/copyLinkToClipboard';
 import { createShareUrl } from '../../../utils/createSpaceUrl';
@@ -19,7 +21,8 @@ const SharePage = () => {
   const location = useLocation();
   const spaceCode = location.state;
   const { showToast } = useToast();
-  const { tryTask } = useError();
+  const { tryTask, tryFetch } = useError();
+  const { share } = useWebShareAPI();
 
   const handleSpaceHomeButton = () => {
     navigate(`/manager/space-home/${spaceCode}`);
@@ -37,7 +40,7 @@ const SharePage = () => {
     });
   };
 
-  const handleCopyLink = async () => {
+  const handleCopyLink = () => {
     tryTask({
       task: copyShareLink,
       errorActions: ['toast'],
@@ -47,6 +50,18 @@ const SharePage = () => {
           position: 'top',
         },
       },
+    });
+  };
+
+  const handleShare = async () => {
+    await tryFetch({
+      task: async () =>
+        share({
+          title: '스페이스 업로드 링크 공유',
+          text: '스페이스에 사진을 업로드 할 수 있는 링크를 공유했어요!',
+          url: createShareUrl(spaceCode),
+        }),
+      errorActions: ['toast'],
     });
   };
 
@@ -81,6 +96,16 @@ const SharePage = () => {
               <IconLabelButton
                 icon={<LinkIcon fill={theme.colors.white} width="20px" />}
                 onClick={handleCopyLink}
+              />
+              <IconLabelButton
+                icon={
+                  <ShareIcon
+                    fill={theme.colors.white}
+                    stroke={theme.colors.gray06}
+                    width="20px"
+                  />
+                }
+                onClick={handleShare}
               />
             </S.IconLabelButtonContainer>
           </S.ShareContainer>

--- a/frontend/src/pages/guest/sharePage/SharePage.tsx
+++ b/frontend/src/pages/guest/sharePage/SharePage.tsx
@@ -19,7 +19,7 @@ import * as S from './SharePage.styles';
 const SharePage = () => {
   const navigate = useNavigate();
   const location = useLocation();
-  const spaceCode = location.state;
+  const { name, spaceCode } = location.state;
   const { showToast } = useToast();
   const { tryTask, tryFetch } = useError();
   const { share } = useWebShareAPI();
@@ -58,7 +58,7 @@ const SharePage = () => {
       task: async () =>
         share({
           title: INFORMATION.SHARE_LINK_API.TITLE,
-          text: INFORMATION.SHARE_LINK_API.TEXT,
+          text: INFORMATION.SHARE_LINK_API.CREATE_TEXT(name),
           url: createShareUrl(spaceCode),
         }),
       errorActions: ['toast'],

--- a/frontend/src/pages/guest/sharePage/SharePage.tsx
+++ b/frontend/src/pages/guest/sharePage/SharePage.tsx
@@ -57,8 +57,8 @@ const SharePage = () => {
     await tryFetch({
       task: async () =>
         share({
-          title: '스페이스 업로드 링크 공유',
-          text: '스페이스에 사진을 업로드 할 수 있는 링크를 공유했어요!',
+          title: INFORMATION.SHARE_LINK_API.TITLE,
+          text: INFORMATION.SHARE_LINK_API.TEXT,
           url: createShareUrl(spaceCode),
         }),
       errorActions: ['toast'],

--- a/frontend/src/pages/manager/spaceHome/SpaceHome.tsx
+++ b/frontend/src/pages/manager/spaceHome/SpaceHome.tsx
@@ -31,7 +31,6 @@ import useSpaceInfo from '../../../hooks/useSpaceInfo';
 import { ScrollableBlurArea } from '../../../styles/@common/ScrollableBlurArea';
 import { theme } from '../../../styles/theme';
 import { checkIsEarlyDate } from '../../../utils/checkIsEarlyTime';
-import { checkIsIos } from '../../../utils/checkIsIos';
 import { copyLinkToClipboard } from '../../../utils/copyLinkToClipboard';
 import { createShareUrl, createSpaceUrl } from '../../../utils/createSpaceUrl';
 import { track } from '../../../utils/googleAnalytics/track';
@@ -78,19 +77,23 @@ const SpaceHome = () => {
 
   const navigate = useNavigate();
 
-  const { isDownloading, downloadAll, downloadSelected, downloadSingle } =
-    useDownload({
-      spaceCode: spaceCode ?? '',
-      spaceName,
-      onDownloadSuccess: () => {
-        navigate(ROUTES.COMPLETE.DOWNLOAD, {
-          state: {
-            spaceCode: spaceCode ?? '',
-          },
-        });
-      },
-    });
-  const downloadMode = checkIsIos() ? 'share' : 'download';
+  const {
+    downloadMode,
+    isDownloading,
+    downloadAll,
+    downloadSelected,
+    downloadSingle,
+  } = useDownload({
+    spaceCode: spaceCode ?? '',
+    spaceName,
+    onDownloadSuccess: () => {
+      navigate(ROUTES.COMPLETE.DOWNLOAD, {
+        state: {
+          spaceCode: spaceCode ?? '',
+        },
+      });
+    },
+  });
 
   const {
     isSelectMode,

--- a/frontend/src/pages/manager/spaceHome/SpaceHome.tsx
+++ b/frontend/src/pages/manager/spaceHome/SpaceHome.tsx
@@ -31,6 +31,7 @@ import useSpaceInfo from '../../../hooks/useSpaceInfo';
 import { ScrollableBlurArea } from '../../../styles/@common/ScrollableBlurArea';
 import { theme } from '../../../styles/theme';
 import { checkIsEarlyDate } from '../../../utils/checkIsEarlyTime';
+import { checkIsIos } from '../../../utils/checkIsIos';
 import { copyLinkToClipboard } from '../../../utils/copyLinkToClipboard';
 import { createShareUrl, createSpaceUrl } from '../../../utils/createSpaceUrl';
 import { track } from '../../../utils/googleAnalytics/track';
@@ -92,6 +93,7 @@ const SpaceHome = () => {
         });
       },
     });
+  const downloadMode = checkIsIos() ? 'share' : 'download';
 
   const {
     isSelectMode,
@@ -125,7 +127,7 @@ const SpaceHome = () => {
   };
 
   const downloadPhotoWithTracking = async (photoId: number) => {
-    await downloadSingle(photoId);
+    await downloadSingle(photoId, undefined, downloadMode);
     track.button('single_download_button', {
       page: 'space_home',
       section: 'photo_modal',
@@ -275,7 +277,7 @@ const SpaceHome = () => {
                   label="모두 저장하기"
                   icon={<SaveIcon fill={theme.colors.gray06} />}
                   onClick={() => {
-                    downloadAll();
+                    downloadAll(undefined, 'download');
                     track.button('all_download_button', {
                       page: 'space_home',
                       section: 'space_home',
@@ -298,7 +300,9 @@ const SpaceHome = () => {
                 <PhotoSelectionToolBar
                   selectedCount={selectedPhotosCount}
                   onDelete={() => tryDeleteSelectedPhotos(selectedPhotoIds)}
-                  onDownload={() => selectDownload(selectedPhotoIds)}
+                  onDownload={() =>
+                    selectDownload(selectedPhotoIds, undefined, downloadMode)
+                  }
                 />
               )}
             </S.BottomNavigatorContainer>

--- a/frontend/src/pages/manager/spaceHome/SpaceHome.tsx
+++ b/frontend/src/pages/manager/spaceHome/SpaceHome.tsx
@@ -300,9 +300,16 @@ const SpaceHome = () => {
                 <PhotoSelectionToolBar
                   selectedCount={selectedPhotosCount}
                   onDelete={() => tryDeleteSelectedPhotos(selectedPhotoIds)}
-                  onDownload={() =>
-                    selectDownload(selectedPhotoIds, undefined, downloadMode)
-                  }
+                  onDownload={() => {
+                    if (selectedPhotosCount === 1)
+                      downloadSingle(
+                        selectedPhotoIds[0],
+                        undefined,
+                        downloadMode,
+                      );
+                    else
+                      selectDownload(selectedPhotoIds, undefined, 'download');
+                  }}
                 />
               )}
             </S.BottomNavigatorContainer>

--- a/frontend/src/pages/manager/spaceHome/SpaceHome.tsx
+++ b/frontend/src/pages/manager/spaceHome/SpaceHome.tsx
@@ -151,6 +151,14 @@ const SpaceHome = () => {
     );
   };
 
+  const handleSelectDelete = () => tryDeleteSelectedPhotos(selectedPhotoIds);
+
+  const handleSelectDownload = () => {
+    if (selectedPhotosCount === 1)
+      downloadSingle(selectedPhotoIds[0], undefined, downloadMode);
+    else downloadSelected(selectedPhotoIds, undefined, 'download');
+  };
+
   const handleImageClick = isSelectMode ? toggleSelectedPhoto : openPhotoModal;
 
   //biome-ignore lint/correctness/useExhaustiveDependencies: isFetchSectionVisible 변경 시 호출
@@ -298,17 +306,8 @@ const SpaceHome = () => {
               {isSelectMode && (
                 <PhotoSelectionToolBar
                   selectedCount={selectedPhotosCount}
-                  onDelete={() => tryDeleteSelectedPhotos(selectedPhotoIds)}
-                  onDownload={() => {
-                    if (selectedPhotosCount === 1)
-                      downloadSingle(
-                        selectedPhotoIds[0],
-                        undefined,
-                        downloadMode,
-                      );
-                    else
-                      downloadSelected(selectedPhotoIds, undefined, 'download');
-                  }}
+                  onDelete={handleSelectDelete}
+                  onDownload={handleSelectDownload}
                 />
               )}
             </S.BottomNavigatorContainer>

--- a/frontend/src/pages/manager/spaceHome/SpaceHome.tsx
+++ b/frontend/src/pages/manager/spaceHome/SpaceHome.tsx
@@ -45,9 +45,6 @@ const SpaceHome = () => {
   const { spaceInfo } = useSpaceInfo(spaceCode ?? '');
   const isEarlyTime =
     spaceInfo?.openedAt && checkIsEarlyDate(spaceInfo.openedAt);
-
-  // TODO: NoData 시 표시할 Layout 필요
-  const _isNoData = !spaceInfo;
   const isSpaceExpired = spaceInfo?.isExpired;
   const spaceName = spaceInfo?.name ?? '';
   const { targetRef: hideBlurAreaTriggerRef, isIntersecting: isAtPageBottom } =
@@ -220,7 +217,6 @@ const SpaceHome = () => {
 
   return (
     <S.Wrapper>
-      {/* TODO: 버튼 지우기 */}
       {isEarlyTime && <EarlyPage openedAt={spaceInfo.openedAt} />}
       {(isDownloading || isDeleting) && (
         <LoadingLayout loadingContents={loadingContents} percentage={0} />

--- a/frontend/src/pages/manager/spaceHome/SpaceHome.tsx
+++ b/frontend/src/pages/manager/spaceHome/SpaceHome.tsx
@@ -78,7 +78,7 @@ const SpaceHome = () => {
 
   const navigate = useNavigate();
 
-  const { isDownloading, downloadAll, selectDownload, downloadSingle } =
+  const { isDownloading, downloadAll, downloadSelected, downloadSingle } =
     useDownload({
       spaceCode: spaceCode ?? '',
       spaceName,
@@ -304,7 +304,7 @@ const SpaceHome = () => {
                         downloadMode,
                       );
                     else
-                      selectDownload(selectedPhotoIds, undefined, 'download');
+                      downloadSelected(selectedPhotoIds, undefined, 'download');
                   }}
                 />
               )}

--- a/frontend/src/utils/checkIsIos.ts
+++ b/frontend/src/utils/checkIsIos.ts
@@ -1,0 +1,4 @@
+export const checkIsIos = () => {
+  const userAgent = navigator.userAgent;
+  return /iPad|iPhone|iPod/.test(userAgent);
+};

--- a/frontend/src/validators/share.validator.ts
+++ b/frontend/src/validators/share.validator.ts
@@ -1,0 +1,9 @@
+export const validateCanWebShare = () => {
+  if (!navigator.canShare || !navigator.share)
+    throw new Error('공유 기능을 지원하지 않는 브라우저에요.');
+};
+
+export const validateCanShareFile = (files?: File[]) => {
+  if (files && !navigator.canShare({ files }))
+    throw new Error('파일 중 공유를 할 수 없는 파일이 있습니다.');
+};


### PR DESCRIPTION
## 연관된 이슈

- close #391

## 작업 내용

### useWebShareAPI 훅 생성

- Web Share API를 사용할 수 있는 커스텀 훅
- share를 이용해 WebShare API를 사용할 수 있음

### ios 모바일 + 단일 다운로드 시 Web Share API로 다운로드
- ios의 경우 사진 한 장을 다운받은 뒤 갤러리에 저장하기 위해 한번 더 들어가야 하는 불편함이 있음
- 단일 다운로드 시 Web Share로 바로 넘어가게 함으로써 필요한 depth를 감소
<img width="333" height="720" alt="image" src="https://github.com/user-attachments/assets/5948440a-3c27-4961-a66b-f4c2468b9c32" />

### SharePage에서 스페이스 업로드 링크를 공유할 수 있는 버튼 추가
- Web Share API를 이용해 title, text, url을 공유할 수 있음
- 공유한 결과(카카오톡)

  <img width="585" height="325" alt="image" src="https://github.com/user-attachments/assets/f6e16026-61e6-4ead-90f0-f262c0ff92d4" />
