### PR TITLE
fix: 퍼블릭 스페이스일 경우 누구나 접근이 가능하도록 변경

### DIFF
--- a/frontend/src/hooks/domain/useSpaceAccess.ts
+++ b/frontend/src/hooks/domain/useSpaceAccess.ts
@@ -4,36 +4,45 @@ import type { SpaceAccessType } from '../../types/space.type';
 
 interface UseSpaceAccessProps {
   hostId: number | undefined;
-  spaceType: SpaceAccessType;
+  spaceType: SpaceAccessType | undefined;
 }
 
 const useSpaceAccess = ({ hostId, spaceType }: UseSpaceAccessProps) => {
   // TODO : 전역에서 내려주는 hostId로 변경
   const [hasAccess, setHasAccess] = useState(false);
-  const [isLoadingAccess, setIsLoadingAccess] = useState(true);
+  type LoadingStateType = 'pending' | 'loading' | 'success' | 'error';
+  const [accessLoadingState, setAccessLoadingState] =
+    useState<LoadingStateType>('pending');
 
   useEffect(() => {
+    setAccessLoadingState('loading');
     if (spaceType === 'PUBLIC') {
       setHasAccess(true);
+      setAccessLoadingState('success');
       return;
     }
+    if (!hostId) {
+      setHasAccess(false);
+      setAccessLoadingState('error');
+      return;
+    }
+
+    setAccessLoadingState('loading');
     const fetchAccess = async () => {
-      if (!hostId) return;
-      setIsLoadingAccess(true);
       try {
         await authService.status().then((res) => {
           setHasAccess(res.data?.id === hostId);
+          setAccessLoadingState('success');
         });
       } catch (error) {
         console.error(`접근 권한 확인 실패 : ${error}`);
-      } finally {
-        setIsLoadingAccess(false);
+        setAccessLoadingState('error');
       }
     };
     fetchAccess();
   }, [hostId, spaceType]);
 
-  return { hasAccess, isLoadingAccess };
+  return { hasAccess, accessLoadingState };
 };
 
 export default useSpaceAccess;

--- a/frontend/src/hooks/domain/useSpaceAccess.ts
+++ b/frontend/src/hooks/domain/useSpaceAccess.ts
@@ -1,12 +1,22 @@
 import { useEffect, useState } from 'react';
 import { authService } from '../../apis/services/auth.service';
+import type { SpaceAccessType } from '../../types/space.type';
 
-const useSpaceAccess = (hostId: number | undefined) => {
+interface UseSpaceAccessProps {
+  hostId: number | undefined;
+  spaceType: SpaceAccessType;
+}
+
+const useSpaceAccess = ({ hostId, spaceType }: UseSpaceAccessProps) => {
   // TODO : 전역에서 내려주는 hostId로 변경
   const [hasAccess, setHasAccess] = useState(false);
   const [isLoadingAccess, setIsLoadingAccess] = useState(true);
 
   useEffect(() => {
+    if (spaceType === 'PUBLIC') {
+      setHasAccess(true);
+      return;
+    }
     const fetchAccess = async () => {
       if (!hostId) return;
       setIsLoadingAccess(true);
@@ -21,7 +31,7 @@ const useSpaceAccess = (hostId: number | undefined) => {
       }
     };
     fetchAccess();
-  }, [hostId]);
+  }, [hostId, spaceType]);
 
   return { hasAccess, isLoadingAccess };
 };

--- a/frontend/src/hooks/useDownload.ts
+++ b/frontend/src/hooks/useDownload.ts
@@ -120,7 +120,6 @@ const useDownload = ({
           ...info,
           url: buildOriginalImageUrl(parseImagePath(info.url)),
         }));
-        console.log(parsedUrls);
         await downloadAsZip(parsedUrls);
       },
       errorActions: ['toast'],

