### PR TITLE
fix: heic -> jpeg로 변환하여 blob url을 추출할 수 있도록 수정

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "@sentry/react": "^10.1.0",
         "client-zip": "^2.5.0",
         "exifr": "^7.1.3",
+        "heic2any": "^0.0.4",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-ga4": "^2.1.0",
@@ -8912,6 +8913,12 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/heic2any": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/heic2any/-/heic2any-0.0.4.tgz",
+      "integrity": "sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA==",
+      "license": "MIT"
     },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -62,6 +62,7 @@
     "@sentry/react": "^10.1.0",
     "client-zip": "^2.5.0",
     "exifr": "^7.1.3",
+    "heic2any": "^0.0.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-ga4": "^2.1.0",

--- a/frontend/src/utils/heic.ts
+++ b/frontend/src/utils/heic.ts
@@ -1,0 +1,15 @@
+import heic2any from 'heic2any';
+
+export const isHeic = (file: File) => {
+  const HEIC_RE = /\.(heic|heif)$/i;
+  return /image\/hei(c|f)/i.test(file.type) || HEIC_RE.test(file.name);
+};
+
+export const heicToJpegBlob = async (file: File) => {
+  const output = await heic2any({
+    blob: file,
+    toType: 'image/jpeg',
+  });
+  const convertedJpeg = Array.isArray(output) ? output[0] : output;
+  return convertedJpeg as Blob;
+};


### PR DESCRIPTION
## 연관된 이슈

- close #564 

## 작업 내용

자세한 문서는 [노션 참고](https://www.notion.so/Chrome-heic-265864a9cb03807ea002fa26d0d1139b?source=copy_link)해주세요!!

### 문제

- 크롬 및 대부분의 브라우저가 HEIC를 직접 디코딩하지 못해 미리보기가 깨지는 문제가 있었습니다.

- iOS: 업로드 시 자동으로 jpeg 변환 → 미리보기 정상 동작

- Android/PC(except Safari): heic 그대로 업로드 → 브라우저에서 해석 불가 → 미리보기 깨짐

### 해결

- 기존: URL.createObjectURL(file) 로 blob URL 생성 후 <img> 태그에 바인딩

- 문제: heic는 브라우저에서 디코딩 불가 → 렌더링 실패

- 해결: heic 파일 감지 후 heic2any 라이브러리로 jpeg 변환 → 변환된 blob으로 미리보기 생성