### PR TITLE
chore: ci-cd build 과정에서 branch를 지정

### DIFF
--- a/backend/forgather/deploy/buildspec-dev.yml
+++ b/backend/forgather/deploy/buildspec-dev.yml
@@ -7,7 +7,7 @@ phases:
     commands:
       - echo "Git clone 시작"
       - rm -rf *  # 소스 스테이지에서 내려온 불완전한 zip 제거
-      - git clone https://github.com/woowacourse-teams/2025-PhotoGather.git
+      - git clone -b v2/develop --single-branch https://github.com/woowacourse-teams/2025-PhotoGather.git
       - cd 2025-PhotoGather
       - echo "[install] git-crypt 설치"
       - sudo apt-get install git-crypt

--- a/backend/forgather/deploy/buildspec-prod.yml
+++ b/backend/forgather/deploy/buildspec-prod.yml
@@ -7,7 +7,7 @@ phases:
     commands:
       - echo "Git clone 시작"
       - rm -rf *  # 소스 스테이지에서 내려온 불완전한 zip 제거
-      - git clone https://github.com/woowacourse-teams/2025-PhotoGather.git
+      - git clone -b v2/main --single-branch https://github.com/woowacourse-teams/2025-PhotoGather.git
       - cd 2025-PhotoGather
       - echo "[install] git-crypt 설치"
       - sudo apt-get install git-crypt


### PR DESCRIPTION
## 연관된 이슈

ci-cd 시 `v2/develop`이 아닌 `develop` 브랜치의 버전이 배포된다.
buildspec.yml에서 git clone을 하고 있는데 브랜치를 별도로 지정하지 않아 default 브랜치인 `develop` 코드를 받아온다.

-> git clone 시 branch를 `v2/develop`으로 지정한다.