### PR TITLE
feature: presignedURL api로 마이그레이션

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@emotion/styled": "^11.14.1",
         "@microsoft/clarity": "^1.0.0",
         "@sentry/react": "^10.1.0",
+        "exifr": "^7.1.3",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-ga4": "^2.1.0",
@@ -8092,6 +8093,12 @@
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
+    },
+    "node_modules/exifr": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/exifr/-/exifr-7.1.3.tgz",
+      "integrity": "sha512-g/aje2noHivrRSLbAUtBPWFbxKdKhgj/xr1vATDdUXPOFYJlQ62Ft0oy+72V6XLIpDJfHs6gXLbBLAolqOXYRw==",
+      "license": "MIT"
     },
     "node_modules/exit-x": {
       "version": "0.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -57,6 +57,7 @@
     "@emotion/styled": "^11.14.1",
     "@microsoft/clarity": "^1.0.0",
     "@sentry/react": "^10.1.0",
+    "exifr": "^7.1.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-ga4": "^2.1.0",

--- a/frontend/src/apis/createHeaders.ts
+++ b/frontend/src/apis/createHeaders.ts
@@ -3,13 +3,15 @@ import type { BodyContentType } from '../types/api.type';
 export const createHeaders = (
   bodyContentType: BodyContentType,
   token?: string,
+  withTraceId: boolean = true,
 ): HeadersInit => {
-  // TODO : 저장된 토큰 들고오기
   const traceId = crypto.randomUUID().slice(0, 8);
 
-  const headers: HeadersInit = {
-    'trace-id': traceId,
-  };
+  const headers: HeadersInit = withTraceId
+    ? {
+        'trace-id': traceId,
+      }
+    : {};
 
   if (token) {
     headers.Authorization = `Bearer ${token}`;

--- a/frontend/src/apis/services/photo.service.ts
+++ b/frontend/src/apis/services/photo.service.ts
@@ -1,4 +1,10 @@
-import type { PhotoIds, PhotoListResponse } from '../../types/api.type';
+import type {
+  PhotoIds,
+  PhotoListResponse,
+  PresignedUrlsResponse,
+  UploadedPhotos,
+} from '../../types/api.type';
+import { UploadFile } from '../../types/file.type';
 import type { CreatePhotoInput, Photo } from '../../types/photo.type';
 import { authHttp, http } from '../http';
 
@@ -25,6 +31,18 @@ export const photoService = {
       'form-data',
     );
   },
+
+  getPresignedUrls: (spaceCode: string, uploadFileNames: string[]) =>
+    http.post<PresignedUrlsResponse>(
+      `/spaces/${spaceCode}/photos/issue/upload-urls`,
+      { uploadFileNames },
+    ),
+
+  notifyUploadComplete: (spaceCode: string, uploadedPhotos: UploadedPhotos[]) =>
+    http.post(`/spaces/${spaceCode}/photos`, { uploadedPhotos }),
+
+  uploadPhotosToS3: async (presignedUrl: string, file: File) =>
+    http.putToS3(presignedUrl, file),
 
   downloadAll: (spaceCode: string) =>
     authHttp.post<Blob>(`/spaces/${spaceCode}/photos/download`, undefined),

--- a/frontend/src/components/@common/imageLayout/imageElement/guestImageElement/GuestImageElement.tsx
+++ b/frontend/src/components/@common/imageLayout/imageElement/guestImageElement/GuestImageElement.tsx
@@ -47,7 +47,7 @@ const GuestImageElement = ({
       onKeyDown={handleEnterKeyDown}
     >
       <C.Image
-        src={data.path}
+        src={data.previewUrl}
         alt={alt}
         onError={handleError}
         className="clarity-mask-photo"

--- a/frontend/src/components/@common/modal/PhotoModal.tsx
+++ b/frontend/src/components/@common/modal/PhotoModal.tsx
@@ -59,7 +59,7 @@ const PhotoModal = (props: PhotoModalProps) => {
       fetchPhoto();
       return;
     }
-    setDisplayPath(props.previewFile.path);
+    setDisplayPath(props.previewFile.previewUrl);
   }, []);
 
   const fetchPhoto = async () => {

--- a/frontend/src/hooks/@common/useError.ts
+++ b/frontend/src/hooks/@common/useError.ts
@@ -35,8 +35,8 @@ const useError = () => {
     redirect: (path: RedirectPath) => {
       navigate(path.path);
     },
-    console: (message: string) => {
-      console.error(message);
+    console: (error: Error) => {
+      console.error(error);
     },
   };
 
@@ -131,7 +131,7 @@ const useError = () => {
       errorHandler.redirect(redirectPath);
     }
     if (errorActions.includes('console')) {
-      errorHandler.console(error.message);
+      errorHandler.console(error);
     }
   };
 

--- a/frontend/src/hooks/@common/useLocalFile.ts
+++ b/frontend/src/hooks/@common/useLocalFile.ts
@@ -15,7 +15,7 @@ interface UseFileUploadProps {
   onUploadSuccess?: () => void;
 }
 
-const useFileUpload = ({
+const useLocalFile = ({
   spaceCode,
   fileType,
   onUploadSuccess,
@@ -144,4 +144,4 @@ const useFileUpload = ({
   };
 };
 
-export default useFileUpload;
+export default useLocalFile;

--- a/frontend/src/hooks/useFileUpload.ts
+++ b/frontend/src/hooks/useFileUpload.ts
@@ -1,0 +1,259 @@
+import { useEffect, useState } from 'react';
+import { photoService } from '../apis/services/photo.service';
+import type { LocalFile, UploadFile } from '../types/file.type';
+import useError from './@common/useError';
+
+interface Batch {
+  id: number;
+  total: number;
+  success: number;
+  failed: number;
+  inProgress: number;
+  uploadFiles: UploadFile[];
+}
+
+interface Session {
+  total: number;
+  success: number;
+  failed: number;
+  inProgress: number;
+  batches: Batch[];
+}
+
+interface UseFileUploadProps {
+  spaceCode: string;
+  localFiles: LocalFile[];
+}
+const useFileUpload = ({ spaceCode, localFiles }: UseFileUploadProps) => {
+  const [uploadFiles, setUploadFiles] = useState<UploadFile[]>([]);
+  const [batches, setBatches] = useState<Batch[]>();
+  const [session, setSession] = useState<Session>();
+  const { tryTask, tryFetch } = useError();
+
+  useEffect(() => {
+    console.log(session);
+  }, [session]);
+
+  const createUploadFiles = (localFiles: LocalFile[]) => {
+    const newUploadFiles: UploadFile[] = localFiles.map((file) => {
+      const extension = file.originFile.name.split('.').pop();
+      const objectKey = `${crypto.randomUUID()}.${extension}`;
+
+      return {
+        id: file.id,
+        originFile: file.originFile,
+        objectKey,
+        capturedAt: file.capturedAt,
+        presignedUrl: '',
+        state: 'idle',
+      };
+    });
+
+    setUploadFiles(newUploadFiles);
+    return newUploadFiles;
+  };
+
+  const createBatches = (uploadFiles: UploadFile[]) => {
+    // 100개 단위로 나누어 배치 생성
+    const chunkSize = 100;
+    const newBatches: Batch[] = [];
+    for (let i = 0; i < uploadFiles.length; i += chunkSize) {
+      const chunk = uploadFiles.slice(i, i + chunkSize);
+      newBatches.push({
+        id: i,
+        total: chunk.length,
+        success: 0,
+        failed: 0,
+        inProgress: 0,
+        uploadFiles: uploadFiles.slice(i, i + chunkSize),
+      });
+    }
+
+    setBatches(newBatches);
+    return newBatches;
+  };
+
+  // uploadFiles, batches, session 초기화
+  const createSession = (localFiles: LocalFile[]) => {
+    const newFiles = createUploadFiles(localFiles);
+    const newBatches = createBatches(newFiles);
+
+    // 세션도 초기화
+    const newSession: Session = {
+      total: newBatches.length,
+      success: 0,
+      failed: 0,
+      inProgress: 0,
+      batches: newBatches,
+    };
+    setSession(newSession);
+    return newSession;
+  };
+
+  const fetchPresignedUrls = async (uploadFiles: UploadFile[]) => {
+    const objectKeys = uploadFiles.map((f) => f.objectKey);
+    const res = await photoService.getPresignedUrls(spaceCode, objectKeys);
+    if (!res || !res.data?.signedUrls)
+      throw new Error('presignedUrl 발급 실패');
+    return res.data.signedUrls as Record<string, string>;
+  };
+
+  const addPresignedUrls = (
+    presignedUrls: Record<string, string>,
+    targetFiles: UploadFile[],
+  ) => {
+    const updated = targetFiles.map(
+      (file): UploadFile => ({
+        ...file,
+        presignedUrl: presignedUrls[file.objectKey] ?? '',
+        state: 'signed' as const,
+      }),
+    );
+
+    setUploadFiles((prev) =>
+      prev.map((f) => {
+        const found = updated.find((u) => u.id === f.id);
+        return found ?? f;
+      }),
+    );
+
+    return updated;
+  };
+
+  const canNotifySuccess = (successFiles: UploadFile[]) => {
+    if (successFiles.length === 0) throw new Error('성공한 파일이 없습니다.');
+  };
+
+  const notifySuccessFiles = async (successFiles: UploadFile[]) => {
+    tryTask({
+      task: () => canNotifySuccess(successFiles),
+      errorActions: ['console'],
+    });
+
+    const uploadedPhotos = successFiles.map((file) => ({
+      uploadFileName: file.objectKey,
+      originalName: file.originFile.name,
+      capturedAt: file.capturedAt,
+    }));
+
+    await tryFetch({
+      task: async () =>
+        await photoService.notifyUploadComplete(spaceCode, uploadedPhotos),
+      errorActions: ['console'],
+    });
+  };
+
+  const uploadBatch = async (batch: Batch) => {
+    const presignedUrls = await tryFetch({
+      task: async () => await fetchPresignedUrls(batch.uploadFiles),
+      errorActions: ['console'],
+    });
+
+    const updatedBatchFiles = addPresignedUrls(
+      presignedUrls.data ?? {},
+      batch.uploadFiles,
+    );
+
+    await Promise.allSettled(
+      updatedBatchFiles.map(async (file) => {
+        try {
+          await photoService.uploadPhotosToS3(
+            file.presignedUrl,
+            file.originFile,
+          );
+          file.state = 'uploaded';
+        } catch {
+          file.state = 'failed';
+        }
+      }),
+    );
+
+    setUploadFiles((prev) =>
+      prev.map((file) => {
+        const target = updatedBatchFiles.find((u) => u.id === file.id);
+        return target ? { ...file, state: target.state } : file;
+      }),
+    );
+
+    calculateSuccessFiles(batch, updatedBatchFiles);
+
+    const successFiles = updatedBatchFiles.filter((f) => f.state === 'success');
+    await notifySuccessFiles(successFiles);
+  };
+
+  //TODO: 구조 정리하기 닉네임 연결 후 통계가 정상동작하는지 확인
+  const calculateSuccessFiles = (
+    batch: Batch,
+    updatedBatchFiles: UploadFile[],
+  ) => {
+    const successCount = updatedBatchFiles.filter(
+      (f) => f.state === 'success',
+    ).length;
+    const failedCount = updatedBatchFiles.filter(
+      (f) => f.state === 'failed',
+    ).length;
+    const inProgressCount = updatedBatchFiles.filter(
+      (f) => f.state === 'uploaded',
+    ).length;
+
+    const updatedBatch: Batch = {
+      ...batch,
+      success: successCount,
+      failed: failedCount,
+      inProgress: inProgressCount,
+      uploadFiles: updatedBatchFiles,
+    };
+
+    setBatches((prev) =>
+      prev?.map((b) => (b.id === batch.id ? updatedBatch : b)),
+    );
+
+    setSession((prev) => {
+      if (!prev) return prev;
+
+      const newBatches = prev.batches.map((b) =>
+        b.id === batch.id ? updatedBatch : b,
+      );
+
+      const totalSuccess = newBatches.reduce((acc, b) => acc + b.success, 0);
+      const totalFailed = newBatches.reduce((acc, b) => acc + b.failed, 0);
+      const totalInProgress = newBatches.reduce(
+        (acc, b) => acc + b.inProgress,
+        0,
+      );
+
+      return {
+        ...prev,
+        success: totalSuccess,
+        failed: totalFailed,
+        inProgress: totalInProgress,
+        batches: newBatches,
+      };
+    });
+  };
+
+  // "진짜" 업로드
+  const submitFileUpload = async () => {
+    if (!session) createSession(localFiles);
+
+    for (const batch of session?.batches ?? []) {
+      await tryFetch({
+        task: async () => {
+          await uploadBatch(batch);
+        },
+        errorActions: ['toast', 'console'],
+        context: {
+          toast: {
+            text: '업로드에 실패했습니다. 다시 시도해주세요.',
+            type: 'error',
+          },
+        },
+      });
+      //TODO: 실패한 경우 전체 삭제 로직 추가 예정
+    }
+  };
+
+  return { submitFileUpload, total: session?.total, success: session?.success };
+};
+
+export default useFileUpload;

--- a/frontend/src/pages/guest/imageUploadPage/ImageUploadPage.tsx
+++ b/frontend/src/pages/guest/imageUploadPage/ImageUploadPage.tsx
@@ -47,7 +47,7 @@ const ImageUploadPage = () => {
   const spaceName = spaceInfo?.name ?? '';
   const overlay = useOverlay();
   const {
-    previewData,
+    previewFile,
     isUploading,
     handleFilesUploadClick,
     handleFilesDrop,
@@ -59,7 +59,7 @@ const ImageUploadPage = () => {
     onUploadSuccess: navigateToUploadComplete,
   });
 
-  const hasImages = Array.isArray(previewData) && previewData.length > 0;
+  const hasImages = Array.isArray(previewFile) && previewFile.length > 0;
   const { targetRef: hideBlurAreaTriggerRef, isIntersecting: isAtPageBottom } =
     useIntersectionObserver({});
   const { targetRef: scrollTopTriggerRef, isIntersecting: isAtPageTop } =
@@ -78,7 +78,7 @@ const ImageUploadPage = () => {
   };
 
   const handleImageClick = async (photoId: number) => {
-    const selectedPhoto = previewData.find((photo) => photo.id === photoId);
+    const selectedPhoto = previewFile.find((photo) => photo.id === photoId);
     if (!selectedPhoto) return;
 
     await overlay(
@@ -151,10 +151,10 @@ const ImageUploadPage = () => {
             <FloatingActionButton
               label={
                 <HighlightText
-                  text={`사진 ${previewData.length}장 업로드하기`}
+                  text={`사진 ${previewFile.length}장 업로드하기`}
                   fontStyle="buttonPrimary"
                   highlightColorStyle="gray04"
-                  highlightTextArray={[`사진 ${previewData.length}장`]}
+                  highlightTextArray={[`사진 ${previewFile.length}장`]}
                 />
               }
               onClick={submitFileUpload}
@@ -162,7 +162,7 @@ const ImageUploadPage = () => {
             />
           </S.ButtonContainer>
           <GuestImageGrid
-            photoData={previewData}
+            photoData={previewFile}
             rowImageAmount={3}
             onImageClick={handleImageClick}
             onDeleteClick={(id: number) => {

--- a/frontend/src/pages/guest/imageUploadPage/ImageUploadPage.tsx
+++ b/frontend/src/pages/guest/imageUploadPage/ImageUploadPage.tsx
@@ -14,6 +14,7 @@ import { useOverlay } from '../../../contexts/OverlayProvider';
 import useIntersectionObserver from '../../../hooks/@common/useIntersectionObserver';
 import useLeftTimer from '../../../hooks/@common/useLeftTimer';
 import useLocalFile from '../../../hooks/@common/useLocalFile';
+import useFileUpload from '../../../hooks/useFileUpload';
 import useSpaceCodeFromPath from '../../../hooks/useSpaceCodeFromPath';
 import useSpaceInfo from '../../../hooks/useSpaceInfo';
 import { ScrollableBlurArea } from '../../../styles/@common/ScrollableBlurArea';
@@ -47,16 +48,21 @@ const ImageUploadPage = () => {
   const spaceName = spaceInfo?.name ?? '';
   const overlay = useOverlay();
   const {
+    localFiles,
     previewFile,
     isUploading,
     handleFilesUploadClick,
     handleFilesDrop,
-    submitFileUpload,
     deleteFile,
   } = useLocalFile({
     spaceCode: spaceCode ?? '',
     fileType: 'image',
     onUploadSuccess: navigateToUploadComplete,
+  });
+
+  const { submitFileUpload } = useFileUpload({
+    localFiles: localFiles,
+    spaceCode: spaceCode ?? '',
   });
 
   const hasImages = Array.isArray(previewFile) && previewFile.length > 0;

--- a/frontend/src/pages/guest/imageUploadPage/ImageUploadPage.tsx
+++ b/frontend/src/pages/guest/imageUploadPage/ImageUploadPage.tsx
@@ -11,9 +11,9 @@ import LoadingLayout from '../../../components/layout/loadingLayout/LoadingLayou
 import UploadBox from '../../../components/uploadBox/UploadBox';
 import { ROUTES } from '../../../constants/routes';
 import { useOverlay } from '../../../contexts/OverlayProvider';
-import useFileUpload from '../../../hooks/@common/useFileUpload';
 import useIntersectionObserver from '../../../hooks/@common/useIntersectionObserver';
 import useLeftTimer from '../../../hooks/@common/useLeftTimer';
+import useLocalFile from '../../../hooks/@common/useLocalFile';
 import useSpaceCodeFromPath from '../../../hooks/useSpaceCodeFromPath';
 import useSpaceInfo from '../../../hooks/useSpaceInfo';
 import { ScrollableBlurArea } from '../../../styles/@common/ScrollableBlurArea';
@@ -53,7 +53,7 @@ const ImageUploadPage = () => {
     handleFilesDrop,
     submitFileUpload,
     deleteFile,
-  } = useFileUpload({
+  } = useLocalFile({
     spaceCode: spaceCode ?? '',
     fileType: 'image',
     onUploadSuccess: navigateToUploadComplete,

--- a/frontend/src/stories/GuestImageElement.stories.tsx
+++ b/frontend/src/stories/GuestImageElement.stories.tsx
@@ -16,7 +16,8 @@ export const Default: Story = {
   args: {
     data: {
       id: 1,
-      path: 'https://mblogthumb-phinf.pstatic.net/MjAyMTA0MTlfOTMg/MDAxNjE4ODIyODEyNjIy.PlBJ_yLT_0RQxDVzmDuEWrIioxajvdDqzG3nVK3qJQ0g.Ya7t_4dySMXtr2YT-p326Z1odr5MVxg_rBKZBPtHKp8g.JPEG.dochiqueens/april-blog-1.jpg?type=w800',
+      previewUrl:
+        'https://mblogthumb-phinf.pstatic.net/MjAyMTA0MTlfOTMg/MDAxNjE4ODIyODEyNjIy.PlBJ_yLT_0RQxDVzmDuEWrIioxajvdDqzG3nVK3qJQ0g.Ya7t_4dySMXtr2YT-p326Z1odr5MVxg_rBKZBPtHKp8g.JPEG.dochiqueens/april-blog-1.jpg?type=w800',
     },
     alt: '스페이스 이미지',
     onImageClick: () => {

--- a/frontend/src/stories/GuestImageGrid.stories.tsx
+++ b/frontend/src/stories/GuestImageGrid.stories.tsx
@@ -15,15 +15,18 @@ export const Default: Story = {
     photoData: [
       {
         id: 1,
-        path: 'https://mblogthumb-phinf.pstatic.net/MjAyMTA0MTlfOTMg/MDAxNjE4ODIyODEyNjIy.PlBJ_yLT_0RQxDVzmDuEWrIioxajvdDqzG3nVK3qJQ0g.Ya7t_4dySMXtr2YT-p326Z1odr5MVxg_rBKZBPtHKp8g.JPEG.dochiqueens/april-blog-1.jpg?type=w800',
+        previewUrl:
+          'https://mblogthumb-phinf.pstatic.net/MjAyMTA0MTlfOTMg/MDAxNjE4ODIyODEyNjIy.PlBJ_yLT_0RQxDVzmDuEWrIioxajvdDqzG3nVK3qJQ0g.Ya7t_4dySMXtr2YT-p326Z1odr5MVxg_rBKZBPtHKp8g.JPEG.dochiqueens/april-blog-1.jpg?type=w800',
       },
       {
         id: 2,
-        path: 'https://mblogthumb-phinf.pstatic.net/MjAyMTA0MTlfOTMg/MDAxNjE4ODIyODEyNjIy.PlBJ_yLT_0RQxDVzmDuEWrIioxajvdDqzG3nVK3qJQ0g.Ya7t_4dySMXtr2YT-p326Z1odr5MVxg_rBKZBPtHKp8g.JPEG.dochiqueens/april-blog-1.jpg?type=w800',
+        previewUrl:
+          'https://mblogthumb-phinf.pstatic.net/MjAyMTA0MTlfOTMg/MDAxNjE4ODIyODEyNjIy.PlBJ_yLT_0RQxDVzmDuEWrIioxajvdDqzG3nVK3qJQ0g.Ya7t_4dySMXtr2YT-p326Z1odr5MVxg_rBKZBPtHKp8g.JPEG.dochiqueens/april-blog-1.jpg?type=w800',
       },
       {
         id: 3,
-        path: 'https://mblogthumb-phinf.pstatic.net/MjAyMTA0MTlfOTMg/MDAxNjE4ODIyODEyNjIy.PlBJ_yLT_0RQxDVzmDuEWrIioxajvdDqzG3nVK3qJQ0g.Ya7t_4dySMXtr2YT-p326Z1odr5MVxg_rBKZBPtHKp8g.JPEG.dochiqueens/april-blog-1.jpg?type=w800',
+        previewUrl:
+          'https://mblogthumb-phinf.pstatic.net/MjAyMTA0MTlfOTMg/MDAxNjE4ODIyODEyNjIy.PlBJ_yLT_0RQxDVzmDuEWrIioxajvdDqzG3nVK3qJQ0g.Ya7t_4dySMXtr2YT-p326Z1odr5MVxg_rBKZBPtHKp8g.JPEG.dochiqueens/april-blog-1.jpg?type=w800',
       },
     ],
   },

--- a/frontend/src/types/api.type.ts
+++ b/frontend/src/types/api.type.ts
@@ -7,7 +7,10 @@ export interface requestOptionsType {
   body?: unknown;
   params?: Record<string, unknown>;
   bodyContentType?: BodyContentType;
+  withTraceId: boolean;
   token?: string;
+  fullUrl?: string;
+  headersOverride?: Record<string, string>;
 }
 export interface ApiResponse<T> {
   success: boolean;
@@ -37,4 +40,14 @@ export interface PhotoIds {
 
 export interface PhotoId {
   photoId: number;
+}
+
+export interface PresignedUrlsResponse {
+  signedUrls: Record<string, string>;
+}
+
+export interface UploadedPhotos {
+  uploadFileName: string;
+  originalName: string;
+  capturedAt: string | null;
 }

--- a/frontend/src/types/file.type.ts
+++ b/frontend/src/types/file.type.ts
@@ -2,9 +2,26 @@ export interface LocalFile {
   id: number;
   originFile: File;
   previewUrl: string;
+  capturedAt: string | null;
 }
 
 export interface PreviewFile {
   id: number;
   previewUrl: string;
+}
+
+export type UploadFileState =
+  | 'idle'
+  | 'signed'
+  | 'uploaded'
+  | 'success'
+  | 'failed';
+
+export interface UploadFile {
+  id: number;
+  originFile: File;
+  objectKey: string;
+  presignedUrl: string;
+  capturedAt: string | null;
+  state: UploadFileState;
 }

--- a/frontend/src/types/file.type.ts
+++ b/frontend/src/types/file.type.ts
@@ -1,9 +1,10 @@
-export interface UploadFile {
+export interface LocalFile {
   id: number;
   originFile: File;
+  previewUrl: string;
 }
 
 export interface PreviewFile {
   id: number;
-  path: string;
+  previewUrl: string;
 }


### PR DESCRIPTION
## 연관된 이슈

- close #386 

## 작업 내용

### presignedURL로 마이그레이션 진행했습니다 😎🫡

많은 변경이 있었지만,, 리팩터링하면서 최소화하였구요. 
현재 구조까지의 배경은 노션에 문서화해두었습니다 ㅎㅎ!!

https://www.notion.so/presigned-url-255864a9cb0380b7b245d83b63c07659?source=copy_link

## 추가 구현할 사항

- 지금 현재 로직이 "절차적이다"라는 생각이 듭니다. api를 호출하고 데이터를 다루다보니 당연한가? 싶다가도 조금 더 선언형으로 작성해보고 싶다는 생각이 드네요.

- 전체 삭제 api가 올라오면 추가로 연동해야 합니다.