### PR TITLE
fix: 업로드 중 오류가 발생한 경우 

### DIFF
--- a/frontend/src/hooks/useFileUpload.ts
+++ b/frontend/src/hooks/useFileUpload.ts
@@ -179,21 +179,7 @@ const useFileUpload = ({
     }
   };
 
-  const uploadSingleBatch = async (
-    batch: Batch,
-    validGuestId: number,
-    nickName: string,
-  ) => {
-    const presignedUrls = await tryFetch({
-      task: async () => await fetchPresignedUrls(batch.uploadFiles),
-      errorActions: ['console'],
-    });
-
-    const updatedBatchFiles = addPresignedUrls(
-      presignedUrls.data ?? {},
-      batch.uploadFiles,
-    );
-
+  const uploadToS3 = async (updatedBatchFiles: UploadFile[]) => {
     await Promise.allSettled(
       updatedBatchFiles.map(async (file) => {
         try {
@@ -209,6 +195,24 @@ const useFileUpload = ({
         }
       }),
     );
+  };
+
+  const uploadSingleBatch = async (
+    batch: Batch,
+    validGuestId: number,
+    nickName: string,
+  ) => {
+    const presignedUrls = await tryFetch({
+      task: async () => await fetchPresignedUrls(batch.uploadFiles),
+      errorActions: ['console'],
+    });
+
+    const updatedBatchFiles = addPresignedUrls(
+      presignedUrls.data ?? {},
+      batch.uploadFiles,
+    );
+
+    await uploadToS3(updatedBatchFiles);
 
     setUploadFiles((prev) =>
       prev.map((file) => {

--- a/frontend/src/hooks/useFileUpload.ts
+++ b/frontend/src/hooks/useFileUpload.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { photoService } from '../apis/services/photo.service';
 import { FAILED_GUEST_ID } from '../constants/errors';
 import type { LocalFile, UploadFile } from '../types/file.type';
@@ -20,7 +20,6 @@ interface Session {
 }
 
 // TODO: progress를 따로 관리하도록 설계
-// TODO: fetchPresignedUrls, uploadPhotosToS3, notifyUploadComplete을 호출만하고 외부에서 사용할 수 있도록 리팩토링 ?
 // TODO: reducer로 상태값 변경하도록 리팩토링
 
 interface UseFileUploadProps {
@@ -45,7 +44,7 @@ const useFileUpload = ({
   const [batches, setBatches] = useState<Batch[]>();
   const [session, setSession] = useState<Session>();
   const [isUploading, setIsUploading] = useState(false);
-  const { tryTask, tryFetch } = useError();
+  const { tryFetch } = useError();
   const [progress, setProgress] = useState(0);
 
   //TODO: 진행률 확인하고 제거
@@ -148,19 +147,14 @@ const useFileUpload = ({
     return updated;
   };
 
-  const canNotifySuccess = (successFiles: UploadFile[]) => {
-    if (successFiles.length === 0) throw new Error('성공한 파일이 없습니다.');
-  };
-
   const notifySuccessFiles = async (
     successFiles: UploadFile[],
     validGuestId: number,
     nickName: string,
   ) => {
-    tryTask({
-      task: () => canNotifySuccess(successFiles),
-      errorActions: ['console'],
-    });
+    if (successFiles.length !== localFiles.length) {
+      throw new Error('성공한 파일이 없습니다.');
+    }
 
     const uploadedPhotos = successFiles.map((file) => ({
       uploadFileName: file.objectKey,
@@ -169,7 +163,7 @@ const useFileUpload = ({
       capacityValue: file.capacityValue,
     }));
 
-    await tryFetch({
+    const response = await tryFetch({
       task: async () =>
         await photoService.notifyUploadComplete(
           spaceCode,
@@ -179,6 +173,10 @@ const useFileUpload = ({
         ),
       errorActions: ['console'],
     });
+
+    if (!response.success) {
+      throw new Error('서버에게 성공 알림에 실패했습니다.');
+    }
   };
 
   const uploadSingleBatch = async (
@@ -207,6 +205,7 @@ const useFileUpload = ({
           setProgress((prev) => prev + 1);
         } catch {
           file.state = 'failed';
+          throw new Error('S3에 업로드하는데 실패했습니다.');
         }
       }),
     );
@@ -226,7 +225,6 @@ const useFileUpload = ({
     await notifySuccessFiles(successFiles, validGuestId, nickName);
   };
 
-  //TODO: 구조 정리하기 닉네임 연결 후 통계가 정상동작하는지 확인
   const calculateSuccessFiles = (
     batch: Batch,
     updatedBatchFiles: UploadFile[],
@@ -275,19 +273,25 @@ const useFileUpload = ({
     validGuestId: number,
     nickName: string,
   ) => {
-    await tryFetch({
+    const response = await tryFetch({
       task: async () => {
         for (const batch of currentSession.batches) {
-          await tryFetch({
+          const response = await tryFetch({
             task: async () => {
               await uploadSingleBatch(batch, validGuestId, nickName);
             },
             errorActions: ['console'],
           });
+          if (!response.success) {
+            throw new Error('배치 업로드 중 오류 발생');
+          }
         }
       },
       errorActions: ['console'],
     });
+    if (!response.success) {
+      throw new Error('배치 업로드 실패');
+    }
   };
 
   // "진짜" 업로드
@@ -312,12 +316,7 @@ const useFileUpload = ({
       },
     });
 
-    console.log('File upload response:', response);
-    console.log('Session state:', session);
-    console.log('Session total:', session?.total);
-    console.log('Session success:', session?.success);
-
-    if (response.success && session?.total === session?.success) {
+    if (response.success) {
       onUploadSuccess();
       clearFiles();
     }


### PR DESCRIPTION
## 연관된 이슈

- close #473 

## 작업 내용

- 업로드가 실패한 경우에 대해서 다시 throw 하도록 수정하였습니다.
- 놀랍게도 처리하지 않고 있었는데, ~클린코드를 버리고~ 기능을 택했습니다.

- s3에 업로드 실패
<img width="400" alt="스크린샷 2025-08-21 오후 8 41 06" src="https://github.com/user-attachments/assets/c2235814-5464-446f-a397-6f56ec3e99e6" />

- 서버에게 성공 알림 실패한 경우
<img width="400" alt="스크린샷 2025-08-21 오후 8 40 35" src="https://github.com/user-attachments/assets/012839da-b6f0-4b17-90a2-a2d9a4e819c1" />

- presigned-url 발급 오류

<img width="400" alt="스크린샷 2025-08-21 오후 8 40 05" src="https://github.com/user-attachments/assets/d5a4900c-3b04-43df-85af-ffdc19c3a12d" />


# 추후 리팩토링 예정