### PR TITLE
chore: webpack 개발 서버(Dev server) 실행 및 HMR 속도 최적화

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -52,6 +52,7 @@
         "jest": "^30.0.4",
         "jest-environment-jsdom": "^30.0.4",
         "prettier": "^3.6.2",
+        "speed-measure-webpack-plugin": "^1.5.0",
         "storybook": "^9.0.16",
         "ts-jest": "^29.4.0",
         "typescript": "^5.8.3",
@@ -13803,6 +13804,22 @@
         "obuf": "^1.1.2",
         "readable-stream": "^3.0.6",
         "wbuf": "^1.7.3"
+      }
+    },
+    "node_modules/speed-measure-webpack-plugin": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/speed-measure-webpack-plugin/-/speed-measure-webpack-plugin-1.5.0.tgz",
+      "integrity": "sha512-Re0wX5CtM6gW7bZA64ONOfEPEhwbiSF/vz6e2GvadjuaPrQcHTQdRGsD8+BE7iUOysXH8tIenkPCQBEcspXsNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^1 || ^2 || ^3 || ^4 || ^5"
       }
     },
     "node_modules/sprintf-js": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "test": "jest",
     "start": "webpack serve --mode none",
-    "start:dev": "webpack serve --mode development",
-    "start:prod": "webpack serve --mode production",
+    "start:dev": "webpack serve --mode development --progress --profile",
+    "start:prod": "webpack serve --mode production --progress --profile",
     "build:dev": "webpack --mode development",
     "build:prod": "webpack --mode production",
     "format:styles": "prettier --write 'src/styles/**/*.{ts,tsx,js,jsx}' 'src/**/*.styles.{ts,tsx,js,jsx}'",
@@ -48,6 +48,7 @@
     "jest": "^30.0.4",
     "jest-environment-jsdom": "^30.0.4",
     "prettier": "^3.6.2",
+    "speed-measure-webpack-plugin": "^1.5.0",
     "storybook": "^9.0.16",
     "ts-jest": "^29.4.0",
     "typescript": "^5.8.3",

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -137,9 +137,9 @@ module.exports = (_, argv) => {
       level: 'verbose',
     },
     optimization: {
-      minimize: argv.mode === 'production',
+      minimize: argv.mode === 'production' || argv.mode === 'development',
       minimizer: [
-        ...(argv.mode === 'production'
+        ...(argv.mode === 'production' || argv.mode === 'development'
           ? [
               new ImageMinimizerPlugin({
                 minimizer: {


### PR DESCRIPTION
## 연관된 이슈

- close #605

## 작업 내용

### SMP 분석 (번들링 시간 측정 툴)
- ImageMinimizer 플러그인 실행 시간이 압도적으로 길게 나옴 -> 병목
<img width="325" height="342" alt="image" src="https://github.com/user-attachments/assets/4d03269a-fa01-4199-98fc-82da0c448ebb" />


### 1️⃣ imageminimizer Production 전용으로 설정

```typescript
    optimization: {
      minimize: argv.mode === 'production' || argv.mode === 'development',
      minimizer: [
        ...(argv.mode === 'production' || argv.mode === 'development'
          ? [
              new ImageMinimizerPlugin({
                minimizer: {
                  implementation: ImageMinimizerPlugin.sharpMinify,
// 그 외 설정은 동일
```
- 매 빌드 과정에 (저장할 때마다) 이미지 최적화가 수행됨
- 이미지 최적화는 CPU 연산량이 많은 작업
- production  및 development 환경에서만 최적화를 진행하도록 설정 (로컬 환경은 argv.mode가 "none"으로 설정돼있음)

---
아래는 시도해본 설정입니다 (실제 효과는 크지 않았음)

### 2️⃣ 캐시 설정 (cache: { type: 'filesystem' })
```typescript
cache:
  argv.mode === 'none'
    ? {
        type: 'filesystem',
        buildDependencies: {
          config: [__filename],
        },
      }
    : false,
```

- 개발모드 (argv.mode === 'none') 에서 파일 시스템 캐시를 활성화
- 변경된 파일만 재빌드하고 나머지는 캐시된 아웃풋을 불러옴 : 재빌드 속도가 빨라짐 
- 단, config / env에 대한 변경은 반영되지 않음 (기존 설정과 같음)

### 3️⃣ devtool 설정
```typescript
devtool:
  argv.mode === 'none' ? 'eval-cheap-module-source-map' : 'source-map',
```

- 개발 모드에서는 가벼운 소스맵, 배포모드에서는 정확한 소스맵 사용
- 소스맵 : 번들링 및 압축된 코드와 원래 코드를 연결해주는 지도 파일
- eval : 가장 빠름, 원본 위치 정보 없음 / source-map : 가장 정확, 빌드 느림
빌드 결과를 파일로 쓰지 않고 브라우저에서 eval로 바로 실행, eval-cheap-module-source-map은 에러가 날 경우 라인 단위로 추적 가능 하면서도 빠른 소스맵


## 결과

적용 후 
<img width="294" height="287" alt="image" src="https://github.com/user-attachments/assets/8db1cd57-8842-4b29-a8cb-a0ab2e29393f" />

- ImageMinimizer 실행 시간 감소
- 캐시 설정을 통해 변경된 파일만 다시 변환하면서 시간 축소
- 소스맵을 변경 (eval-cahep-module-source-map) 하면서 소스맵 정보를 꼼꼼히 들여다 보는 시간 축소