### PR TITLE
fix: 다운로딩 중 로딩 UI 삭제 및 다운로드 풀기

### DIFF
--- a/frontend/src/hooks/useDownload.ts
+++ b/frontend/src/hooks/useDownload.ts
@@ -137,11 +137,14 @@ const useDownload = ({
           downloadUrls[0].originalName,
         );
       },
-      errorActions: ['toast', 'console'],
+      errorActions: ['toast', 'afterAction'],
       context: {
         toast: {
           text: '다운로드에 실패했습니다. 다시 시도해 주세요.',
           type: 'error',
+        },
+        afterAction: {
+          action: () => setIsDownloading(false),
         },
       },
     });
@@ -162,11 +165,14 @@ const useDownload = ({
 
         onDownloadSuccess?.();
       },
-      errorActions: ['toast', 'console'],
+      errorActions: ['toast', 'afterAction'],
       context: {
         toast: {
           text: '다운로드에 실패했습니다. 다시 시도해 주세요.',
           type: 'error',
+        },
+        afterAction: {
+          action: () => setIsDownloading(false),
         },
       },
     });


### PR DESCRIPTION
## 연관된 이슈

- close #478

## 작업 내용
* 다운로드 중 에러 발생시 로딩 UI를 삭제하고 다운로드를 해제
* afterAction에 setIsDownloading(false)를 추가


https://github.com/user-attachments/assets/739b3727-b6ef-4655-9a14-9347c57531bc

