### PR TITLE
refactor: 라우터 위치 변경

### DIFF
--- a/frontend/src/components/layout/global/header/Header.tsx
+++ b/frontend/src/components/layout/global/header/Header.tsx
@@ -23,7 +23,7 @@ const Header = ({ profileImageSrc, mode = 'default' }: HeaderProps) => {
 
   return (
     <S.Wrapper>
-      <button type="button" onClick={() => navigate(ROUTES.MAIN)}>
+      <button type="button" onClick={() => navigate(ROUTES.LANDING)}>
         <Logo fill={theme.colors.white} width={100} />
       </button>
       {noneMode && null}

--- a/frontend/src/constants/routes.ts
+++ b/frontend/src/constants/routes.ts
@@ -1,5 +1,6 @@
 export const ROUTES = {
   MAIN: '/',
+  LANDING: '/landing',
   LOGIN: '/login',
   AUTH: {
     KAKAO: '/auth/login/kakao',

--- a/frontend/src/constants/routes.ts
+++ b/frontend/src/constants/routes.ts
@@ -6,14 +6,13 @@ export const ROUTES = {
   },
   CREATE: '/create',
   MANAGER: {
-    SPACE_HOME: (spaceCode: string) => `/manager/space-home/${spaceCode}`,
-    DASHBOARD: (spaceCode: string) =>
-      `/manager/space-home/${spaceCode}/dashboard`,
-    SETTING: (spaceCode: string) => `/manager/space-home/${spaceCode}/settings`,
+    SPACE_HOME: (spaceCode: string) => `/space/${spaceCode}`,
+    DASHBOARD: (spaceCode: string) => `/space/${spaceCode}/dashboard`,
+    SETTING: (spaceCode: string) => `/space/${spaceCode}/settings`,
   },
   GUEST: {
-    IMAGE_UPLOAD: (spaceCode: string) => `/guest/image-upload/${spaceCode}`,
-    SHARE: '/guest/share',
+    IMAGE_UPLOAD: (spaceCode: string) => `/upload/${spaceCode}`,
+    SHARE: '/share',
   },
   COMPLETE: {
     UPLOAD: '/complete/upload',

--- a/frontend/src/hooks/useSpaceCodeFromPath.ts
+++ b/frontend/src/hooks/useSpaceCodeFromPath.ts
@@ -3,11 +3,9 @@ import { useLocation } from 'react-router-dom';
 const useSpaceCodeFromPath = () => {
   const { pathname } = useLocation();
 
-  const match = pathname.match(
-    /^\/(manager|guest)\/(space-home|image-upload)\/([^/]+)/,
-  );
+  const match = pathname.match(/^\/(upload|space)\/([^/]+)/);
 
-  const spaceCode = match ? match[3] : null;
+  const spaceCode = match ? match[2] : null;
 
   return { spaceCode };
 };

--- a/frontend/src/pages/MainPage.tsx
+++ b/frontend/src/pages/MainPage.tsx
@@ -1,0 +1,15 @@
+import { useNavigate } from 'react-router-dom';
+import { ROUTES } from '../constants/routes';
+import useAuthConditionTasks from '../hooks/@common/useAuthConditionTasks';
+
+const MainPage = () => {
+  const navigate = useNavigate();
+  useAuthConditionTasks({
+    taskWhenAuth: () => navigate(ROUTES.MYPAGE),
+    taskWhenNoAuth: () => navigate(ROUTES.LANDING),
+  });
+
+  return null;
+};
+
+export default MainPage;

--- a/frontend/src/pages/landing/LandingPage.tsx
+++ b/frontend/src/pages/landing/LandingPage.tsx
@@ -8,15 +8,12 @@ import { ReactComponent as MockupThree } from '@assets/images/mockup_3.svg';
 import { ReactComponent as MockupFour } from '@assets/images/mockup_4.svg';
 import { ReactComponent as Logo } from '@assets/logo.svg';
 import { useEffect, useMemo, useRef } from 'react';
-import { useNavigate } from 'react-router-dom';
 import Button from '../../components/@common/buttons/button/Button';
 import FloatingActionButton from '../../components/@common/buttons/floatingActionButton/FloatingActionButton';
 import IconLabelButton from '../../components/@common/buttons/iconLabelButton/IconLabelButton';
 import Footer from '../../components/footer/Footer';
 import KakaoLoginButton from '../../components/kakaoLoginButton/KakaoLoginButton';
 import LeftTimeInformationBox from '../../components/leftTimeInformationBox/LeftTimeInformationBox';
-import { ROUTES } from '../../constants/routes';
-import useAuthConditionTasks from '../../hooks/@common/useAuthConditionTasks';
 import useLandingScroll from '../../hooks/@common/useLandingScroll';
 import useLeftTimer from '../../hooks/@common/useLeftTimer';
 import useKakaoAuth from '../../hooks/domain/useKakaoAuth';
@@ -28,7 +25,6 @@ import { track } from '../../utils/googleAnalytics/track';
 import * as S from './LandingPage.styles';
 
 const LandingPage = () => {
-  const navigate = useNavigate();
   const mockDate = useMemo(() => {
     const today = new Date();
     const targetDate = new Date(today);
@@ -40,8 +36,6 @@ const LandingPage = () => {
   const { date, time } = formatDate(mockDate.toISOString());
   const mockupRef = useRef<HTMLDivElement>(null);
   const { handleKakaoLogin, handleLogout } = useKakaoAuth();
-
-  useAuthConditionTasks({ taskWhenAuth: () => navigate(ROUTES.MYPAGE) });
 
   useEffect(() => {
     const target = mockupRef.current;

--- a/frontend/src/router/router.tsx
+++ b/frontend/src/router/router.tsx
@@ -46,52 +46,42 @@ const routes: AppRouteObject[] = [
         element: <SpaceCreateFunnel />,
       },
       {
-        path: 'manager',
-        children: [
-          {
-            path: 'space-home/:spaceCode',
-            element: <SpaceHomePage />,
-            handle: {
-              header: true,
-              starField: true,
-              highlight: true,
-            },
-          },
-          {
-            path: 'space-home/:spaceCode/dashboard',
-            element: <DashboardPage />,
-            handle: {
-              header: true,
-              highlight: true,
-            },
-          },
-          {
-            path: 'space-home/:spaceCode/settings',
-            element: <SettingsPage />,
-            handle: {
-              header: true,
-              highlight: true,
-            },
-          },
-        ],
+        path: 'space/:spaceCode',
+        element: <SpaceHomePage />,
+        handle: {
+          header: true,
+          starField: true,
+          highlight: true,
+        },
+      },
+
+      {
+        path: 'space/:spaceCode/dashboard',
+        element: <DashboardPage />,
+        handle: {
+          header: true,
+          highlight: true,
+        },
       },
       {
-        // TODO : 데모 후 삭제
-        path: 'guest',
-        children: [
-          {
-            path: 'image-upload/:spaceCode',
-            element: <ImageUploadPage />,
-            handle: {
-              starField: true,
-              highlight: true,
-            },
-          },
-          {
-            path: 'share',
-            element: <SharePage />,
-          },
-        ],
+        path: 'space/:spaceCode/settings',
+        element: <SettingsPage />,
+        handle: {
+          header: true,
+          highlight: true,
+        },
+      },
+      {
+        path: 'upload/:spaceCode',
+        element: <ImageUploadPage />,
+        handle: {
+          starField: true,
+          highlight: true,
+        },
+      },
+      {
+        path: 'share',
+        element: <SharePage />,
       },
       {
         path: 'mypage',

--- a/frontend/src/router/router.tsx
+++ b/frontend/src/router/router.tsx
@@ -11,6 +11,7 @@ import SharePage from '../pages/guest/sharePage/SharePage';
 import LandingPage from '../pages/landing/LandingPage';
 import LoginPage from '../pages/login/LoginPage';
 import LogoutPage from '../pages/logout/LogoutPage';
+import MainPage from '../pages/MainPage';
 import DashboardPage from '../pages/manager/dashboard/DashboardPage';
 import SettingsPage from '../pages/manager/settings/SettingsPage';
 import SpaceHomePage from '../pages/manager/spaceHome/SpaceHomePage';
@@ -27,7 +28,7 @@ const routes: AppRouteObject[] = [
     children: [
       {
         path: '/',
-        element: <LandingPage />,
+        element: <MainPage />,
         handle: {
           header: true,
           starField: true,

--- a/frontend/src/router/router.tsx
+++ b/frontend/src/router/router.tsx
@@ -34,6 +34,15 @@ const routes: AppRouteObject[] = [
           highlight: true,
         },
       },
+      {
+        path: '/landing',
+        element: <LandingPage />,
+        handle: {
+          header: true,
+          starField: true,
+          highlight: true,
+        },
+      },
       // {
       //   path: '/demo',
       //   element: <DemoHome />,


### PR DESCRIPTION
## 연관된 이슈

- close #490

## 작업 내용

- 라우터 변경
  - 스페이스 페이지: `manager/space-home` -> `space`
  - 업로드 페이지: `guest/image-upload` -> `upload`
  - 공유 페이지: `guest/share` -> `share`
- 랜딩 페이지 라우터 추가: `/landing`
  - 타이틀을 누르면 랜딩페이지로 이동됨
- 메인 페이지는 하이라이트가 적용된 빈 페이지, 로그인에 따라 자동 라우터를 하는 역할만 함
  - 이를 통해 깜빡이는 현상을 수정할 수 있음