### PR TITLE
refactor: 사진 관련 API 응답값 일관화

### DIFF
--- a/backend/forgather/src/main/java/com/forgather/domain/space/dto/DownloadUrlsResponse.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/space/dto/DownloadUrlsResponse.java
@@ -14,7 +14,7 @@ public record DownloadUrlsResponse(
         String originalName,
 
         @Schema(description = "다운로드 URL",
-            example = "https://bucket.s3.ap-northeast-2.amazonaws.com/test/contents/0987654321/UUID1.jpg")
+            example = "photogather/contents/0987654321/UUID1.jpg")
         String url
     ) {
         public static DownloadUrl from(String originalName, String url) {

--- a/backend/forgather/src/main/java/com/forgather/domain/space/service/AwsS3Cloud.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/space/service/AwsS3Cloud.java
@@ -137,6 +137,7 @@ public class AwsS3Cloud implements ContentsStorage {
         return transferManager.downloadFile(request).completionFuture();
     }
 
+    @Deprecated(since = "2025-09-19", forRemoval = true)
     @Override
     public URL issueDownloadUrl(String photoPath) {
         return s3Client.utilities()

--- a/backend/forgather/src/main/java/com/forgather/domain/space/service/PhotoService.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/space/service/PhotoService.java
@@ -5,7 +5,6 @@ import static com.forgather.domain.space.dto.DownloadUrlsResponse.DownloadUrl;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -127,8 +126,7 @@ public class PhotoService {
         }
         Photo photo = photoRepository.getById(photoId);
         photo.validateSpace(space);
-        URL downloadUrl = contentsStorage.issueDownloadUrl(photo.getPath());
-        return new DownloadUrlsResponse(List.of(DownloadUrl.from(photo.getOriginalName(), downloadUrl.toString())));
+        return new DownloadUrlsResponse(List.of(DownloadUrl.from(photo.getOriginalName(), photo.getPath())));
     }
 
     public DownloadUrlsResponse getSelectedDownloadUrls(String spaceCode, DownloadPhotosRequest request, Host host) {
@@ -174,8 +172,7 @@ public class PhotoService {
 
         for (Photo photo : photos) {
             String uniqueFileName = createUniqueFileName(photo, originalNameCounts);
-            String downloadUrl = contentsStorage.issueDownloadUrl(photo.getPath()).toString();
-            downloadUrls.put(uniqueFileName, downloadUrl);
+            downloadUrls.put(uniqueFileName, photo.getPath());
         }
 
         return createDownloadUrlsResponse(downloadUrls);


### PR DESCRIPTION
## 작업 내용
- 아래 API들에 대해 다음과 같이 응답하도록 수정: `photogather/dev/contents/61a33a645f/eb2b649a-2491-4679-a504-6d7aa73a616c.png`
     - 사진 일괄 다운로드 API
     - 사진 단일 다운로드
     - 사진 선택 다운로드