### PR TITLE
fix: android FileReader의 FILE_CHANGED 발생 문제를 해결하기 위해 file을 복제하여, File…

### DIFF
--- a/frontend/src/hooks/@common/useLocalFile.ts
+++ b/frontend/src/hooks/@common/useLocalFile.ts
@@ -50,13 +50,18 @@ const useLocalFile = ({ fileType }: UseLocalFileProps) => {
     const startIndex = localFiles.length;
 
     const tmpFiles = await Promise.all(
-      files.map(async (file, index) => ({
-        id: startIndex + index,
-        originFile: file,
-        capturedAt: await extractDateTimeOriginal(file),
-        capacityValue: file.size,
-        previewUrl: await createImagePreviewUrl(file),
-      })),
+      files.map(async (file, index) => {
+        const buf = await file.arrayBuffer();
+        const cloned = new File([buf], file.name, { type: file.type });
+
+        return {
+          id: startIndex + index,
+          originFile: cloned,
+          capturedAt: await extractDateTimeOriginal(cloned),
+          capacityValue: cloned.size,
+          previewUrl: await createImagePreviewUrl(cloned),
+        };
+      }),
     );
 
     setLocalFiles((prev) => [...prev, ...tmpFiles]);


### PR DESCRIPTION
## 연관된 이슈

- close #561 

## 작업 내용

- 안드로이드 크롬에서 Photo-Picker에서 이미지를 업로드하면, 내부적으로 파일을 저장하지 않고, 바뀌었다는 `ERR_UPLOAD_FILE_CHANGED`가 발생하는 문제가 있습니다. (일명 모코폰 이슈)

### 원인
- Android Chrome에서 발생하는 알려진 문제라고 합니다. 
- [공식 버그](https://issues.chromium.org/issues/41101822)로 문서가 존재하나, 아직 해결되지 않았다고 합니다.
- Android14 이후 도입된 '사진 피커(Photo Picker)'를 통해 전달되는 임시 파일을 Chrome이 파일로 인식하지 못함

### 해결
- 파일을 읽었을 떄, 강제로 arrayBuffer에 저장하고, 해당 파일을 읽도로 수정하였습니다.
- 즉, OS에서 올린 원본을 FileReader가 읽는 것이 아니라, 강제로 복사한 메모리에 있는 파일 복사본을 FileReader가 읽을 것이기 때문에 해결될 것이라고 생각합니다.