### PR TITLE
feature: host main page API 연동 및 라우터 설정

### DIFF
--- a/frontend/src/components/@common/dropdown/Dropdown.styles.ts
+++ b/frontend/src/components/@common/dropdown/Dropdown.styles.ts
@@ -52,8 +52,7 @@ export const DropdownMenu = styled.ul`
 export const DropdownItem = styled.li<{ isSelected: boolean }>`
   padding: 10px 16px;
   ${({ theme }) => theme.typography.captionSmall};
-  color: ${({ theme, isSelected }) =>
-    isSelected ? theme.colors.white : theme.colors.gray06};
+  color: ${({ theme, isSelected }) => (isSelected ? theme.colors.white : theme.colors.gray06)};
   background-color: ${({ theme, isSelected }) =>
     isSelected ? theme.colors.gray06 : theme.colors.white};
   cursor: pointer;

--- a/frontend/src/components/layout/global/layout/Layout.tsx
+++ b/frontend/src/components/layout/global/layout/Layout.tsx
@@ -1,6 +1,10 @@
 import { Activity, useState } from 'react';
 import { IoSettingsSharp, IoShareOutline } from 'react-icons/io5';
-import { Outlet, useMatches } from 'react-router-dom';
+import { Outlet, useMatches, useNavigate, useParams } from 'react-router-dom';
+import {
+  createSpaceInfoRoute,
+  createSpaceMainRoute,
+} from '../../../../constants/routes';
 import type { AppRouteObject } from '../../../../types/route.type';
 import Header from '../../../@common/header/Header';
 import SpaceShareModal from '../../../specific/modal/spaceShareModal/SpaceShareModal';
@@ -8,6 +12,9 @@ import * as S from './Layout.styles';
 
 const Layout = () => {
   const [isShareModalOpen, setIsShareModalOpen] = useState(false);
+  const navigate = useNavigate();
+  const { spaceCode } = useParams();
+
   const openShareModal = () => {
     setIsShareModalOpen(true);
   };
@@ -22,7 +29,7 @@ const Layout = () => {
     },
     settings: {
       icon: <IoSettingsSharp />,
-      onClick: () => console.log('Settings clicked'),
+      onClick: () => navigate(createSpaceInfoRoute(spaceCode ?? '')),
     },
   };
 
