### PR TITLE
refactor: Repository의 default 메서드 null 대응

### DIFF
--- a/backend/forgather/src/main/java/com/forgather/domain/guest/repository/GuestRepository.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/guest/repository/GuestRepository.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.forgather.domain.guest.model.Guest;
+import com.forgather.global.exception.BaseException;
 import com.forgather.global.exception.NotFoundException;
 
 public interface GuestRepository extends JpaRepository<Guest, Long> {
@@ -12,6 +13,9 @@ public interface GuestRepository extends JpaRepository<Guest, Long> {
     Optional<Guest> findById(Long id);
 
     default Guest getById(Long id) {
+        if (id ==  null) {
+            throw new BaseException("id는 null일 수 없습니다.");
+        }
         return findById(id).orElseThrow(() -> new NotFoundException("Guest를 찾을 수 없습니다. guestId: " + id));
     }
 }

--- a/backend/forgather/src/main/java/com/forgather/domain/space/repository/HostRepository.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/space/repository/HostRepository.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.forgather.global.auth.model.Host;
+import com.forgather.global.exception.BaseException;
 import com.forgather.global.exception.NotFoundException;
 
 public interface HostRepository extends JpaRepository<Host, Long> {
@@ -12,6 +13,9 @@ public interface HostRepository extends JpaRepository<Host, Long> {
     Optional<Host> findById(Long id);
 
     default Host getById(Long id) {
+        if (id ==  null) {
+            throw new BaseException("id는 null일 수 없습니다.");
+        }
         return findById(id)
             .orElseThrow(() -> new NotFoundException("Host를 찾을 수 없습니다. id: " + id));
     }

--- a/backend/forgather/src/main/java/com/forgather/domain/space/repository/PhotoRepository.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/space/repository/PhotoRepository.java
@@ -8,13 +8,17 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.forgather.domain.space.model.Photo;
 import com.forgather.domain.space.model.Space;
+import com.forgather.global.exception.BaseException;
 import com.forgather.global.exception.NotFoundException;
 
 public interface PhotoRepository extends JpaRepository<Photo, Long> {
 
-    default Photo getById(Long photoId) {
-        return findById(photoId)
-            .orElseThrow(() -> new NotFoundException("존재하지 않는 사진입니다. 사진 ID: " + photoId));
+    default Photo getById(Long id) {
+        if (id ==  null) {
+            throw new BaseException("id는 null일 수 없습니다.");
+        }
+        return findById(id)
+            .orElseThrow(() -> new NotFoundException("존재하지 않는 사진입니다. 사진 ID: " + id));
     }
 
     Page<Photo> findAllBySpace(Space space, Pageable pageable);

--- a/backend/forgather/src/main/java/com/forgather/domain/space/repository/SpaceRepository.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/space/repository/SpaceRepository.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.forgather.domain.space.model.Space;
+import com.forgather.global.exception.BaseException;
 import com.forgather.global.exception.NotFoundException;
 
 public interface SpaceRepository extends JpaRepository<Space, Long> {
@@ -15,6 +16,9 @@ public interface SpaceRepository extends JpaRepository<Space, Long> {
     void deleteByCode(String spaceCode);
 
     default Space getByCode(String spaceCode) {
+        if (spaceCode ==  null) {
+            throw new BaseException("스페이스 코드는 null일 수 없습니다.");
+        }
         return findByCode(spaceCode)
             .orElseThrow(() -> new NotFoundException("존재하지 않는 스페이스입니다. 스페이스 코드: " + spaceCode));
     }


### PR DESCRIPTION
## 연관된 이슈

- close #611 

## 작업 내용
각 `Repositoy#findById` 디폴트 메서드에 Long 타입 파라미터인 id의 null 검증 로직을 추가했습니다. 