### PR TITLE
fix: 단건 조회 image-url 변경

### DIFF
--- a/frontend/__test__/parsedImagePath.test.ts
+++ b/frontend/__test__/parsedImagePath.test.ts
@@ -1,27 +1,27 @@
-import { parsedImagePath } from '../src/utils/parsedImagePath';
+import { extractImageFileName } from '../src/utils/parsedImagePath';
 
 describe('parsedImagePath 테스트', () => {
   it('이미지의 형식과 경로를 파싱하여 맨 마지막 image 경로만 반환한다', () => {
     const imagePath = 'https://example.com/image3.jpg';
     const expected = 'image3';
-    const result = parsedImagePath(imagePath);
+    const result = extractImageFileName(imagePath);
     expect(result).toBe(expected);
   });
 
   it('파일명이 존재하지 않을 경우 빈 문자열을 반환한다', () => {
     const invalidPath = 'https://example.com/';
-    const result = parsedImagePath(invalidPath);
+    const result = extractImageFileName(invalidPath);
     expect(result).toBe('');
   });
 
   it('파일명이 없이 확장자만 있을 경우 빈 문자열을 반환한다', () => {
     const invalidPath = '.jpg';
-    const result = parsedImagePath(invalidPath);
+    const result = extractImageFileName(invalidPath);
     expect(result).toBe('');
   });
 
   it('지원하지 않는 확장자(.exe)인 경우 빈 문자열을 반환한다', () => {
-    const result = parsedImagePath('https://example.com/file/virus.exe');
+    const result = extractImageFileName('https://example.com/file/virus.exe');
     expect(result).toBe('');
   });
 });

--- a/frontend/src/components/@common/modal/photoModal/PhotoModal.tsx
+++ b/frontend/src/components/@common/modal/photoModal/PhotoModal.tsx
@@ -8,6 +8,7 @@ import type { BaseModalProps } from '../../../../types/modal.type';
 import type { Photo } from '../../../../types/photo.type';
 import { buildOriginalImageUrl } from '../../../../utils/buildImageUrl';
 import { createImageErrorHandler } from '../../../../utils/createImageErrorHandler';
+import { parseImagePath } from '../../../../utils/parsedImagePath';
 import IconLabelButton from '../../buttons/iconLabelButton/IconLabelButton';
 import ConfirmModal from '../confirmModal/ConfirmModal';
 import * as S from './PhotoModal.styles';
