### PR TITLE
feat: 스페이스 정보 조회 시 통계 정보 추가

### DIFF
--- a/backend/forgather/src/main/java/com/forgather/domain/space/dto/SpaceResponse.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/space/dto/SpaceResponse.java
@@ -34,7 +34,13 @@ public record SpaceResponse(
     boolean isExpired,
 
     @Schema(description = "호스트 정보")
-    HostResponse host
+    HostResponse host,
+
+    @Schema(description = "스페이스에 참여한 게스트 수", example = "10")
+    long guestCount,
+
+    @Schema(description = "스페이스에 업로드된 사진 수", example = "500")
+    long photoCount
 ) {
 
     public static SpaceResponse from(Space space) {
@@ -47,7 +53,9 @@ public record SpaceResponse(
             space.getExpiredAt(),
             space.isExpired(LocalDateTime.now()),
             // TODO: 스페이스 : 호스트 m:n 관계로 변경 후 수정 필요
-            HostResponse.from(space.getSpaceHostMap().getFirst().getHost())
+            HostResponse.from(space.getSpaceHostMap().getFirst().getHost()),
+            space.getGuestCount(),
+            space.getPhotoCount()
         );
     }
 }

--- a/backend/forgather/src/main/java/com/forgather/domain/space/model/Space.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/space/model/Space.java
@@ -18,8 +18,10 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.PostLoad;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Transient;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -48,6 +50,18 @@ public class Space extends BaseTimeEntity {
     @Column(name = "opened_at", nullable = false)
     private LocalDateTime openedAt;
 
+    @OneToMany(mappedBy = "space")
+    private List<Guest> guests = new ArrayList<>();
+
+    @OneToMany(mappedBy = "space")
+    private List<SpaceContent> contents = new ArrayList<>();
+
+    @Transient
+    private long guestCount = 0;
+
+    @Transient
+    private long photoCount = 0;
+
     public Space(Host host, String code, String name, int validHours, LocalDateTime openedAt) {
         validate(code, name, validHours, openedAt);
         spaceHostMap.add(new SpaceHostMap(this, host));
@@ -55,6 +69,14 @@ public class Space extends BaseTimeEntity {
         this.name = name;
         this.openedAt = openedAt;
         this.validHours = validHours;
+    }
+
+    @PostLoad
+    private void postLoad() {
+        this.guestCount = guests.size();
+        this.photoCount = contents.stream()
+            .filter(content -> content instanceof Photo)
+            .count();
     }
 
     public void validateExpiration(LocalDateTime currentDateTime) {


### PR DESCRIPTION
## 연관된 이슈

- close #443

## 작업 내용

스페이스 단건 조회 시 업로더 수와 업로드된 사진 수를 함께 반환하도록 필드를 추가했습니다.

이후 스페이스 목록 조회 시에도 통계 정보(guestCount, photoCount)를 추가해야 합니다.