### PR TITLE
refactor: 스페이스 정보 페이지의 수정 로직 변경

### DIFF
--- a/frontend/src/apis/services/space.service.ts
+++ b/frontend/src/apis/services/space.service.ts
@@ -7,7 +7,7 @@ export const spaceService = {
 
   getInfoByCode: (spaceCode: string) => http.get<Space>(`/spaces/${spaceCode}`),
 
-  update: (spaceCode: string, data: SpaceCreateInfo) =>
+  update: (spaceCode: string, data: Partial<SpaceCreateInfo>) =>
     authHttp.patch<SpaceCreateInfo>(`/spaces/${spaceCode}`, data),
 
   delete: (spaceCode: string) => authHttp.delete<void>(`/spaces/${spaceCode}`),

--- a/frontend/src/hooks/@common/useGraphemeInput.ts
+++ b/frontend/src/hooks/@common/useGraphemeInput.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 const segmenter = new Intl.Segmenter('und', { granularity: 'grapheme' });
 
@@ -18,13 +18,16 @@ const useGraphemeInput = ({
   );
 
   const validValue = graphemes.join('');
+  const validLength = graphemes.length;
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setValue(e.target.value);
     onChange?.(e);
   };
 
-  const validLength = graphemes.length;
+  useEffect(() => {
+    setValue(initialValue);
+  }, [initialValue]);
 
   return { handleChange, validValue, validLength };
 };

--- a/frontend/src/hooks/useSpaceInfo.ts
+++ b/frontend/src/hooks/useSpaceInfo.ts
@@ -15,25 +15,25 @@ const useSpaceInfo = (spaceCode: string) => {
     setSpaceInfo(response.data);
   };
 
+  const fetchSpaceInfo = async () => {
+    await tryFetch({
+      task: requestSpaceInfo,
+      errorActions: ['toast'],
+      context: {
+        toast: {
+          text: '스페이스 정보를 불러오는데 실패했습니다.',
+        },
+      },
+      onFinally: () => setIsLoading(false),
+    });
+  };
+
   //biome-ignore lint/correctness/useExhaustiveDependencies: 무한 렌더링 방지
   useEffect(() => {
-    const fetchSpaceInfo = async () => {
-      await tryFetch({
-        task: requestSpaceInfo,
-        errorActions: ['toast'],
-        context: {
-          toast: {
-            text: '스페이스 정보를 불러오는데 실패했습니다.',
-          },
-        },
-        onFinally: () => setIsLoading(false),
-      });
-    };
-
     fetchSpaceInfo();
   }, [spaceCode]);
 
-  return { isLoading, spaceInfo };
+  return { isLoading, spaceInfo, refetchSpaceInfo: fetchSpaceInfo };
 };
 
 export default useSpaceInfo;

--- a/frontend/src/pages/manager/settings/SettingsPage.tsx
+++ b/frontend/src/pages/manager/settings/SettingsPage.tsx
@@ -105,7 +105,6 @@ const SettingsPage = () => {
       context: {
         toast: {
           text: '스페이스 정보 수정에 실패했어요.',
-          position: 'top',
         },
       },
     });
@@ -119,7 +118,7 @@ const SettingsPage = () => {
 
       showToast({
         text: '스페이스 정보가 수정되었어요.',
-        position: 'top',
+        type: 'info',
       });
 
       await refetchSpaceInfo();
@@ -150,7 +149,6 @@ const SettingsPage = () => {
       context: {
         toast: {
           text: '스페이스 삭제에 실패했어요.',
-          position: 'top',
         },
       },
     });
@@ -164,7 +162,7 @@ const SettingsPage = () => {
 
       showToast({
         text: '스페이스가 성공적으로 삭제됐어요.',
-        position: 'top',
+        type: 'info',
       });
 
       navigate(ROUTES.MAIN);

--- a/frontend/src/pages/manager/settings/SettingsPage.tsx
+++ b/frontend/src/pages/manager/settings/SettingsPage.tsx
@@ -21,7 +21,7 @@ import * as S from './SettingsPage.styles';
 
 const SettingsPage = () => {
   const { spaceCode } = useSpaceCodeFromPath();
-  const { spaceInfo } = useSpaceInfo(spaceCode || '');
+  const { spaceInfo, refetchSpaceInfo } = useSpaceInfo(spaceCode || '');
   const { tryFetch } = useError();
   const overlay = useOverlay();
   const navigate = useNavigate();
@@ -42,6 +42,7 @@ const SettingsPage = () => {
 
   const { handleChange, validValue, validLength } = useGraphemeInput({
     initialValue: spaceName,
+    onChange: (e) => setSpaceName(e.target.value),
   });
 
   useEffect(() => {
@@ -65,7 +66,7 @@ const SettingsPage = () => {
     const originalTime = openedAtDate.toTimeString().slice(0, 5);
 
     return (
-      spaceName !== spaceInfo.name ||
+      validValue !== spaceInfo.name ||
       date !== originalDate ||
       time !== originalTime
     );
@@ -85,7 +86,7 @@ const SettingsPage = () => {
     const result = await tryFetch({
       task: () =>
         spaceService.update(spaceCode, {
-          name: spaceName,
+          name: validValue,
           validHours: validHours || 72,
           openedAt: openedAt,
           password: '',
@@ -111,7 +112,7 @@ const SettingsPage = () => {
         position: 'top',
       });
 
-      window.location.reload();
+      await refetchSpaceInfo();
     }
   };
 


### PR DESCRIPTION
## 연관된 이슈

- close #509

## 작업 내용

스페이스 정보 수정이 가능해졌습니다.
- 스페이스 이름, 시작 날짜, 시작 시간 중 변경이 있는 부분만 서버로 전송합니다.
- 만료/시작된 스페이스는 이름만 수정 가능하도록 분기처리했습니다. 
- 예정된 스페이스는 3가지 모두 변경 가능합니다. 
- 요청이 성공하면 info 타입의 토스트가 뜹니다. 

## 영상 

### 예정된 스페이스

https://github.com/user-attachments/assets/ce16f30b-8886-4270-bc09-1561e2e9829d

### 오픈된 스페이스 - 이름만 변경 가능

https://github.com/user-attachments/assets/97caa061-f011-4263-a315-e0365b0f52e1

