### PR TITLE
refactor: 퍼널 공통 훅 분리

### DIFF
--- a/frontend/src/hooks/useFormFunnel.ts
+++ b/frontend/src/hooks/useFormFunnel.ts
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+import useFunnel from './useFunnel';
+
+const useFormFunnel = <Step extends string, Form>(
+  initialStep: Step,
+  initialFormData: Form,
+) => {
+  const funnel = useFunnel(initialStep);
+  const [form, setForm] = useState<Form>(initialFormData);
+
+  const updateFormData = (updates: Partial<Form>) => {
+    setForm((prev) => ({ ...prev, ...updates }));
+  };
+
+  const goNextWithData = (nextStep: Step, data: Partial<Form>) => {
+    updateFormData(data);
+    funnel.goNextStep(nextStep);
+  };
+
+  return {
+    ...funnel,
+    form,
+    updateFormData,
+    goNextWithData,
+  };
+};
+
+export default useFormFunnel;

--- a/frontend/src/hooks/useFunnel.ts
+++ b/frontend/src/hooks/useFunnel.ts
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+import useFunnelHistory from './useFunnelHistory';
+
+interface FunnelStepProps<T> {
+  name: T;
+  children: React.ReactNode;
+}
+
+const useFunnel = <Step extends string>(initialStep: Step) => {
+  const [funnelStep, setFunnelStep] = useState<Step>(initialStep);
+
+  const { navigateToNext } = useFunnelHistory<Step>(funnelStep, setFunnelStep);
+
+  const goNextStep = (nextStep: Step) => {
+    navigateToNext(nextStep);
+    setFunnelStep(nextStep);
+  };
+
+  const Step = ({ name, children }: FunnelStepProps<Step>) => {
+    if (funnelStep === name) return children;
+    return null;
+  };
+
+  return { Step, funnelStep, setFunnelStep, goNextStep };
+};
+
+export default useFunnel;

--- a/frontend/src/pages/create/funnel/SpaceCreateFunnel.tsx
+++ b/frontend/src/pages/create/funnel/SpaceCreateFunnel.tsx
@@ -6,7 +6,7 @@ import { ROUTES } from '../../../constants/routes';
 import useConfirmBeforeRefresh from '../../../hooks/@common/useConfirmBeforeRefresh';
 import useAgreements from '../../../hooks/domain/auth/useAgreements';
 import useAuthConditionTasks from '../../../hooks/domain/auth/useAuthConditionTasks';
-import useFunnelHistory from '../../../hooks/useFunnelHistory';
+import useFunnel from '../../../hooks/useFunnel';
 import type { SpaceFunnelInfo } from '../../../types/space.type';
 import AccessTypeElement from '../funnelElements/accessTypeElement/AccessTypeElement';
 import AgreementElement from '../funnelElements/agreementElement/AgreementElement';
