### PR TITLE
fix: notifySuccessFiles 실패 여부 판단 로직 수정

### DIFF
--- a/frontend/src/hooks/useFileUpload.ts
+++ b/frontend/src/hooks/useFileUpload.ts
@@ -146,17 +146,12 @@ const useFileUpload = ({
     validGuestId: number,
     nickName: string,
   ) => {
-    if (successFiles.length === 0) {
-      throw new Error('성공한 파일이 없습니다.');
-    }
-
     const uploadedPhotos = successFiles.map((file) => ({
       uploadFileName: file.objectKey,
       originalName: file.originFile.name,
       capturedAt: file.capturedAt,
       capacityValue: file.capacityValue,
     }));
-
     const response = await tryFetch({
       task: async () =>
         await photoService.notifyUploadComplete(
@@ -220,6 +215,14 @@ const useFileUpload = ({
     const successFiles = updatedBatchFiles.filter(
       (f) => f.state === 'uploaded',
     );
+    const failedFiles = updatedBatchFiles.filter((f) => f.state === 'failed');
+
+    if (failedFiles.length > 0 || successFiles.length === 0) {
+      throw new Error(
+        `failed files exist(${failedFiles.length}) or no success files(${successFiles.length})`,
+      );
+    }
+
     await notifySuccessFiles(successFiles, validGuestId, nickName);
   };
 

--- a/frontend/src/hooks/useFileUpload.ts
+++ b/frontend/src/hooks/useFileUpload.ts
@@ -146,7 +146,7 @@ const useFileUpload = ({
     validGuestId: number,
     nickName: string,
   ) => {
-    if (successFiles.length !== localFiles.length) {
+    if (successFiles.length === 0) {
       throw new Error('성공한 파일이 없습니다.');
     }
 


### PR DESCRIPTION
## 연관된 이슈

- close #621 

## 작업 내용

``` ts
if (successFiles.length !== localFiles.length) {
      throw new Error('성공한 파일이 없습니다.');
    }
````
로 설정되어 있었는데요,

~언제부터인지 잘 모르겠으나~

성공한 파일이 없는 경우 | 실패한 파일이 있는 경우에 대한 조건문 분기 로직을 수정하였습니다.

``` ts
if (failedFiles.length > 0 || successFiles.length === 0) {
      throw new Error(
        `failed files exist(${failedFiles.length}) or no success files(${successFiles.length})`,
      );
    }
```

임시 조치하였고, 500장까지 파일 업로드 잘 되는 것 확인했습니다 🫡