### PR TITLE
fix: 다운로드 기능 안정화를 위한 업로드 헤더 수정

### DIFF
--- a/frontend/src/apis/http.ts
+++ b/frontend/src/apis/http.ts
@@ -188,6 +188,8 @@ const createHttpClient = ({
       fullUrl: url,
       headersOverride: {
         'Content-Type': file.type || 'application/octet-stream',
+        'Cache-Control': 'no-store',
+        'Content-Disposition': `attachment; filename*=UTF-8''${encodeURIComponent(file.name)}`,
         'x-amz-tagging':
           'Service=techcourse&Role=techcourse-etc&ProjectTeam=PhotoGather',
       },

--- a/frontend/src/hooks/useDownload.ts
+++ b/frontend/src/hooks/useDownload.ts
@@ -105,23 +105,17 @@ const useDownload = ({
         if (!response.data) return;
         const data = response.data;
         const { downloadUrls } = data;
-        const noCacheUrls = downloadUrls.map((url) => {
-          return {
-            ...url,
-            url: `${url.url}?t=${Date.now()}`,
-          };
-        });
 
         if (downloadUrls.length === 1) {
           await downloadAsImage(
-            noCacheUrls[0].url,
-            noCacheUrls[0].originalName,
+            downloadUrls[0].url,
+            downloadUrls[0].originalName,
           );
           return;
         }
 
-        setTotalProgress(noCacheUrls.length);
-        await downloadAsZip(noCacheUrls);
+        setTotalProgress(downloadUrls.length);
+        await downloadAsZip(downloadUrls);
       },
       errorActions: ['toast', 'afterAction'],
       context: {
@@ -145,9 +139,11 @@ const useDownload = ({
         );
         if (!response.data) return;
         const { downloadUrls } = response.data;
-        const noCacheUrl = `${downloadUrls[0].url}?t=${Date.now()}`;
 
-        await downloadAsImage(noCacheUrl, downloadUrls[0].originalName);
+        await downloadAsImage(
+          downloadUrls[0].url,
+          downloadUrls[0].originalName,
+        );
       },
       errorActions: ['toast', 'afterAction'],
       context: {
@@ -171,15 +167,9 @@ const useDownload = ({
         if (!response.data) return;
         const data = response.data;
         const { downloadUrls } = data;
-        const noCacheUrls = downloadUrls.map((url) => {
-          return {
-            ...url,
-            url: `${url.url}?t=${Date.now()}`,
-          };
-        });
 
-        setTotalProgress(noCacheUrls.length);
-        await downloadAsZip(noCacheUrls);
+        setTotalProgress(downloadUrls.length);
+        await downloadAsZip(downloadUrls);
 
         onDownloadSuccess?.();
       },


### PR DESCRIPTION
## 연관된 이슈

- close #548

## 작업 내용
[트러블슈팅문서](https://www.notion.so/presigned-url-25a864a9cb03804c849fdec3146ed037?source=copy_link)

업로드 시 헤더에 다음 2개를 추가
* Content-Control : 브라우저나 중간 프록시(Cache 서버)가 이 응답을 캐싱하지 않도록 강제하는 지시어 (다운로드 전용 컨텐츠에 사용함)
* Content-Disposition attachment: 응답을 브라우저가 화면에 표시하지 않고 파일 다운로드로 처리하도록 지시 (특정 브라우저에선 a download가 팝업이 뜨는 것으로 연결될 수 있음, 이를 방지하기 위함)

```typescript
			headersOverride: {
				"Content-Type": file.type || "application/octet-stream",
				"Cache-Control": "no-store",
				"Content-Disposition": `attachment; filename*=UTF-8''${encodeURIComponent(file.name)}`,
				"x-amz-tagging":
					"Service=techcourse&Role=techcourse-etc&ProjectTeam=PhotoGather",
			},
```

해당 설정을 적용한 이미지는 다운로드에 오류 X
해당 설정을 적용하지 않은 이미지는 간헐적으로 다운로드에 오류가 생기는 문제 확인