@@ -32,6 +32,15 @@ const SpaceCreateFunnel = () => {
   useConfirmBeforeRefresh();
   const { handleAgree, isAgree, loadingAgreements } = useAgreements();
   const needsAgreement = !isAgree;
+  const { Step, funnelStep, setFunnelStep, goNextStep } =
+    useFunnel<STEP>('name');
+  useEffect(() => {
+    if (!loadingAgreements && needsAgreement) setFunnelStep('agreement');
+  }, [needsAgreement, loadingAgreements, setFunnelStep]);
+
+  const [spaceInfo, setSpaceInfo] =
+    useState<SpaceFunnelInfo>(initialFunnelValue);
+
   const PROGRESS_STEP_LIST: STEP[] = [
     'name',
     'date',
@@ -39,22 +48,8 @@ const SpaceCreateFunnel = () => {
     'inbox',
     'check',
   ];
-  const [step, setStep] = useState<STEP>('name');
-  useEffect(() => {
-    if (!loadingAgreements && needsAgreement) setStep('agreement');
-  }, [needsAgreement, loadingAgreements]);
-
-  const [spaceInfo, setSpaceInfo] =
-    useState<SpaceFunnelInfo>(initialFunnelValue);
-  const { navigateToNext } = useFunnelHistory<STEP>(step, setStep);
-
-  const goNextStep = (nextStep: STEP) => {
-    navigateToNext(nextStep);
-    setStep(nextStep);
-  };
-
   const currentStep =
-    PROGRESS_STEP_LIST.findIndex((oneStep) => oneStep === step) + 1;
+    PROGRESS_STEP_LIST.findIndex((oneStep) => oneStep === funnelStep) + 1;
 
   const navigate = useNavigate();
   useAuthConditionTasks({ taskWhenNoAuth: () => navigate(ROUTES.MAIN) });
@@ -71,7 +66,7 @@ const SpaceCreateFunnel = () => {
         </S.IconContainer>
       </S.TopContainer>
       <S.ContentContainer>
-        {step === 'agreement' && (
+        <Step name="agreement">
           <AgreementElement
             value={
               spaceInfo.agreements ?? {
@@ -87,8 +82,8 @@ const SpaceCreateFunnel = () => {
               goNextStep('name');
             }}
           />
-        )}
-        {step === 'name' && (
+        </Step>
+        <Step name="name">
           <NameInputElement
             onNext={(name) => {
               goNextStep('date');
@@ -96,8 +91,8 @@ const SpaceCreateFunnel = () => {
             }}
             initialValue={spaceInfo.name}
           />
-        )}
-        {step === 'date' && (
+        </Step>
+        <Step name="date">
           <ImmediateOpenElement
             onNext={({ date, time, isImmediateOpen }) => {
               goNextStep('accessType');
@@ -114,8 +109,8 @@ const SpaceCreateFunnel = () => {
               isImmediateOpen: spaceInfo.isImmediateOpen,
             }}
           />
-        )}
-        {step === 'accessType' && (
+        </Step>
+        <Step name="accessType">
           <AccessTypeElement
             onNext={(accessType) => {
               goNextStep('inbox');
@@ -126,8 +121,8 @@ const SpaceCreateFunnel = () => {
             }}
             initialValue={spaceInfo.accessType}
           />
-        )}
-        {step === 'inbox' && (
+        </Step>
+        <Step name="inbox">
           <InboxElement
             onNext={(isInboxEnabled) => {
               goNextStep('check');
@@ -138,8 +133,8 @@ const SpaceCreateFunnel = () => {
             }}
             initialValue={spaceInfo.isInboxEnabled}
           />
-        )}
-        {step === 'check' && (
+        </Step>
+        <Step name="check">
           <CheckSpaceInfoElement
             spaceInfo={spaceInfo}
             onNext={(isImmediateOpen) => {
@@ -147,7 +142,7 @@ const SpaceCreateFunnel = () => {
               handleAgree();
             }}
           />
-        )}
+        </Step>
       </S.ContentContainer>
     </S.Wrapper>
   );

--- a/frontend/src/pages/create/funnel/SpaceCreateFunnel.tsx
+++ b/frontend/src/pages/create/funnel/SpaceCreateFunnel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { DiamondImg as diamondImage } from '../../../@assets/images';
 import StepProgressBar from '../../../components/@common/progressBar/step/StepProgressBar';
@@ -6,7 +6,7 @@ import { ROUTES } from '../../../constants/routes';
 import useConfirmBeforeRefresh from '../../../hooks/@common/useConfirmBeforeRefresh';
 import useAgreements from '../../../hooks/domain/auth/useAgreements';
 import useAuthConditionTasks from '../../../hooks/domain/auth/useAuthConditionTasks';
-import useFunnel from '../../../hooks/useFunnel';
+import useFormFunnel from '../../../hooks/useFormFunnel';
 import type { SpaceFunnelInfo } from '../../../types/space.type';
 import AccessTypeElement from '../funnelElements/accessTypeElement/AccessTypeElement';
 import AgreementElement from '../funnelElements/agreementElement/AgreementElement';
@@ -32,14 +32,18 @@ const SpaceCreateFunnel = () => {
   useConfirmBeforeRefresh();
   const { handleAgree, isAgree, loadingAgreements } = useAgreements();
   const needsAgreement = !isAgree;
-  const { Step, funnelStep, setFunnelStep, goNextStep } =
-    useFunnel<STEP>('name');
+
+  const {
+    Step,
+    form: spaceInfo,
+    updateFormData: updateSpaceInfo,
+    funnelStep,
+    goNextWithData,
+    setFunnelStep,
+  } = useFormFunnel<STEP, SpaceFunnelInfo>('name', initialFunnelValue);
   useEffect(() => {
     if (!loadingAgreements && needsAgreement) setFunnelStep('agreement');
   }, [needsAgreement, loadingAgreements, setFunnelStep]);
-
-  const [spaceInfo, setSpaceInfo] =
-    useState<SpaceFunnelInfo>(initialFunnelValue);
 
   const PROGRESS_STEP_LIST: STEP[] = [
     'name',
@@ -75,19 +79,17 @@ const SpaceCreateFunnel = () => {
               }
             }
             onChange={(agreements) => {
-              setSpaceInfo((prev) => ({ ...prev, agreements }));
+              updateSpaceInfo({ agreements });
             }}
-            onNext={(agreement) => {
-              setSpaceInfo((prev) => ({ ...prev, agreement }));
-              goNextStep('name');
+            onNext={(agreements) => {
+              goNextWithData('name', { agreements });
             }}
           />
         </Step>
         <Step name="name">
           <NameInputElement
             onNext={(name) => {
-              goNextStep('date');
-              setSpaceInfo((prev) => ({ ...prev, name }));
+              goNextWithData('date', { name });
             }}
             initialValue={spaceInfo.name}
           />
@@ -95,13 +97,11 @@ const SpaceCreateFunnel = () => {
         <Step name="date">
           <ImmediateOpenElement
             onNext={({ date, time, isImmediateOpen }) => {
-              goNextStep('accessType');
-              setSpaceInfo((prev) => ({
-                ...prev,
+              goNextWithData('accessType', {
                 date,
                 time,
                 isImmediateOpen: isImmediateOpen ?? false,
-              }));
+              });
             }}
             initialValue={{
               date: spaceInfo.date,
@@ -113,11 +113,7 @@ const SpaceCreateFunnel = () => {
         <Step name="accessType">
           <AccessTypeElement
             onNext={(accessType) => {
-              goNextStep('inbox');
-              setSpaceInfo((prev) => ({
-                ...prev,
-                accessType: accessType,
-              }));
+              goNextWithData('inbox', { accessType });
             }}
             initialValue={spaceInfo.accessType}
           />
@@ -125,11 +121,7 @@ const SpaceCreateFunnel = () => {
         <Step name="inbox">
           <InboxElement
             onNext={(isInboxEnabled) => {
-              goNextStep('check');
-              setSpaceInfo((prev) => ({
-                ...prev,
-                isInboxEnabled,
-              }));
+              goNextWithData('check', { isInboxEnabled });
             }}
             initialValue={spaceInfo.isInboxEnabled}
           />
@@ -138,7 +130,7 @@ const SpaceCreateFunnel = () => {
           <CheckSpaceInfoElement
             spaceInfo={spaceInfo}
             onNext={(isImmediateOpen) => {
-              setSpaceInfo((prev) => ({ ...prev, isImmediateOpen }));
+              updateSpaceInfo({ isImmediateOpen });
               handleAgree();
             }}
           />


### PR DESCRIPTION
## 연관된 이슈

- close #652 

## 작업 내용

### 퍼널을 사용할 수 있는 useFunnel, useFormFunnel 훅 제작

- [자세한 내용](http://catkin-chokeberry-f58.notion.site/27e864a9cb03806aa371c251f50489a0)
- useFunnel은 컴포넌트를 바꾸는 역할, useFormFunnel은 컴포넌트를 바꾸며 Data를 수정하는 역할
- 두 훅을 이용해 Funnel을 대체