### PR TITLE
refactor: 업로드 취소 api의 요청 미디어 타입 변경

### DIFF
--- a/backend/forgather/src/main/java/com/forgather/domain/space/controller/UploadController.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/space/controller/UploadController.java
@@ -1,10 +1,12 @@
 package com.forgather.domain.space.controller;
 
 import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED_VALUE;
 
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -56,11 +58,11 @@ public class UploadController {
         return ResponseEntity.ok(response);
     }
 
-    @PostMapping("/upload/cancel")
+    @PostMapping(value = "/upload/cancel", consumes = APPLICATION_FORM_URLENCODED_VALUE)
     @Operation(summary = "사진 업로드 취소", description = "업로드 취소 발생 시 클라우드 저장소에 업로드 된 사진들을 일괄 삭제합니다.")
     public ResponseEntity<Void> cancelUpload(
         @PathVariable String spaceCode,
-        @RequestBody CancelUploadRequest request,
+        @ModelAttribute CancelUploadRequest request,
         @RequestParam(name = "guestId", required = false) Long guestId
     ) {
         uploadService.cancelUpload(spaceCode, request, guestId);

--- a/backend/forgather/src/main/java/com/forgather/domain/space/controller/UploadController.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/space/controller/UploadController.java
@@ -23,6 +23,8 @@ import com.forgather.domain.space.dto.SaveUploadedPhotoRequest;
 import com.forgather.domain.space.service.UploadService;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -58,7 +60,10 @@ public class UploadController {
         return ResponseEntity.ok(response);
     }
 
-    @PostMapping(value = "/upload/cancel", consumes = APPLICATION_FORM_URLENCODED_VALUE)
+    @PostMapping(value = "/upload/cancel", consumes = APPLICATION_FORM_URLENCODED_VALUE, produces = "application/json")
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+        content = @Content(mediaType = APPLICATION_FORM_URLENCODED_VALUE,
+            schema = @Schema(implementation = CancelUploadRequest.class)))
     @Operation(summary = "사진 업로드 취소", description = "업로드 취소 발생 시 클라우드 저장소에 업로드 된 사진들을 일괄 삭제합니다.")
     public ResponseEntity<Void> cancelUpload(
         @PathVariable String spaceCode,


### PR DESCRIPTION
## 연관된 이슈

- close #645 

정리하자면 업로드 취소 요청 시 단순 요청만 가능합니다.
기존 POST application/json은 단순 요청이 아니어서 예비 요청이 나갑니다.
이로 인해 CORS가 발생합니다.

따라서 request의 content-type을 단순 요청에 해당하는 미디어 타입으로 변경해야합니다.
- application/form-data :  파일 업로드에 적합함. 단순 텍스트 전달 시 오버헤드가 큽니다.
- application/x-www-url-encoded : 단순 텍스트 전달에 적합합니다.
- text/plain : 텍스트 하나만을 보낼 수 있습니다. 구분자를 주어 여러 값을 하나의 텍스트로 만들 수 있지만 부자연스럽고 파싱이 어렵습니다.

따라서 퐁쥬와 합의 하에 `application/x-www-url-encoded` 타입으로 변경했습니다.

<img width="1056" height="454" alt="image" src="https://github.com/user-attachments/assets/75df1794-884d-4af4-9dd0-466a868c3924" />

<img width="1088" height="460" alt="image" src="https://github.com/user-attachments/assets/d239aef8-1333-48da-b1d8-4a16dc2b4df0" />

<img width="1704" height="746" alt="image" src="https://github.com/user-attachments/assets/1a549245-c963-45b5-aa39-0cb87d6e679e" />


## 작업 내용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 업로드 취소 API가 이제 JSON 대신 application/x-www-form-urlencoded 요청을 정상 처리합니다. 기존 동작과 응답 형식(JSON)은 동일하며, 폼 방식 전송 클라이언트의 호환성이 향상됩니다. 다른 엔드포인트에는 영향이 없습니다.
- 문서
  - 업로드 취소 요청의 폼 필드 스펙과 예제가 API 문서에 명확히 반영되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->