### PR TITLE
fix: 모바일 safari에서 scrollTop이 적용되지 않는 문제 해결

### DIFF
--- a/frontend/src/utils/goToTop.ts
+++ b/frontend/src/utils/goToTop.ts
@@ -1,3 +1,8 @@
 export const goToTop = () => {
-  window.scrollTo({ top: 0 });
+  if ('scrollBehavior' in document.documentElement.style) {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  } else {
+    document.body.scrollTop = 0;
+    document.documentElement.scrollTop = 0;
+  }
 };


### PR DESCRIPTION
## 연관된 이슈

- close #501 

## 작업 내용

[사파리에서의 스크롤 문제 해결](https://stackoverflow.com/questions/40635409/scroll-to-top-not-working-for-safari)를 참고하여 수정하였습니다.

로그인 문제로 더이상 ip 주소로 들어가서 모바일을 확인할 수 없기 때문에 추후 정상 동작하는지 확인해야 합니다.