### PR TITLE
fix: 요청 content-type이 json일 때만 요청 래핑 및 바디 로깅

### DIFF
--- a/backend/forgather/src/main/java/com/forgather/global/logging/LoggingInterceptor.java
+++ b/backend/forgather/src/main/java/com/forgather/global/logging/LoggingInterceptor.java
@@ -73,8 +73,8 @@ public class LoggingInterceptor implements HandlerInterceptor {
     @Override
     public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler,
         Exception exception) {
-        boolean isGetRequest = request.getMethod().equals("GET");
-        if (!isGetRequest) { // requestBody 로깅
+        String contentType = request.getContentType();
+        if (contentType != null && contentType.toLowerCase().startsWith("application/json")) {
             logRequestBody(request);
         }
 

--- a/backend/forgather/src/main/java/com/forgather/global/logging/RequestWrappingFilter.java
+++ b/backend/forgather/src/main/java/com/forgather/global/logging/RequestWrappingFilter.java
@@ -16,7 +16,12 @@ public class RequestWrappingFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
         FilterChain filterChain) throws ServletException, IOException {
-        HttpServletRequest customWrapper = new CustomRequestBodyWrapper(request);
-        filterChain.doFilter(customWrapper, response);
+        String contentType = request.getContentType();
+        if (contentType != null && contentType.toLowerCase().startsWith("application/json")) {
+            HttpServletRequest customWrapper = new CustomRequestBodyWrapper(request);
+            filterChain.doFilter(customWrapper, response);
+        } else {
+            filterChain.doFilter(request, response);
+        }
     }
 }


### PR DESCRIPTION
## 연관된 이슈

- close # #427 

## 작업 내용
요청의 content-type이 application/json일 경우에만 `RequestWrappingFilter`가 동작해 요청을 래핑하도록 한다.
request body 로깅 또한 content-type이 application/json일 경우에만 수행한다.