@@ -37,7 +44,11 @@ const Layout = () => {
   return (
     <>
       <Activity mode={isNoHeader ? 'hidden' : 'visible'}>
-        <Header mode={isDarkPage ? 'dark' : 'light'} icons={matchedIcons} />
+        <Header
+          mode={isDarkPage ? 'dark' : 'light'}
+          icons={matchedIcons}
+          onLogoClick={() => navigate(createSpaceMainRoute(spaceCode ?? ''))}
+        />
       </Activity>
       <S.Container $isDarkPage={isDarkPage}>
         <SpaceShareModal isOpen={isShareModalOpen} onClose={closeShareModal} />

--- a/frontend/src/constants/routes.ts
+++ b/frontend/src/constants/routes.ts
@@ -1,6 +1,5 @@
 export const ROUTES = {
   HOST: {
-    MAIN: '/host/main',
     MY_PAGE: '/host/my-page',
     WORK_DETAIL: '/host/work-detail',
     WORK_FORM: '/host/work-form',
@@ -9,6 +8,10 @@ export const ROUTES = {
     MAIN: '/guest/main',
     WORK_DETAIL: '/guest/work-detail',
   },
+};
+
+export const createSpaceMainRoute = (spaceCode: string) => {
+  return `/host/${spaceCode}/main`;
 };
 
 export const createSpaceInfoRoute = (spaceCode: string) => {

--- a/frontend/src/hooks/domain/space/useSpaceDelete.ts
+++ b/frontend/src/hooks/domain/space/useSpaceDelete.ts
@@ -2,7 +2,6 @@ import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { spaceService } from '../../../apis/services/space/space.service';
 import { createSpaceMainRoute } from '../../../constants/routes';
-import { mockSpaceCode } from '../../../pages/mockData';
 import { useToast } from '../../@common/useToast';
 
 interface UseSpaceDeleteProps {
@@ -18,7 +17,7 @@ const useSpaceDelete = ({
   const navigate = useNavigate();
 
   const { mutate: deleteSpace, isPending } = useMutation({
-    mutationFn: () => spaceService.deleteSpace(mockSpaceCode),
+    mutationFn: () => spaceService.deleteSpace(spaceCode),
 
     onSuccess: (res) => {
       closeDeleteModal();

--- a/frontend/src/hooks/domain/space/useSpaceDelete.ts
+++ b/frontend/src/hooks/domain/space/useSpaceDelete.ts
@@ -1,15 +1,19 @@
 import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { spaceService } from '../../../apis/services/space/space.service';
-import { ROUTES } from '../../../constants/routes';
+import { createSpaceMainRoute } from '../../../constants/routes';
 import { mockSpaceCode } from '../../../pages/mockData';
 import { useToast } from '../../@common/useToast';
 
 interface UseSpaceDeleteProps {
+  spaceCode: string;
   closeDeleteModal: () => void;
 }
 
-const useSpaceDelete = ({ closeDeleteModal }: UseSpaceDeleteProps) => {
+const useSpaceDelete = ({
+  closeDeleteModal,
+  spaceCode,
+}: UseSpaceDeleteProps) => {
   const { showToast } = useToast();
   const navigate = useNavigate();
 
@@ -21,7 +25,7 @@ const useSpaceDelete = ({ closeDeleteModal }: UseSpaceDeleteProps) => {
 
       if (res.success) {
         showToast({ text: '스페이스가 삭제되었습니다.', type: 'info' });
-        navigate(ROUTES.HOST.MAIN);
+        navigate(createSpaceMainRoute(spaceCode));
       } else {
         showToast({ text: '스페이스 삭제에 실패했습니다.', type: 'error' });
       }

--- a/frontend/src/pages/host/mainPage/HostMainPage.tsx
+++ b/frontend/src/pages/host/mainPage/HostMainPage.tsx
@@ -1,22 +1,32 @@
 import { IoLogoInstagram } from 'react-icons/io5';
 import { MdEmail } from 'react-icons/md';
+import { useParams } from 'react-router-dom';
 import FooterLogo from '../../../@assets/logo/footer-logo.svg?react';
 import Button from '../../../components/@common/buttons/button/Button';
 import IconButton from '../../../components/@common/buttons/iconButton/IconButton';
+import Thumbnail from '../../../components/@common/thumbnail/Thumbnail';
+import useSpaceInfo from '../../../hooks/domain/space/useSpaceInfo';
 import { DividerLine } from '../../../styles/@common/DividerLine.styles';
 import { createInstagramUrl } from '../../../utils/createExternalLinks';
 import * as MainPageStyles from '../../MainPage.common.styles';
 import { mockData } from '../../mockData';
 
 const HostMainPage = () => {
+  const { spaceCode } = useParams();
+  const { spaceInfo } = useSpaceInfo({
+    spaceCode: spaceCode ?? '',
+  });
+
   return (
     <MainPageStyles.Wrapper>
       <MainPageStyles.ProfileContainer>
-        <MainPageStyles.Thumbnail src={mockData.thumbnail} />
+        <Thumbnail
+          src={`${import.meta.env.VITE_IMAGE_BASE_URL}${spaceInfo.spacePhoto.path}`}
+        />
         <MainPageStyles.InfoContainer>
-          <MainPageStyles.Name>{mockData.title}</MainPageStyles.Name>
+          <MainPageStyles.Name>{spaceInfo.name}</MainPageStyles.Name>
           <MainPageStyles.Introduction>
-            {mockData.introduction}
+            {spaceInfo.description}
           </MainPageStyles.Introduction>
         </MainPageStyles.InfoContainer>
       </MainPageStyles.ProfileContainer>

--- a/frontend/src/pages/host/spaceInfoPage/SpaceInfoPage.tsx
+++ b/frontend/src/pages/host/spaceInfoPage/SpaceInfoPage.tsx
@@ -22,7 +22,10 @@ const SpaceInfoPage = () => {
   };
 
   const { spaceCode } = useParams();
-  const { deleteSpace, isPending } = useSpaceDelete({ closeDeleteModal });
+  const { deleteSpace, isPending } = useSpaceDelete({
+    closeDeleteModal,
+    spaceCode: spaceCode ?? '',
+  });
   const { spaceInfo } = useSpaceInfo({
     spaceCode: spaceCode ?? '',
   });

--- a/frontend/src/pages/mockData.ts
+++ b/frontend/src/pages/mockData.ts
@@ -2,7 +2,7 @@ import img1 from '../@assets/workDetail_mock_1.png';
 import img2 from '../@assets/workDetail_mock_2.png';
 import img3 from '../@assets/workDetail_mock_3.png';
 
-export const mockSpaceCode = 'a6b9f9e496';
+export const mockSpaceCode = 'fb216ef6b1';
 
 export const mockData = {
   title: '2025 PKNU VCD',

--- a/frontend/src/router/router.tsx
+++ b/frontend/src/router/router.tsx
@@ -25,7 +25,7 @@ const routes: AppRouteObject[] = [
         path: 'host',
         children: [
           {
-            path: 'main',
+            path: ':spaceCode/main',
             element: <HostMainPage />,
             handle: {
               headerIcons: ['share', 'settings'],


### PR DESCRIPTION
## 연관된 이슈

- close #714

## 작업 내용
- 스페이스 메인 페이지 동적 라우팅 설정 (스페이스 코드 포함) 
<img width="339" height="52" alt="image" src="https://github.com/user-attachments/assets/2c49f4a0-7172-4455-b68c-128e4ba62bbf" />

- 스페이스 메인 페이지 "스페이스 정보 API 연동"
- 로고 클릭시 메인 페이지로 이동하도록 설정
- 삭제 시 mock space code가 아닌 파라미터에서 뽑아낸 space code 사용하도록 설정
- 삭제 후 스페이스 메인 페이지로 나가짐
  - 삭제 후에 이동할 페이지가 마땅치 않아 메인 페이지로 연결시켜둠, 스페이스 정보가 삭제된 이후라 메인페이지로 이동 후에 에러가 발생할 것
  -  추후 랜딩 페이지 등이 생성되면 그쪽으로 이동하도록 변경 필요