### PR TITLE
refactor: 스페이스 용량 단위 변경

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -17,7 +17,7 @@
     <meta property="og:url" content="https://forgather.me/">
     <meta property="og:title" content="포게더 | 당신을 위한 순간, 흩어지지 않게">
     <meta property="og:description" content="특별한 순간을 함께 모으는 사진 공유 서비스">
-    <meta property="og:image" content="https://github.com/user-attachments/assets/a1cf1e50-9579-4299-835e-3bdc535f338d">
+    <meta property="og:image" content="https://private-user-images.githubusercontent.com/97431021/483545823-b6909cfe-a6c3-4903-bbfb-7da75e6d3c23.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NTY0NTgyNjcsIm5iZiI6MTc1NjQ1Nzk2NywicGF0aCI6Ii85NzQzMTAyMS80ODM1NDU4MjMtYjY5MDljZmUtYTZjMy00OTAzLWJiZmItN2RhNzVlNmQzYzIzLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTA4MjklMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwODI5VDA4NTkyN1omWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWIxMTFiNThmNzFlOGRkNmZlNTdlNDA4MjBhZTExOGI4NjhiZGIwZTg1OGUzMjc5YmI5NTA4OTJjMjQ4ZjgzYzYmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.jHoL7dvoSJSAU6EbOKkH8W9j7dUeHjA1J8KAf55yjCA">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta property="og:site_name" content="ForGather">

--- a/frontend/src/apis/createHeaders.ts
+++ b/frontend/src/apis/createHeaders.ts
@@ -4,6 +4,7 @@ export const createHeaders = (
   bodyContentType: BodyContentType,
   token?: string,
   withTraceId: boolean = true,
+  method?: string,
 ): HeadersInit => {
   const traceId = crypto.randomUUID().slice(0, 8);
 
@@ -17,15 +18,17 @@ export const createHeaders = (
     headers.Authorization = `Bearer ${token}`;
   }
 
-  switch (bodyContentType) {
-    case 'json':
-      headers['Content-Type'] = 'application/json';
-      break;
-    case 'blob':
-      headers['Content-Type'] = 'application/zip';
-      break;
-    default:
-      break;
+  if (method !== 'GET') {
+    switch (bodyContentType) {
+      case 'json':
+        headers['Content-Type'] = 'application/json';
+        break;
+      case 'blob':
+        headers['Content-Type'] = 'application/zip';
+        break;
+      default:
+        break;
+    }
   }
 
   return headers;

--- a/frontend/src/apis/http.ts
+++ b/frontend/src/apis/http.ts
@@ -40,7 +40,7 @@ const request = async <T>(
   }: requestOptionsType,
 ): Promise<ApiResponse<T>> => {
   const url = fullUrl ?? `${BASE_URL}${endpoint}${buildQueryString(params)}`;
-  const baseHeaders = createHeaders(bodyContentType, token, withTraceId);
+  const baseHeaders = createHeaders(bodyContentType, token, withTraceId, method);
   const headers = { ...baseHeaders, ...headersOverride };
 
   const requestBody = createBody(body, bodyContentType);

--- a/frontend/src/apis/http.ts
+++ b/frontend/src/apis/http.ts
@@ -40,7 +40,12 @@ const request = async <T>(
   }: requestOptionsType,
 ): Promise<ApiResponse<T>> => {
   const url = fullUrl ?? `${BASE_URL}${endpoint}${buildQueryString(params)}`;
-  const baseHeaders = createHeaders(bodyContentType, token, withTraceId, method);
+  const baseHeaders = createHeaders(
+    bodyContentType,
+    token,
+    withTraceId,
+    method,
+  );
   const headers = { ...baseHeaders, ...headersOverride };
 
   const requestBody = createBody(body, bodyContentType);

--- a/frontend/src/pages/manager/dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/manager/dashboard/DashboardPage.tsx
@@ -22,12 +22,12 @@ const DashboardPage = () => {
     }
   };
 
-  const bytesToMB = (bytes: number): number => {
-    return Number((bytes / (1024 * 1024)).toFixed(2));
+  const bytesToGB = (bytes: number): number => {
+    return Number((bytes / (1024 * 1024 * 1024)).toFixed(2));
   };
 
-  const usedMB = capacity ? bytesToMB(capacity.usedCapacity) : 0;
-  const maxMB = capacity ? bytesToMB(capacity.maxCapacity) : 10240;
+  const usedGB = capacity ? bytesToGB(capacity.usedCapacity) : 0;
+  const maxGB = capacity ? bytesToGB(capacity.maxCapacity) : 10;
 
   return (
     <S.Wrapper>
@@ -35,9 +35,9 @@ const DashboardPage = () => {
       <S.DashboardContainer>
         <DashboardBox
           title="스페이스 용량"
-          description={`${usedMB}MB / ${maxMB}MB`}
+          description={`${usedGB}GB / ${maxGB}GB`}
         >
-          <DonutGraph value={usedMB} maxValue={maxMB} width={80} height={80} />
+          <DonutGraph value={usedGB} maxValue={maxGB} width={80} height={80} />
         </DashboardBox>
         <S.DashboardInfoContainer>
           <DashboardBox


### PR DESCRIPTION
## 연관된 이슈

- close #558

## 작업 내용

### 1. 스페이스 용량 단위 변경

백엔드에서 설정한 '한 스페이스에서 가질 수 있는 최대 용량'은 `10GB`입니다. 
기존의 MB 단위로 표기하면 '1024MB'가 되어 가독성을 해치는 문제가 있었습니다.(런칭 페스티벌에 받은 피드백)
이에 따라 MB -> GB로 변경했습니다. 

전
<img width="226" height="402" alt="CleanShot 2025-08-29 at 18 00 52@2x" src="https://github.com/user-attachments/assets/888ee45d-32a0-42c9-a5c2-4f4156c89847" />
후
<img width="224" height="386" alt="CleanShot 2025-08-29 at 18 01 01@2x" src="https://github.com/user-attachments/assets/b82199ba-e9c7-495b-b2bd-9663676facae" />


### 2. GET 요청시 Content-Type 헤더 제거

백엔드 측에서 요청을 부탁한 사항입니다.
기존에는 request body 로그 파일을 보면 body가 없는데도 로그들이 쌓인 것을 확인 가능했으며, request body가 없는 경우 header에 content-type를 없애달라는 요청이 있었습니다.
따라서 GET 메서드일 때는 `Content-Type` 헤더를 설정하지 않도록 조건을 추가했습니다.


### 3. OG 썸네일 이미지 경로 변경

이전에는 OG 이미지가 `GitHub user-attachments URL`을 사용하고 있었는데, 이는 외부 접근이 제한될 수 있다는 문제가 있었습니다.
OG 이미지는 공개적으로 접근 가능한 URL이어야 한다고 하여 [포게더 WIKI](https://github.com/woowacourse-teams/2025-PhotoGather/wiki)에 이미지를 추가했고, 이 이미지 경로를 사용하도록 변경했습니다.
배포 후에 테스트가 가능한 문제라 우선 코드만 바꿔두었습니다.