@@ -72,10 +73,8 @@ const PhotoModal = (props: PhotoModalProps) => {
         if (!response || !response.data) return;
         const data = response.data;
         setPhoto(data);
-        const filePath = data.path;
-        const arr = filePath.split('contents/');
-        const path = arr[arr.length - 1];
-        setDisplayPath(buildOriginalImageUrl(path));
+        const parsedPath = parseImagePath(data.path);
+        setDisplayPath(buildOriginalImageUrl(parsedPath));
       },
       errorActions: ['toast'],
       context: {

--- a/frontend/src/components/@common/modal/photoModal/PhotoModal.tsx
+++ b/frontend/src/components/@common/modal/photoModal/PhotoModal.tsx
@@ -72,7 +72,10 @@ const PhotoModal = (props: PhotoModalProps) => {
         if (!response || !response.data) return;
         const data = response.data;
         setPhoto(data);
-        setDisplayPath(buildOriginalImageUrl(data.path));
+        const filePath = data.path;
+        const arr = filePath.split('contents/');
+        const path = arr[arr.length - 1];
+        setDisplayPath(buildOriginalImageUrl(path));
       },
       errorActions: ['toast'],
       context: {

--- a/frontend/src/hooks/useDownload.ts
+++ b/frontend/src/hooks/useDownload.ts
@@ -2,6 +2,8 @@ import { downloadZip } from 'client-zip';
 import { useState } from 'react';
 import { photoService } from '../apis/services/photo.service';
 import type { DownloadInfo } from '../types/photo.type';
+import { buildOriginalImageUrl } from '../utils/buildImageUrl';
+import { parseImagePath } from '../utils/parsedImagePath';
 import { checkSelectedPhotoExist } from '../validators/photo.validator';
 import useTaskHandler from './@common/useTaskHandler';
 
@@ -114,7 +116,12 @@ const useDownload = ({
         }
 
         setTotalProgress(downloadUrls.length);
-        await downloadAsZip(downloadUrls);
+        const parsedUrls = downloadUrls.map((info) => ({
+          ...info,
+          url: buildOriginalImageUrl(parseImagePath(info.url)),
+        }));
+        console.log(parsedUrls);
+        await downloadAsZip(parsedUrls);
       },
       errorActions: ['toast'],
       context: {
@@ -142,7 +149,7 @@ const useDownload = ({
         const { downloadUrls } = response.data;
 
         await downloadAsImage(
-          downloadUrls[0].url,
+          buildOriginalImageUrl(parseImagePath(downloadUrls[0].url)),
           downloadUrls[0].originalName,
         );
       },
@@ -167,7 +174,11 @@ const useDownload = ({
         const { downloadUrls } = data;
 
         setTotalProgress(downloadUrls.length);
-        await downloadAsZip(downloadUrls);
+        const parsedUrls = downloadUrls.map((info) => ({
+          ...info,
+          url: buildOriginalImageUrl(parseImagePath(info.url)),
+        }));
+        await downloadAsZip(parsedUrls);
 
         onDownloadSuccess?.();
       },

--- a/frontend/src/hooks/usePhotosBySpaceCode.ts
+++ b/frontend/src/hooks/usePhotosBySpaceCode.ts
@@ -2,7 +2,7 @@ import { useMemo, useRef, useState } from 'react';
 import { photoService } from '../apis/services/photo.service';
 import type { Photo } from '../types/photo.type';
 import { buildThumbnailUrl } from '../utils/buildImageUrl';
-import { parsedImagePath } from '../utils/parsedImagePath';
+import { extractImageFileName } from '../utils/parsedImagePath';
 import useTaskHandler from './@common/useTaskHandler';
 
 interface UsePhotosBySpaceIdProps {
@@ -28,7 +28,7 @@ const usePhotosBySpaceCode = ({
     return new Map(
       photosList.map((photo) => [
         photo.id,
-        buildThumbnailUrl(spaceCode, parsedImagePath(photo.path), PRESET),
+        buildThumbnailUrl(spaceCode, extractImageFileName(photo.path), PRESET),
       ]),
     );
   }, [photosList, spaceCode]);

--- a/frontend/src/pages/mypage/MyPage.tsx
+++ b/frontend/src/pages/mypage/MyPage.tsx
@@ -13,7 +13,7 @@ import useSpacesDisplay from '../../hooks/domain/useSpacesDisplay';
 import type { MyInfo } from '../../types/api.type';
 import type { MySpace, SpaceFilterType } from '../../types/space.type';
 import { buildThumbnailUrl } from '../../utils/buildImageUrl';
-import { parsedImagePath } from '../../utils/parsedImagePath';
+import { extractImageFileName } from '../../utils/parsedImagePath';
 import * as S from './MyPage.styles';
 
 const MyPage = () => {
@@ -51,7 +51,7 @@ const MyPage = () => {
           if (!photo) return;
           results[space.spaceCode] = buildThumbnailUrl(
             space.spaceCode,
-            parsedImagePath(photo?.path),
+            extractImageFileName(photo?.path),
             'x800',
           );
         }),

--- a/frontend/src/utils/buildImageUrl.ts
+++ b/frontend/src/utils/buildImageUrl.ts
@@ -6,6 +6,8 @@ export const buildThumbnailUrl = (
   return `${process.env.IMAGE_BASE_URL}/${spaceCode}/thumbnails/${fileName}_${preset}.webp`;
 };
 
-export const buildOriginalImageUrl = (fileName: string) => {
-  return `${process.env.IMAGE_BASE_URL}/${fileName}`;
+export const buildOriginalImageUrl = (imagePath: string) => {
+  return `${process.env.IMAGE_BASE_URL}/${imagePath}`;
 };
+
+// IMAGE_BASE_URL=https://d2dzpk5q88o697.cloudfront.net/dev/contents

--- a/frontend/src/utils/buildImageUrl.ts
+++ b/frontend/src/utils/buildImageUrl.ts
@@ -9,5 +9,3 @@ export const buildThumbnailUrl = (
 export const buildOriginalImageUrl = (imagePath: string) => {
   return `${process.env.IMAGE_BASE_URL}/${imagePath}`;
 };
-
-// IMAGE_BASE_URL=https://d2dzpk5q88o697.cloudfront.net/dev/contents

--- a/frontend/src/utils/parsedImagePath.ts
+++ b/frontend/src/utils/parsedImagePath.ts
@@ -1,6 +1,6 @@
 import { DEBUG_MESSAGES } from '../constants/debugMessages';
 
-export const parsedImagePath = (path: string): string => {
+export const extractImageFileName = (path: string): string => {
   const cleanPath = path.split('?')[0];
   const segments = cleanPath.split('/');
   const lastSegment = segments.pop();
@@ -20,4 +20,10 @@ export const parsedImagePath = (path: string): string => {
 
   const fileName = parts.join('.');
   return fileName;
+};
+
+export const parseImagePath = (path: string): string => {
+  const arr = path.split('contents/');
+  const parsedPath = arr[arr.length - 1];
+  return parsedPath;
 };

--- a/frontend/src/utils/removeWhiteSpace.ts
+++ b/frontend/src/utils/removeWhiteSpace.ts
@@ -1,4 +1,3 @@
 export const removeWhiteSpace = (text: string) => {
-  console.log(text, text.replace(/\s+/g, ''));
   return text.replace(/\s+/g, '');
 };

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -118,34 +118,34 @@ module.exports = (_, argv) => {
       open: true,
       historyApiFallback: true,
     },
-    // optimization: {
-    //   minimize: true,
-    //   minimizer: [
-    //     new ImageMinimizerPlugin({
-    //       minimizer: {
-    //         implementation: ImageMinimizerPlugin.sharpMinify,
-    //         options: {
-    //           encodeOptions: {
-    //             png: { quality: 80, palette: true },
-    //             jpg: { quality: 75, progressive: true },
-    //             jpeg: { quality: 75, progressive: true },
-    //           },
-    //         },
-    //       },
-    //       generator: [
-    //         {
-    //           preset: 'webp',
-    //           implementation: ImageMinimizerPlugin.sharpGenerate,
-    //           options: {
-    //             encodeOptions: {
-    //               webp: { quality: 80, effort: 6, lossless: false },
-    //             },
-    //           },
-    //           filename: 'static/images/[name][ext]',
-    //         },
-    //       ],
-    //     }),
-    //   ],
-    // },
+    optimization: {
+      minimize: true,
+      minimizer: [
+        new ImageMinimizerPlugin({
+          minimizer: {
+            implementation: ImageMinimizerPlugin.sharpMinify,
+            options: {
+              encodeOptions: {
+                png: { quality: 80, palette: true },
+                jpg: { quality: 75, progressive: true },
+                jpeg: { quality: 75, progressive: true },
+              },
+            },
+          },
+          generator: [
+            {
+              preset: 'webp',
+              implementation: ImageMinimizerPlugin.sharpGenerate,
+              options: {
+                encodeOptions: {
+                  webp: { quality: 80, effort: 6, lossless: false },
+                },
+              },
+              filename: 'static/images/[name][ext]',
+            },
+          ],
+        }),
+      ],
+    },
   };
 };

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -118,34 +118,34 @@ module.exports = (_, argv) => {
       open: true,
       historyApiFallback: true,
     },
-    optimization: {
-      minimize: true,
-      minimizer: [
-        new ImageMinimizerPlugin({
-          minimizer: {
-            implementation: ImageMinimizerPlugin.sharpMinify,
-            options: {
-              encodeOptions: {
-                png: { quality: 80, palette: true },
-                jpg: { quality: 75, progressive: true },
-                jpeg: { quality: 75, progressive: true },
-              },
-            },
-          },
-          generator: [
-            {
-              preset: 'webp',
-              implementation: ImageMinimizerPlugin.sharpGenerate,
-              options: {
-                encodeOptions: {
-                  webp: { quality: 80, effort: 6, lossless: false },
-                },
-              },
-              filename: 'static/images/[name][ext]',
-            },
-          ],
-        }),
-      ],
-    },
+    // optimization: {
+    //   minimize: true,
+    //   minimizer: [
+    //     new ImageMinimizerPlugin({
+    //       minimizer: {
+    //         implementation: ImageMinimizerPlugin.sharpMinify,
+    //         options: {
+    //           encodeOptions: {
+    //             png: { quality: 80, palette: true },
+    //             jpg: { quality: 75, progressive: true },
+    //             jpeg: { quality: 75, progressive: true },
+    //           },
+    //         },
+    //       },
+    //       generator: [
+    //         {
+    //           preset: 'webp',
+    //           implementation: ImageMinimizerPlugin.sharpGenerate,
+    //           options: {
+    //             encodeOptions: {
+    //               webp: { quality: 80, effort: 6, lossless: false },
+    //             },
+    //           },
+    //           filename: 'static/images/[name][ext]',
+    //         },
+    //       ],
+    //     }),
+    //   ],
+    // },
   };
 };


### PR DESCRIPTION
## 연관된 이슈

- close #597

## 작업 내용
- 단건조회 이미지 조회가 안되는 문제 해결
- 전체 다운로드 / 단일 다운로드가 안되는 문제 해결
- env 파일은 동일

✅ 서버에서 전송되는 url 형태
```typescript
photogather/dev/contents/d51ea4707d/cd5ab532-9eed-42c2-8675-c39f2622e68c.jpeg
```
유틸 함수를 통해 url 조합
* parseImagePath: url 중 "photogather/dev/contents/" 삭제
* buildOriginalImageUrl: env 파일에 있는 imageBaseUrl에 parseImagePath로 파싱한 url 합성