### PR TITLE
fix: 작품 저장/수정 시 path가 클라우드 스토리지의 path와 동일하도록 수정

### DIFF
--- a/backend/forgather/src/main/java/com/forgather/domain/product/dto/ProductResponse.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/product/dto/ProductResponse.java
@@ -29,19 +29,19 @@ public record ProductResponse(
             {
                 "id": 1,
                 "originalName": "chair1.jpg",
-                "path": "1234567890/abc.jpg",
+                "path": "photogather/spaces/1234567890/product/abc.jpg",
                 "order": 1
             },
             {
                 "id": 2,
                 "originalName": "chair2.jpg",
-                "path": "1234567890/def.jpg",
+                "path": "photogather/spaces/1234567890/product/1234567890/def.jpg",
                 "order": 2
             },
             {
                 "id": 3,
                 "originalName": "chair3.jpg",
-                "path": "1234567890/ghi.jpg",
+                "path": "photogather/spaces/1234567890/product/1234567890/ghi.jpg",
                 "order": 3
             }
         ]

--- a/backend/forgather/src/main/java/com/forgather/domain/product/dto/RegisterProductPhotoRequest.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/product/dto/RegisterProductPhotoRequest.java
@@ -5,12 +5,12 @@ import com.forgather.domain.product.model.ProductPhoto;
 
 public record RegisterProductPhotoRequest(
     String originalName,
-    String path,
+    String uploadFileName,
     Long capacity
 ) {
 
     // ProductPhotos.add()가 정렬 순서를 자동 할당하므로, 초기값(1)은 의미 없음
-    public ProductPhoto toEntity(Product product) {
+    public ProductPhoto toEntity(Product product, String path) {
         return new ProductPhoto(product, originalName, path, capacity, 1);
     }
 }

--- a/backend/forgather/src/main/java/com/forgather/domain/product/dto/RegisterProductRequest.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/product/dto/RegisterProductRequest.java
@@ -24,17 +24,17 @@ public record RegisterProductRequest(
         [
             {
                 "originalName": "chair1.jpg",
-                "path": "1234567890/abc.jpg",
+                "uploadFileName": "abc.jpg",
                 "capacity": 1024
             },
             {
                 "originalName": "chair2.jpg",
-                "path": "1234567890/def.jpg",
+                "uploadFileName": "def.jpg",
                 "capacity": 2048
             },
             {
                 "originalName": "chair3.jpg",
-                "path": "1234567890/ghi.jpg",
+                "uploadFileName": "ghi.jpg",
                 "capacity": 4096
             }
         ]

--- a/backend/forgather/src/main/java/com/forgather/domain/product/dto/UpdateProductRequest.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/product/dto/UpdateProductRequest.java
@@ -25,17 +25,17 @@ public record UpdateProductRequest(
         [
             {
                 "originalName": "chair4.jpg",
-                "path": "1234567890/jkl.jpg",
+                "uploadFileName": "jkl.jpg",
                 "capacity": 1024
             },
             {
                 "originalName": "chair5.jpg",
-                "path": "1234567890/mno.jpg",
+                "uploadFileName": "mno.jpg",
                 "capacity": 2048
             },
             {
                 "originalName": "chair6.jpg",
-                "path": "1234567890/pqr.jpg",
+                "uploadFileName": "pqr.jpg",
                 "capacity": 4096
             }
         ]

--- a/backend/forgather/src/main/java/com/forgather/domain/product/service/ProductService.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/product/service/ProductService.java
@@ -1,5 +1,9 @@
 package com.forgather.domain.product.service;
 
+import static com.forgather.domain.upload.domain.FilePathGenerator.generateContentsFilePath;
+import static com.forgather.domain.upload.domain.UploadCategory.PRODUCT;
+
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -44,12 +48,15 @@ public class ProductService {
         Product product = productRepository.save(request.toEntity(space));
 
         ProductPhotos productPhotos = new ProductPhotos();
-        productPhotos.add(
-            request.photos()
-                .stream()
-                .map(photoRequest -> photoRequest.toEntity(product))
-                .toList()
-        );
+        for (var photoRequest : request.photos()) {
+            String path = generateContentsFilePath(
+                contentsStorage.getRootDirectory(),
+                spaceCode,
+                PRODUCT,
+                photoRequest.uploadFileName()
+            );
+            productPhotos.add(photoRequest.toEntity(product, path));
+        }
         productPhotoRepository.saveAll(productPhotos.getAll());
         return new ProductResponse(product, productPhotos.getAll());
     }
@@ -73,10 +80,16 @@ public class ProductService {
         productPhotoRepository.deleteAll(deletedPhotos);
 
         // 새로운 사진 추가 및 db 저장
-        List<ProductPhoto> newPhotos = request.newPhotos()
-            .stream()
-            .map(photo -> photo.toEntity(product))
-            .toList();
+        List<ProductPhoto> newPhotos = new ArrayList<>();
+        for (var photoRequest : request.newPhotos()) {
+            String path = generateContentsFilePath(
+                contentsStorage.getRootDirectory(),
+                spaceCode,
+                PRODUCT,
+                photoRequest.uploadFileName()
+            );
+            newPhotos.add(photoRequest.toEntity(product, path));
+        }
         photos.add(newPhotos);
         productPhotoRepository.saveAll(newPhotos);
 

--- a/backend/forgather/src/main/java/com/forgather/domain/space/model/Photo.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/space/model/Photo.java
@@ -23,7 +23,7 @@ public abstract class Photo extends BaseTimeEntity {
     @Column(name = "original_name", nullable = false)
     protected String originalName;
 
-    @Column(name = "path", nullable = false)
+    @Column(name = "uploadFileName", nullable = false)
     protected String path;
 
     @Column(name = "capacity", nullable = false)

--- a/backend/forgather/src/test/java/com/forgather/acceptance/ProductAcceptanceTest.java
+++ b/backend/forgather/src/test/java/com/forgather/acceptance/ProductAcceptanceTest.java
@@ -21,7 +21,6 @@ import com.forgather.domain.product.dto.RegisterProductRequest;
 import com.forgather.domain.product.dto.UpdateProductRequest;
 import com.forgather.domain.product.repository.ProductRepository;
 import com.forgather.domain.space.model.Space;
-import com.forgather.domain.space.repository.HostRepository;
 import com.forgather.domain.space.repository.SpaceRepository;
 import com.forgather.domain.upload.AwsS3Cloud;
 import com.forgather.fixture.SpaceFixture;
@@ -35,9 +34,6 @@ class ProductAcceptanceTest extends AcceptanceTest {
 
     @Autowired
     private MockMvc mockMvc;
-
-    @Autowired
-    private HostRepository hostRepository;
 
     @Autowired
     private SpaceRepository spaceRepository;
@@ -57,9 +53,9 @@ class ProductAcceptanceTest extends AcceptanceTest {
         "authorName",
         "description",
         List.of(
-            new RegisterProductPhotoRequest("photo1", "path1", 1024L),
-            new RegisterProductPhotoRequest("photo2", "path2", 2048L),
-            new RegisterProductPhotoRequest("photo3", "path3", 4096L)
+            new RegisterProductPhotoRequest("photo1", "file1.png", 1024L),
+            new RegisterProductPhotoRequest("photo2", "file2.png", 2048L),
+            new RegisterProductPhotoRequest("photo3", "file3.png", 4096L)
         )
     );
 
@@ -95,10 +91,13 @@ class ProductAcceptanceTest extends AcceptanceTest {
             () -> assertThat(result.authorName()).isEqualTo(registerResponse.authorName()),
             () -> assertThat(result.description()).isEqualTo(registerResponse.description()),
             () -> assertThat(result.photos().get(0).originalName()).isEqualTo("photo1"),
+            () -> assertThat(result.photos().get(0).path()).isEqualTo("null/spaces/1234567890/product/file1.png"),
             () -> assertThat(result.photos().get(0).order()).isEqualTo(1),
             () -> assertThat(result.photos().get(1).originalName()).isEqualTo("photo2"),
+            () -> assertThat(result.photos().get(1).path()).isEqualTo("null/spaces/1234567890/product/file2.png"),
             () -> assertThat(result.photos().get(1).order()).isEqualTo(2),
             () -> assertThat(result.photos().get(2).originalName()).isEqualTo("photo3"),
+            () -> assertThat(result.photos().get(2).path()).isEqualTo("null/spaces/1234567890/product/file3.png"),
             () -> assertThat(result.photos().get(2).order()).isEqualTo(3)
         );
     }
@@ -140,10 +139,13 @@ class ProductAcceptanceTest extends AcceptanceTest {
             () -> assertThat(response.authorName()).isEqualTo(registerRequest.authorName()),
             () -> assertThat(response.description()).isEqualTo(registerRequest.description()),
             () -> assertThat(response.photos().get(0).originalName()).isEqualTo("photo1"),
+            () -> assertThat(response.photos().get(0).path()).isEqualTo("null/spaces/1234567890/product/file1.png"),
             () -> assertThat(response.photos().get(0).order()).isEqualTo(1),
             () -> assertThat(response.photos().get(1).originalName()).isEqualTo("photo2"),
+            () -> assertThat(response.photos().get(1).path()).isEqualTo("null/spaces/1234567890/product/file2.png"),
             () -> assertThat(response.photos().get(1).order()).isEqualTo(2),
             () -> assertThat(response.photos().get(2).originalName()).isEqualTo("photo3"),
+            () -> assertThat(response.photos().get(2).path()).isEqualTo("null/spaces/1234567890/product/file3.png"),
             () -> assertThat(response.photos().get(2).order()).isEqualTo(3)
         );
     }
@@ -181,8 +183,8 @@ class ProductAcceptanceTest extends AcceptanceTest {
             "description",
             List.of(2L),
             List.of(
-                new RegisterProductPhotoRequest("photo4", "path4", 1024L),
-                new RegisterProductPhotoRequest("photo5", "path5", 1024L)
+                new RegisterProductPhotoRequest("photo4", "file4.png", 1024L),
+                new RegisterProductPhotoRequest("photo5", "file5.png", 1024L)
             )
         );
 
@@ -206,12 +208,16 @@ class ProductAcceptanceTest extends AcceptanceTest {
             () -> assertThat(result.authorName()).isEqualTo(registerResponse.authorName()),
             () -> assertThat(result.description()).isEqualTo(request.description()),
             () -> assertThat(result.photos().get(0).originalName()).isEqualTo("photo1"),
+            () -> assertThat(result.photos().get(0).path()).isEqualTo("null/spaces/1234567890/product/file1.png"),
             () -> assertThat(result.photos().get(0).order()).isEqualTo(1),
             () -> assertThat(result.photos().get(1).originalName()).isEqualTo("photo3"),
+            () -> assertThat(result.photos().get(1).path()).isEqualTo("null/spaces/1234567890/product/file3.png"),
             () -> assertThat(result.photos().get(1).order()).isEqualTo(2),
             () -> assertThat(result.photos().get(2).originalName()).isEqualTo("photo4"),
+            () -> assertThat(result.photos().get(2).path()).isEqualTo("null/spaces/1234567890/product/file4.png"),
             () -> assertThat(result.photos().get(2).order()).isEqualTo(3),
             () -> assertThat(result.photos().get(3).originalName()).isEqualTo("photo5"),
+            () -> assertThat(result.photos().get(3).path()).isEqualTo("null/spaces/1234567890/product/file5.png"),
             () -> assertThat(result.photos().get(3).order()).isEqualTo(4)
         );
     }

--- a/backend/forgather/src/test/java/com/forgather/domain/product/model/ProductPhotoTest.java
+++ b/backend/forgather/src/test/java/com/forgather/domain/product/model/ProductPhotoTest.java
@@ -17,7 +17,7 @@ class ProductPhotoTest {
     @Test
     void throwExceptionWhenNoProduct() {
         // when, then
-        assertThatThrownBy(() -> new ProductPhoto(null, "originalName", "path", 1024L, 1))
+        assertThatThrownBy(() -> new ProductPhoto(null, "originalName", "uploadFileName", 1024L, 1))
             .isInstanceOf(BaseException.class)
             .hasMessageContaining("작품 정보는 필수입니다.");
     }
@@ -27,7 +27,7 @@ class ProductPhotoTest {
     @ParameterizedTest
     void throwExceptionWhenOrderIsInvalid(int order) {
         // when, then
-        assertThatThrownBy(() -> new ProductPhoto(createProduct(), "originalName", "path", 1024L, order))
+        assertThatThrownBy(() -> new ProductPhoto(createProduct(), "originalName", "uploadFileName", 1024L, order))
             .isInstanceOf(BaseException.class)
             .hasMessageContaining("작품 사진의 정렬 순서는 1 이상, 10 이하여야 합니다.");
     }
@@ -36,7 +36,7 @@ class ProductPhotoTest {
     @Test
     void changeOrder() {
         // given
-        ProductPhoto productPhoto = new ProductPhoto(createProduct(), "originalName", "path", 1024L, 3);
+        ProductPhoto productPhoto = new ProductPhoto(createProduct(), "originalName", "uploadFileName", 1024L, 3);
 
         // when
         productPhoto.changeOrder(1);
@@ -50,7 +50,7 @@ class ProductPhotoTest {
     @ParameterizedTest
     void throwExceptionWhenChangeOrderIsInvalid(int order) {
         // given
-        ProductPhoto productPhoto = new ProductPhoto(createProduct(), "originalName", "path", 1024L, 1);
+        ProductPhoto productPhoto = new ProductPhoto(createProduct(), "originalName", "uploadFileName", 1024L, 1);
 
         // when, then
         assertThatThrownBy(() -> productPhoto.changeOrder(order))

--- a/backend/forgather/src/test/java/com/forgather/fixture/ProductPhotoFixture.java
+++ b/backend/forgather/src/test/java/com/forgather/fixture/ProductPhotoFixture.java
@@ -8,14 +8,14 @@ public class ProductPhotoFixture {
 
     // TODO Reflection으로 대체
     public static ProductPhoto createProductPhotoSetId(long id) {
-        return new ProductPhoto(id, createProduct(), "originalName", "path", 1024L, 1);
+        return new ProductPhoto(id, createProduct(), "originalName", "uploadFileName", 1024L, 1);
     }
 
     public static ProductPhoto createProductPhotoWithOrder(int order) {
-        return new ProductPhoto(createProduct(), "originalName", "path", 1024L, order);
+        return new ProductPhoto(createProduct(), "originalName", "uploadFileName", 1024L, order);
     }
 
     public static ProductPhoto createProductPhoto() {
-        return new ProductPhoto(createProduct(), "originalName", "path", 1024L, 1);
+        return new ProductPhoto(createProduct(), "originalName", "uploadFileName", 1024L, 1);
     }
 }


### PR DESCRIPTION
## 작업 내용
기존 : 클라이언트로부터 path(업로드 파일명)을 받아 그대로 db에 path로 저장. 사진 조회 시 저장한 업로드 파일명을 내려줌.
수정 : 클라이언트로부터 uploadFileName을 받아 저장된 path로 변환하고, db에 저장. 사진 조회 시 저장 path를 내려줌.