### PR TITLE
feature: Prpduct, ProductPhoto 관련 검증 로직 추가

### DIFF
--- a/backend/forgather/src/main/java/com/forgather/domain/product/dto/RegisterProductPhotoRequest.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/product/dto/RegisterProductPhotoRequest.java
@@ -6,7 +6,7 @@ import com.forgather.domain.product.model.ProductPhoto;
 public record RegisterProductPhotoRequest(
     String originalName,
     String path,
-    long capacity
+    Long capacity
 ) {
 
     // ProductPhotos.add()가 정렬 순서를 자동 할당하므로, 초기값(1)은 의미 없음

--- a/backend/forgather/src/main/java/com/forgather/domain/product/model/Product.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/product/model/Product.java
@@ -30,7 +30,7 @@ public class Product extends BaseTimeEntity {
     @JoinColumn(name = "space_id", nullable = false)
     private Space space;
 
-    @Column(name = "title")
+    @Column(name = "title",  nullable = false)
     private String title;
 
     @Column(name = "category")
@@ -39,11 +39,22 @@ public class Product extends BaseTimeEntity {
     @Column(name = "author_name")
     private String authorName;
 
-    @Column(name = "description")
+    @Column(name = "description", nullable = false)
     private String description;
 
+    /**
+     * 작품을 생성합니다.
+     *
+     * @param space 작품이 속한 스페이스 (필수)
+     * @param title 작품명 (필수, 최대 50자)
+     * @param category 카테고리 (선택, 최대 20자)
+     * @param authorName 작가명 (선택, 최대 20자)
+     * @param description 작품 설명 (필수, 최대 1000자)
+     * @throws BaseNullPointerException 필수 필드가 null인 경우
+     * @throws BaseException 필드 값이 유효하지 않은 경우
+     */
     public Product(Space space, String title, String category, String authorName, String description) {
-        validateSpace(space);
+        validateRequiredFields(space, title, description);
         validateTitle(title);
         validateCategory(category);
         validateAuthorName(authorName);
@@ -55,44 +66,86 @@ public class Product extends BaseTimeEntity {
         this.description = description;
     }
 
-    public void update(String title, String category, String authorName, String description) {
-        validateTitle(title);
-        validateCategory(category);
-        validateAuthorName(authorName);
-        validateDescription(description);
-        if (title != null) this.title = title;
-        if (category != null) this.category = category;
-        if (authorName != null) this.authorName = authorName;
-        if (description != null) this.description = description;
+    private void validateRequiredFields(Space space, String title, String description) {
+        if (space == null) {
+            throw new BaseNullPointerException("스페이스는 필수입니다.");
+        }
+        if (title == null) {
+            throw new BaseNullPointerException("작품명은 필수입니다.");
+        }
+        if (description == null) {
+            throw new BaseNullPointerException("작품 설명은 필수입니다.");
+        }
     }
 
-    private void validateSpace(Space space) {
-        if (space == null) {
-            throw new BaseNullPointerException("스페이스는 null일 수 없습니다.");
+    /**
+     * 작품 정보를 부분 업데이트합니다.
+     * null인 필드는 업데이트하지 않습니다.
+     *
+     * @param title 작품명 (선택)
+     * @param category 카테고리 (선택)
+     * @param authorName 작가명 (선택)
+     * @param description 작품 설명 (선택)
+     * @throws BaseException 필드 값이 유효하지 않은 경우
+     */
+    public void update(String title, String category, String authorName, String description) {
+        if (title != null) {
+            validateTitle(title);
+            this.title = title;
+        }
+        if (category != null) {
+            validateCategory(category);
+            this.category = category;
+        }
+        if (authorName != null) {
+            validateAuthorName(authorName);
+            this.authorName = authorName;
+        }
+        if (description != null) {
+            validateDescription(description);
+            this.description = description;
         }
     }
 
     private void validateTitle(String title) {
-        if (title != null && title.length() > 50) {
-            throw new BaseException("작품명은 최대 50자입니다. title.length(): " + title.length());
+        if (title.isBlank()) {
+            throw new BaseException("작품명은 공백만 입력할 수 없습니다.");
+        }
+        if (title.length() > 50) {
+            throw new BaseException("작품명은 최대 50자까지 입력 가능합니다.");
         }
     }
 
     private void validateCategory(String category) {
-        if (category != null && category.length() > 20) {
-            throw new BaseException("작품 카테고리는 최대 20자입니다. category.length(): " + category.length());
+        if (category == null) {
+            return;
+        }
+        if (category.isBlank()) {
+            throw new BaseException("작품 카테고리는 공백만 입력할 수 없습니다.");
+        }
+        if (category.length() > 20) {
+            throw new BaseException("작품 카테고리는 최대 20자까지 입력 가능합니다.");
         }
     }
 
     private void validateAuthorName(String authorName) {
-        if (authorName != null && authorName.length() > 20) {
-            throw new BaseException("작가명은 최대 20자입니다. authorName.length(): " + authorName.length());
+        if (authorName == null) {
+            return;
+        }
+        if (authorName.isBlank()) {
+            throw new BaseException("작가명은 공백만 입력할 수 없습니다.");
+        }
+        if (authorName.length() > 20) {
+            throw new BaseException("작가명은 최대 20자까지 입력 가능합니다.");
         }
     }
 
     private void validateDescription(String description) {
-        if (description != null && description.length() > 1000) {
-            throw new BaseException("작품 설명은 최대 1000자입니다. description.length(): " + description.length());
+        if (description.isBlank()) {
+            throw new BaseException("작품 설명은 공백만 입력할 수 없습니다.");
+        }
+        if (description.length() > 1000) {
+            throw new BaseException("작품 설명은 최대 1000자까지 입력 가능합니다.");
         }
     }
 }

--- a/backend/forgather/src/main/java/com/forgather/domain/product/model/ProductPhoto.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/product/model/ProductPhoto.java
@@ -2,6 +2,7 @@ package com.forgather.domain.product.model;
 
 import com.forgather.domain.space.model.Photo;
 import com.forgather.global.exception.BaseException;
+import com.forgather.global.exception.BaseNullPointerException;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -17,6 +18,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProductPhoto extends Photo implements Comparable<ProductPhoto> {
 
+    private static final int MIN_ORDER = 1;
+    private static final int MAX_ORDER = 10;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id", nullable = false)
     private Product product;
@@ -24,24 +28,37 @@ public class ProductPhoto extends Photo implements Comparable<ProductPhoto> {
     @Column(name = "sort_order", nullable = false)
     private int sortOrder;
 
-    // TODO 파라미터 검증
-    public ProductPhoto(long id, Product product, String originalName, String path, long capacity, int order) {
+    public ProductPhoto(Long id, Product product, String originalName, String path, Long capacity, int order) {
         super(id, originalName, path, capacity);
+        validateRequiredFields(product);
+        validateOrder(order);
         this.product = product;
         this.sortOrder = order;
     }
 
-    public ProductPhoto(Product product, String originalName, String path, long capacity, int order) {
+    public ProductPhoto(Product product, String originalName, String path, Long capacity, int order) {
         super(originalName, path, capacity);
+        validateRequiredFields(product);
+        validateOrder(order);
         this.product = product;
         this.sortOrder = order;
+    }
+
+    private void validateRequiredFields(Product product) {
+        if (product == null) {
+            throw new BaseNullPointerException("작품 정보는 필수입니다.");
+        }
     }
 
     public void changeOrder(int order) {
-        if (order < 1) {
-            throw new BaseException("정렬 순서는 1 이상이어야 합니다. order: " + order);
-        }
+        validateOrder(order);
         sortOrder = order;
+    }
+
+    private void validateOrder(int order) {
+        if (order < MIN_ORDER || order > MAX_ORDER) {
+            throw new BaseException("작품 사진의 정렬 순서는 1 이상, 10 이하여야 합니다. order: " + order);
+        }
     }
 
     @Override

--- a/backend/forgather/src/main/java/com/forgather/domain/product/model/ProductPhotos.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/product/model/ProductPhotos.java
@@ -12,11 +12,16 @@ import com.forgather.global.exception.BaseException;
  * 항상 productPhoto.sortOrder 기반 오름차순 정렬 유지.
  * productPhoto.sortOrder 중복 검증.
  * productPhotos#add/delete 시 productPhoto.sortOrder 조정.(정렬 순서는 1부터 시작)
+ * 최대 10개까지만 보관.
  */
 public class ProductPhotos {
+
+    private static final int MAX_COUNT = 10;
+
     private final List<ProductPhoto> productPhotos;
 
     public ProductPhotos(List<ProductPhoto> productPhotos) {
+        validateTotalCount(productPhotos.size());
         List<ProductPhoto> sortedProductPhotos = new ArrayList<>(productPhotos);
         sortedProductPhotos.sort(ProductPhoto::compareTo);
         validateDuplicateOrder(sortedProductPhotos);
@@ -59,18 +64,26 @@ public class ProductPhotos {
     }
 
     public void add(List<ProductPhoto> newPhotos) {
+        validateTotalCount(productPhotos.size() + newPhotos.size());
         for (ProductPhoto photo : newPhotos) {
             add(photo);
         }
     }
 
     public void add(ProductPhoto newPhoto) {
+        validateTotalCount(productPhotos.size() + 1);
         int order = 1;
         if (!productPhotos.isEmpty()) {
             order = productPhotos.getLast().getSortOrder() + 1; // 정렬이 보장되기에 가능한 로직.
         }
         newPhoto.changeOrder(order);
         productPhotos.add(newPhoto);
+    }
+
+    private void validateTotalCount(int totalCount) {
+        if (totalCount > MAX_COUNT) {
+            throw new BaseException("작품 사진은 최대 10개까지만 등록 가능합니다. count: " + totalCount);
+        }
     }
 
     public List<ProductPhoto> getAll() {

--- a/backend/forgather/src/main/java/com/forgather/domain/product/model/ProductPhotos.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/product/model/ProductPhotos.java
@@ -82,7 +82,7 @@ public class ProductPhotos {
 
     private void validateTotalCount(int totalCount) {
         if (totalCount > MAX_COUNT) {
-            throw new BaseException("작품 사진은 최대 10개까지만 등록 가능합니다. count: " + totalCount);
+            throw new BaseException("작품 사진은 최대 %s개까지만 등록 가능합니다. count: ".formatted(MAX_COUNT) + totalCount);
         }
     }
 

--- a/backend/forgather/src/main/java/com/forgather/domain/space/model/Photo.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/space/model/Photo.java
@@ -36,7 +36,7 @@ public abstract class Photo extends BaseTimeEntity {
         this.capacity = capacity;
     }
 
-    public Photo(long id, String originalName, String path, long capacity) {
+    public Photo(Long id, String originalName, String path, Long capacity) {
         this.id = id;
         this.originalName = originalName;
         this.path = path;

--- a/backend/forgather/src/main/resources/db/migration/V1__create_initial_tables.sql
+++ b/backend/forgather/src/main/resources/db/migration/V1__create_initial_tables.sql
@@ -77,10 +77,10 @@ CREATE TABLE `product`
 (
     `id`          BIGINT    NOT NULL AUTO_INCREMENT,
     `space_id`    BIGINT    NOT NULL,
-    `title`       VARCHAR(255) NULL,
+    `title`       VARCHAR(255) NOT NULL,
     `category`    VARCHAR(255) NULL,
     `author_name` VARCHAR(255) NULL,
-    `description` VARCHAR(255) NULL,
+    `description` VARCHAR(255) NOT NULL,
     `created_at`  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     `updated_at`  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     PRIMARY KEY (`id`)
@@ -90,10 +90,10 @@ CREATE TABLE `product_photo`
 (
     `id`            BIGINT    NOT NULL AUTO_INCREMENT,
     `product_id`    BIGINT    NOT NULL,
-    `sort_order`    INT NULL,
-    `original_name` VARCHAR(255) NULL,
-    `path`          VARCHAR(255) NULL,
-    `capacity`      BIGINT NULL,
+    `sort_order`    INT NOT NULL,
+    `original_name` VARCHAR(255) NOT NULL,
+    `path`          VARCHAR(255) NOT NULL,
+    `capacity`      BIGINT NOT NULL,
     `created_at`    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     `updated_at`    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     PRIMARY KEY (`id`)
@@ -103,9 +103,9 @@ CREATE TABLE `space_photo`
 (
     `id`            BIGINT    NOT NULL AUTO_INCREMENT,
     `space_id`      BIGINT    NOT NULL,
-    `original_name` VARCHAR(255) NULL,
-    `path`          VARCHAR(255) NULL,
-    `capacity`      BIGINT NULL,
+    `original_name` VARCHAR(255) NOT NULL,
+    `path`          VARCHAR(255) NOT NULL,
+    `capacity`      BIGINT NOT NULL,
     `created_at`    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     `updated_at`    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     PRIMARY KEY (`id`)

--- a/backend/forgather/src/test/java/com/forgather/acceptance/ProductAcceptanceTest.java
+++ b/backend/forgather/src/test/java/com/forgather/acceptance/ProductAcceptanceTest.java
@@ -51,9 +51,9 @@ public class ProductAcceptanceTest extends AcceptanceTest {
         "authorName",
         "description",
         List.of(
-            new RegisterProductPhotoRequest("photo1", "path1", 1024),
-            new RegisterProductPhotoRequest("photo2", "path2", 2048),
-            new RegisterProductPhotoRequest("photo3", "path3", 4096)
+            new RegisterProductPhotoRequest("photo1", "path1", 1024L),
+            new RegisterProductPhotoRequest("photo2", "path2", 2048L),
+            new RegisterProductPhotoRequest("photo3", "path3", 4096L)
         )
     );
 
@@ -175,8 +175,8 @@ public class ProductAcceptanceTest extends AcceptanceTest {
             "description",
             List.of(2L),
             List.of(
-                new RegisterProductPhotoRequest("photo4", "path4", 1024),
-                new RegisterProductPhotoRequest("photo5", "path5", 1024)
+                new RegisterProductPhotoRequest("photo4", "path4", 1024L),
+                new RegisterProductPhotoRequest("photo5", "path5", 1024L)
             )
         );
 

--- a/backend/forgather/src/test/java/com/forgather/domain/product/model/ProductPhotoTest.java
+++ b/backend/forgather/src/test/java/com/forgather/domain/product/model/ProductPhotoTest.java
@@ -13,7 +13,7 @@ import com.forgather.global.exception.BaseException;
 
 class ProductPhotoTest {
 
-    @DisplayName("작품 사진의 정렬 순서 값이 유효하지 않으면 예외를 던진다")
+    @DisplayName("작품 정보가 null이면 예외를 던진다")
     @Test
     void throwExceptionWhenNoProduct() {
         // when, then

--- a/backend/forgather/src/test/java/com/forgather/domain/product/model/ProductPhotoTest.java
+++ b/backend/forgather/src/test/java/com/forgather/domain/product/model/ProductPhotoTest.java
@@ -6,16 +6,37 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import com.forgather.global.exception.BaseException;
 
 class ProductPhotoTest {
 
+    @DisplayName("작품 사진의 정렬 순서 값이 유효하지 않으면 예외를 던진다")
+    @Test
+    void throwExceptionWhenNoProduct() {
+        // when, then
+        assertThatThrownBy(() -> new ProductPhoto(null, "originalName", "path", 1024L, 1))
+            .isInstanceOf(BaseException.class)
+            .hasMessageContaining("작품 정보는 필수입니다.");
+    }
+
+    @DisplayName("작품 사진의 정렬 순서 값이 유효하지 않으면 예외를 던진다")
+    @ValueSource(ints = {-1, 0, 11})
+    @ParameterizedTest
+    void throwExceptionWhenOrderIsInvalid(int order) {
+        // when, then
+        assertThatThrownBy(() -> new ProductPhoto(createProduct(), "originalName", "path", 1024L, order))
+            .isInstanceOf(BaseException.class)
+            .hasMessageContaining("작품 사진의 정렬 순서는 1 이상, 10 이하여야 합니다.");
+    }
+
     @DisplayName("작품 사진의 순서를 변경한다")
     @Test
     void changeOrder() {
         // given
-        ProductPhoto productPhoto = new ProductPhoto(createProduct(), "originalName", "path", 1024, 3);
+        ProductPhoto productPhoto = new ProductPhoto(createProduct(), "originalName", "path", 1024L, 3);
 
         // when
         productPhoto.changeOrder(1);
@@ -24,15 +45,16 @@ class ProductPhotoTest {
         assertThat(productPhoto.getSortOrder()).isEqualTo(1);
     }
 
-    @DisplayName("작품 사진의 정렬 순서가 0이하이면 예외를 던진다")
-    @Test
-    void throwExceptionWhenChangeOrderIsInvalid() {
+    @DisplayName("변경할 작품 사진의 정렬 순서 값이 유효하지 않으면 예외를 던진다")
+    @ValueSource(ints = {-1, 0, 11})
+    @ParameterizedTest
+    void throwExceptionWhenChangeOrderIsInvalid(int order) {
         // given
-        ProductPhoto productPhoto = new ProductPhoto(createProduct(), "originalName", "path", 1024, 3);
+        ProductPhoto productPhoto = new ProductPhoto(createProduct(), "originalName", "path", 1024L, 1);
 
         // when, then
-        assertThatThrownBy(() -> productPhoto.changeOrder(0))
+        assertThatThrownBy(() -> productPhoto.changeOrder(order))
             .isInstanceOf(BaseException.class)
-            .hasMessageContaining("정렬 순서는 1 이상이어야 합니다.");
+            .hasMessageContaining("작품 사진의 정렬 순서는 1 이상, 10 이하여야 합니다.");
     }
 }

--- a/backend/forgather/src/test/java/com/forgather/domain/product/model/ProductPhotosTest.java
+++ b/backend/forgather/src/test/java/com/forgather/domain/product/model/ProductPhotosTest.java
@@ -205,4 +205,51 @@ class ProductPhotosTest {
             () -> assertThat(photo5.getSortOrder()).isEqualTo(2)
         );
     }
+
+    @DisplayName("작품 사진의 개수가 10개를 초과하면 예외를 던진다")
+    @Test
+    public void throwExceptionWhenExceedMaxCount() {
+        // given
+        List<ProductPhoto> productPhotos = List.of(
+            createProductPhotoWithOrder(1),
+            createProductPhotoWithOrder(2),
+            createProductPhotoWithOrder(3),
+            createProductPhotoWithOrder(4),
+            createProductPhotoWithOrder(5),
+            createProductPhotoWithOrder(6),
+            createProductPhotoWithOrder(7),
+            createProductPhotoWithOrder(8),
+            createProductPhotoWithOrder(9),
+            createProductPhotoWithOrder(10),
+            createProductPhotoWithOrder(10)
+        );
+
+        // when, then
+        assertThatThrownBy(() -> new ProductPhotos(productPhotos))
+            .isInstanceOf(BaseException.class)
+            .hasMessageContaining("작품 사진은 최대 10개까지만 등록 가능합니다.");
+    }
+
+    @DisplayName("작품 사진을 추가할 때 개수가 10개를 초과하면 예외를 던진다")
+    @Test
+    public void throwExceptionWhenAdditionExceedMaxCount() {
+        // given
+        List<ProductPhoto> productPhotos = List.of(
+            createProductPhotoWithOrder(1),
+            createProductPhotoWithOrder(2),
+            createProductPhotoWithOrder(3),
+            createProductPhotoWithOrder(4),
+            createProductPhotoWithOrder(5),
+            createProductPhotoWithOrder(6),
+            createProductPhotoWithOrder(7),
+            createProductPhotoWithOrder(8),
+            createProductPhotoWithOrder(9),
+            createProductPhotoWithOrder(10)
+        );
+
+        // when, then
+        assertThatThrownBy(() -> new ProductPhotos(productPhotos).add(createProductPhotoWithOrder(10)))
+            .isInstanceOf(BaseException.class)
+            .hasMessageContaining("작품 사진은 최대 10개까지만 등록 가능합니다.");
+    }
 }

--- a/backend/forgather/src/test/java/com/forgather/domain/product/model/ProductTest.java
+++ b/backend/forgather/src/test/java/com/forgather/domain/product/model/ProductTest.java
@@ -59,7 +59,7 @@ class ProductTest {
 
     @DisplayName("작품명의 길이가 50자를 초과하면 예외를 던진다")
     @Test
-    void throwExceptionWhenBlankTitle() {
+    void throwExceptionWhenExceedTitleLength() {
         // given
         String title = "0123456789".repeat(5) + 1;
 

--- a/backend/forgather/src/test/java/com/forgather/domain/product/model/ProductTest.java
+++ b/backend/forgather/src/test/java/com/forgather/domain/product/model/ProductTest.java
@@ -12,6 +12,8 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import com.forgather.global.exception.BaseException;
 import com.forgather.global.exception.BaseNullPointerException;
@@ -24,12 +26,40 @@ class ProductTest {
         // when, then
         assertThatThrownBy(() -> createProductWithSpace(null))
             .isInstanceOf(BaseNullPointerException.class)
-            .hasMessageContaining("스페이스는 null일 수 없습니다.");
+            .hasMessageContaining("스페이스는 필수입니다.");
+    }
+
+    @DisplayName("작품명이 null이면 예외를 던진다")
+    @Test
+    void throwExceptionWhenTitleIsNull() {
+        // when, then
+        assertThatThrownBy(() -> createProductWithTitle(null))
+            .isInstanceOf(BaseNullPointerException.class)
+            .hasMessageContaining("작품명은 필수입니다.");
+    }
+
+    @DisplayName("작품 설명이 null이면 예외를 던진다")
+    @Test
+    void throwExceptionWhenDescriptionIsNull() {
+        // when, then
+        assertThatThrownBy(() -> createProductWithDescription(null))
+            .isInstanceOf(BaseNullPointerException.class)
+            .hasMessageContaining("작품 설명은 필수입니다.");
+    }
+
+    @DisplayName("작품명이 공백이면 예외를 던진다")
+    @ValueSource(strings = {"", " "})
+    @ParameterizedTest
+    void throwExceptionWhenNoTitle(String title) {
+        // when, then
+        assertThatThrownBy(() -> createProductWithTitle(title))
+            .isInstanceOf(BaseException.class)
+            .hasMessageContaining("작품명은 공백만 입력할 수 없습니다.");
     }
 
     @DisplayName("작품명의 길이가 50자를 초과하면 예외를 던진다")
     @Test
-    void throwExceptionWhenExceedTitleLength() {
+    void throwExceptionWhenBlankTitle() {
         // given
         String title = "0123456789".repeat(5) + 1;
 
@@ -37,6 +67,16 @@ class ProductTest {
         assertThatThrownBy(() -> createProductWithTitle(title))
             .isInstanceOf(BaseException.class)
             .hasMessageContaining("작품명은 최대");
+    }
+
+    @DisplayName("작품 카테고리가 공백이면 예외를 던진다")
+    @ValueSource(strings = {"", " "})
+    @ParameterizedTest
+    void throwExceptionWhenBlankCategory(String category) {
+        // when, then
+        assertThatThrownBy(() -> createProductWithCategory(category))
+            .isInstanceOf(BaseException.class)
+            .hasMessageContaining("작품 카테고리는 공백만 입력할 수 없습니다.");
     }
 
     @DisplayName("작품 카테고리의 길이가 20자를 초과하면 예외를 던진다")
@@ -51,6 +91,16 @@ class ProductTest {
             .hasMessageContaining("작품 카테고리는 최대");
     }
 
+    @DisplayName("작가명이 공백이면 예외를 던진다")
+    @ValueSource(strings = {"", " "})
+    @ParameterizedTest
+    void throwExceptionWhenBlankAuthorName(String authorName) {
+        // when, then
+        assertThatThrownBy(() -> createProductWithAuthorName(authorName))
+            .isInstanceOf(BaseException.class)
+            .hasMessageContaining("작가명은 공백만 입력할 수 없습니다.");
+    }
+
     @DisplayName("작가명의 길이가 20자를 초과하면 예외를 던진다")
     @Test
     void throwExceptionWhenExceedAuthorNameLength() {
@@ -61,6 +111,16 @@ class ProductTest {
         assertThatThrownBy(() -> createProductWithAuthorName(authorName))
             .isInstanceOf(BaseException.class)
             .hasMessageContaining("작가명은 최대");
+    }
+
+    @DisplayName("작품 설명이 공백이면 예외를 던진다")
+    @ValueSource(strings = {"", " "})
+    @ParameterizedTest
+    void throwExceptionWhenBlankDescription(String description) {
+        // when, then
+        assertThatThrownBy(() -> createProductWithDescription(description))
+            .isInstanceOf(BaseException.class)
+            .hasMessageContaining("작품 설명은 공백만 입력할 수 없습니다.");
     }
 
     @DisplayName("작품 설명의 길이가 1000자를 초과하면 예외를 던진다")

--- a/backend/forgather/src/test/java/com/forgather/fixture/ProductPhotoFixture.java
+++ b/backend/forgather/src/test/java/com/forgather/fixture/ProductPhotoFixture.java
@@ -8,14 +8,14 @@ public class ProductPhotoFixture {
 
     // TODO Reflection으로 대체
     public static ProductPhoto createProductPhotoSetId(long id) {
-        return new ProductPhoto(id, createProduct(), "originalName", "path", 1024, 1);
+        return new ProductPhoto(id, createProduct(), "originalName", "path", 1024L, 1);
     }
 
     public static ProductPhoto createProductPhotoWithOrder(int order) {
-        return new ProductPhoto(createProduct(), "originalName", "path", 1024, order);
+        return new ProductPhoto(createProduct(), "originalName", "path", 1024L, order);
     }
 
     public static ProductPhoto createProductPhoto() {
-        return new ProductPhoto(createProduct(), "originalName", "path", 1024, 1);
+        return new ProductPhoto(createProduct(), "originalName", "path", 1024L, 1);
     }
 }


### PR DESCRIPTION
## 연관된 이슈

- close #681

## 작업 내용

**작품 검증 추가**
작품명과 작품 소개는 필수 값으로 확정됨에 따라 검증 로직 및 테스트를 구현했습니다.
이에 맞게 DDL문도 수정해주었습니다.

---

**작품 사진 검증 추가**
작품 사진은 최대 10개까지만 등록 가능하기에 이에 맞는 검증 로직과 테스트를 구현했습니다.