--- a/frontend/src/hooks/usePhotosBySpaceCode.ts
+++ b/frontend/src/hooks/usePhotosBySpaceCode.ts
@@ -64,9 +64,12 @@ const usePhotosBySpaceCode = ({
 
     const { photos, totalPages } = response.data;
     appendPhotosList(photos, totalPages);
-    requestAnimationFrame(() => {
-      reObserve();
-    });
+
+    if (currentPage.current < totalPages) {
+      requestAnimationFrame(() => {
+        reObserve();
+      });
+    }
   };
 
   const tryFetchPhotosList = async () => {
@@ -88,7 +91,7 @@ const usePhotosBySpaceCode = ({
     tryFetchPhotosList,
     thumbnailPhotoMap,
     photosList,
-    loadingState,
+    photosListLoadingState: loadingState.photosList,
     updatePhotos,
   };
 };

--- a/frontend/src/pages/manager/spaceHome/SpaceHomePage.tsx
+++ b/frontend/src/pages/manager/spaceHome/SpaceHomePage.tsx
@@ -184,7 +184,6 @@ const SpaceHomePage = () => {
 
   const handleImageClick = isSelectMode ? toggleSelectedPhoto : openPhotoModal;
 
-  console.log(accessLoadingState, hasAccess);
   //biome-ignore lint/correctness/useExhaustiveDependencies: isFetchSectionVisible 변경 시 호출
   useEffect(() => {
     if (spaceInfoLoadingState !== 'success' || accessLoadingState !== 'success')

--- a/frontend/src/pages/manager/spaceHome/SpaceHomePage.tsx
+++ b/frontend/src/pages/manager/spaceHome/SpaceHomePage.tsx
@@ -70,7 +70,10 @@ const SpaceHomePage = () => {
     spaceInfo?.openedAt && checkIsEarlyDate(spaceInfo.openedAt);
   const isSpaceExpired = spaceInfo?.isExpired;
 
-  const { hasAccess, isLoadingAccess } = useSpaceAccess(spaceInfo?.host.id);
+  const { hasAccess, isLoadingAccess } = useSpaceAccess({
+    hostId: spaceInfo?.host.id,
+    spaceType: spaceInfo?.type ?? 'PUBLIC',
+  });
 
   const {
     photosList,
@@ -78,6 +81,7 @@ const SpaceHomePage = () => {
     isEndPage,
     tryFetchPhotosList,
     updatePhotos,
+    photosListLoadingState,
   } = usePhotosBySpaceCode({
     reObserve,
     spaceCode: spaceCode ?? '',
@@ -182,6 +186,7 @@ const SpaceHomePage = () => {
 
   //biome-ignore lint/correctness/useExhaustiveDependencies: isFetchSectionVisible 변경 시 호출
   useEffect(() => {
+    if (photosListLoadingState === 'loading') return;
     if (isSpaceExpired || isEarlyTime || !hasAccess) return;
     if (!isFetchSectionVisible || isEndPage) return;
 

--- a/frontend/src/pages/manager/spaceHome/SpaceHomePage.tsx
+++ b/frontend/src/pages/manager/spaceHome/SpaceHomePage.tsx
@@ -186,7 +186,7 @@ const SpaceHomePage = () => {
 
   //biome-ignore lint/correctness/useExhaustiveDependencies: isFetchSectionVisible 변경 시 호출
   useEffect(() => {
-    if (photosListLoadingState === 'loading') return;
+    if (photosListLoadingState !== 'success' || isLoadingAccess) return;
     if (isSpaceExpired || isEarlyTime || !hasAccess) return;
     if (!isFetchSectionVisible || isEndPage) return;
 


### PR DESCRIPTION
## 연관된 이슈

- close #618

## 작업 내용

비공개 스페이스일 경우
<img width="200"  alt="image" src="https://github.com/user-attachments/assets/0375e366-2235-40b4-8009-2288437dbdad" />

- 비공개일 경우 스페이스 이미지 fetch를 진행하지 않도록 설정

공개 스페이스일 경우
<img width="200" alt="image" src="https://github.com/user-attachments/assets/fa393816-8783-4cfb-b122-73626fd11f6f" />


초기 Fetch가 여러번 되는 오류 해결
- 간헐적으로 이미지가 로딩 상태일 때 한 번 더 fetch 되는 문제 발생
- useEffect의 의존성배열이 바뀌면서 로딩 상태임에도 불구하고 다시 fetch를 진행했던 오류
- 이미지를 fetch하는 도중 (=loadingState가 'loading'일 경우) 다시 fetch 하지 않도록 useEffect에 if문 추가
```typescript
useEffect(() => {
    if (spaceInfoLoadingState !== 'success' || accessLoadingState !== 'success')
      return;

    if (!hasAccess || isSpaceExpired || isEarlyTime || isEndPage) return;

    if (photosListLoadingState === 'loading') return;

    if (isFetchSectionVisible && !isEndPage) {
      tryFetchPhotosList();
    }
  },
```
