### PR TITLE
feat: 작품 카테고리와 작가명 미입력 시 빈 문자열 저장

### DIFF
--- a/backend/forgather/src/main/java/com/forgather/domain/product/controller/ProductController.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/product/controller/ProductController.java
@@ -60,7 +60,7 @@ public class ProductController {
      *  검증 걸릴 시 업로드 사진 삭제
      * dto단 검증
      */
-    @Operation(summary = "작품 수정")
+    @Operation(summary = "작품 수정", description = "변경 사항이 없는 데이터는 json에 포함하지 않거나 null로 요청한다.")
     @PatchMapping
     public ResponseEntity<ProductResponse> update(
         @PathVariable(value = "spaceCode") String spaceCode,

--- a/backend/forgather/src/main/java/com/forgather/domain/product/model/Product.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/product/model/Product.java
@@ -129,18 +129,12 @@ public class Product extends BaseTimeEntity {
     }
 
     private void validateCategory(String category) {
-        if (category == null) {
-            return;
-        }
         if (category.length() > 20) {
             throw new BaseException("작품 카테고리는 최대 20자까지 입력 가능합니다.");
         }
     }
 
     private void validateAuthorName(String authorName) {
-        if (authorName == null) {
-            return;
-        }
         if (authorName.length() > 20) {
             throw new BaseException("작가명은 최대 20자까지 입력 가능합니다.");
         }

--- a/backend/forgather/src/main/java/com/forgather/domain/product/model/Product.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/product/model/Product.java
@@ -30,13 +30,13 @@ public class Product extends BaseTimeEntity {
     @JoinColumn(name = "space_id", nullable = false)
     private Space space;
 
-    @Column(name = "title",  nullable = false)
+    @Column(name = "title", nullable = false)
     private String title;
 
-    @Column(name = "category")
+    @Column(name = "category", nullable = false)
     private String category;
 
-    @Column(name = "author_name")
+    @Column(name = "author_name", nullable = false)
     private String authorName;
 
     @Column(name = "description", nullable = false)
@@ -45,36 +45,48 @@ public class Product extends BaseTimeEntity {
     /**
      * 작품을 생성합니다.
      *
-     * @param space 작품이 속한 스페이스 (필수)
-     * @param title 작품명 (필수, 최대 50자)
-     * @param category 카테고리 (선택, 최대 20자)
-     * @param authorName 작가명 (선택, 최대 20자)
+     * @param space       작품이 속한 스페이스 (필수)
+     * @param title       작품명 (필수, 최대 50자)
+     * @param category    카테고리 (필수, 최대 20자)
+     * @param authorName  작가명 (필수, 최대 20자)
      * @param description 작품 설명 (필수, 최대 1000자)
      * @throws BaseNullPointerException 필수 필드가 null인 경우
-     * @throws BaseException 필드 값이 유효하지 않은 경우
+     * @throws BaseException            필드 값이 유효하지 않은 경우
      */
     public Product(Space space, String title, String category, String authorName, String description) {
-        validateRequiredFields(space, title, description);
+        validateRequiredFields(space, title, category, authorName, description);
         validateTitle(title);
         validateCategory(category);
         validateAuthorName(authorName);
         validateDescription(description);
         this.space = space;
         this.title = title;
-        this.category = category;
-        this.authorName = authorName;
+        this.category = convertBlankToEmptyString(category);
+        this.authorName = convertBlankToEmptyString(authorName);
         this.description = description;
     }
 
-    private void validateRequiredFields(Space space, String title, String description) {
+    private void validateRequiredFields(
+        Space space,
+        String title,
+        String category,
+        String authorName,
+        String description
+    ) {
         if (space == null) {
-            throw new BaseNullPointerException("스페이스는 필수입니다.");
+            throw new BaseNullPointerException("스페이스는 null일 수 없습니다.");
         }
         if (title == null) {
-            throw new BaseNullPointerException("작품명은 필수입니다.");
+            throw new BaseNullPointerException("작품명은 null일 수 없습니다.");
+        }
+        if (category == null) {
+            throw new BaseNullPointerException("작품 카테고리는 null일 수 없습니다.");
+        }
+        if (authorName == null) {
+            throw new BaseNullPointerException("작가명은 null일 수 없습니다.");
         }
         if (description == null) {
-            throw new BaseNullPointerException("작품 설명은 필수입니다.");
+            throw new BaseNullPointerException("작품 설명은 null일 수 없습니다.");
         }
     }
 
@@ -82,9 +94,9 @@ public class Product extends BaseTimeEntity {
      * 작품 정보를 부분 업데이트합니다.
      * null인 필드는 업데이트하지 않습니다.
      *
-     * @param title 작품명 (선택)
-     * @param category 카테고리 (선택)
-     * @param authorName 작가명 (선택)
+     * @param title       작품명 (선택)
+     * @param category    카테고리 (선택)
+     * @param authorName  작가명 (선택)
      * @param description 작품 설명 (선택)
      * @throws BaseException 필드 값이 유효하지 않은 경우
      */
@@ -95,11 +107,11 @@ public class Product extends BaseTimeEntity {
         }
         if (category != null) {
             validateCategory(category);
-            this.category = category;
+            this.category = convertBlankToEmptyString(category);
         }
         if (authorName != null) {
             validateAuthorName(authorName);
-            this.authorName = authorName;
+            this.authorName = convertBlankToEmptyString(authorName);
         }
         if (description != null) {
             validateDescription(description);
@@ -120,9 +132,6 @@ public class Product extends BaseTimeEntity {
         if (category == null) {
             return;
         }
-        if (category.isBlank()) {
-            throw new BaseException("작품 카테고리는 공백만 입력할 수 없습니다.");
-        }
         if (category.length() > 20) {
             throw new BaseException("작품 카테고리는 최대 20자까지 입력 가능합니다.");
         }
@@ -131,9 +140,6 @@ public class Product extends BaseTimeEntity {
     private void validateAuthorName(String authorName) {
         if (authorName == null) {
             return;
-        }
-        if (authorName.isBlank()) {
-            throw new BaseException("작가명은 공백만 입력할 수 없습니다.");
         }
         if (authorName.length() > 20) {
             throw new BaseException("작가명은 최대 20자까지 입력 가능합니다.");
@@ -147,5 +153,12 @@ public class Product extends BaseTimeEntity {
         if (description.length() > 1000) {
             throw new BaseException("작품 설명은 최대 1000자까지 입력 가능합니다.");
         }
+    }
+
+    private String convertBlankToEmptyString(String string) {
+        if (string.isBlank()) {
+            return "";
+        }
+        return string;
     }
 }

--- a/backend/forgather/src/test/java/com/forgather/domain/product/model/ProductTest.java
+++ b/backend/forgather/src/test/java/com/forgather/domain/product/model/ProductTest.java
@@ -26,7 +26,7 @@ class ProductTest {
         // when, then
         assertThatThrownBy(() -> createProductWithSpace(null))
             .isInstanceOf(BaseNullPointerException.class)
-            .hasMessageContaining("스페이스는 필수입니다.");
+            .hasMessageContaining("스페이스는 null일 수 없습니다.");
     }
 
     @DisplayName("작품명이 null이면 예외를 던진다")
@@ -35,7 +35,25 @@ class ProductTest {
         // when, then
         assertThatThrownBy(() -> createProductWithTitle(null))
             .isInstanceOf(BaseNullPointerException.class)
-            .hasMessageContaining("작품명은 필수입니다.");
+            .hasMessageContaining("작품명은 null일 수 없습니다.");
+    }
+
+    @DisplayName("작품 카테고리가 null이면 예외를 던진다")
+    @Test
+    void throwExceptionWhenCategoryIsNull() {
+        // when, then
+        assertThatThrownBy(() -> createProductWithCategory(null))
+            .isInstanceOf(BaseNullPointerException.class)
+            .hasMessageContaining("작품 카테고리는 null일 수 없습니다.");
+    }
+
+    @DisplayName("작가명이 null이면 예외를 던진다")
+    @Test
+    void throwExceptionWhenAuthorNameIsNull() {
+        // when, then
+        assertThatThrownBy(() -> createProductWithAuthorName(null))
+            .isInstanceOf(BaseNullPointerException.class)
+            .hasMessageContaining("작가명은 null일 수 없습니다.");
     }
 
     @DisplayName("작품 설명이 null이면 예외를 던진다")
@@ -44,7 +62,7 @@ class ProductTest {
         // when, then
         assertThatThrownBy(() -> createProductWithDescription(null))
             .isInstanceOf(BaseNullPointerException.class)
-            .hasMessageContaining("작품 설명은 필수입니다.");
+            .hasMessageContaining("작품 설명은 null일 수 없습니다.");
     }
 
     @DisplayName("작품명이 공백이면 예외를 던진다")
@@ -69,14 +87,15 @@ class ProductTest {
             .hasMessageContaining("작품명은 최대");
     }
 
-    @DisplayName("작품 카테고리가 공백이면 예외를 던진다")
+    @DisplayName("작품 카테고리는 공백일 수 있다")
     @ValueSource(strings = {"", " "})
     @ParameterizedTest
-    void throwExceptionWhenBlankCategory(String category) {
-        // when, then
-        assertThatThrownBy(() -> createProductWithCategory(category))
-            .isInstanceOf(BaseException.class)
-            .hasMessageContaining("작품 카테고리는 공백만 입력할 수 없습니다.");
+    void categoryCanBeBlank(String category) {
+        // when
+        Product result = createProductWithCategory(category);
+
+        // then
+        assertThat(result.getCategory()).isEqualTo("");
     }
 
     @DisplayName("작품 카테고리의 길이가 20자를 초과하면 예외를 던진다")
@@ -91,14 +110,15 @@ class ProductTest {
             .hasMessageContaining("작품 카테고리는 최대");
     }
 
-    @DisplayName("작가명이 공백이면 예외를 던진다")
+    @DisplayName("작가명은 공백일 수 있다")
     @ValueSource(strings = {"", " "})
     @ParameterizedTest
-    void throwExceptionWhenBlankAuthorName(String authorName) {
-        // when, then
-        assertThatThrownBy(() -> createProductWithAuthorName(authorName))
-            .isInstanceOf(BaseException.class)
-            .hasMessageContaining("작가명은 공백만 입력할 수 없습니다.");
+    void authorNameCanBeBlank(String authorName) {
+        // when
+        Product result = createProductWithAuthorName(authorName);
+
+        // then
+        assertThat(result.getAuthorName()).isEqualTo("");
     }
 
     @DisplayName("작가명의 길이가 20자를 초과하면 예외를 던진다")
@@ -135,9 +155,9 @@ class ProductTest {
             .hasMessageContaining("작품 설명은 최대");
     }
 
-    @DisplayName("작품 조건부 수정")
+    @DisplayName("작품 조건부 수정-1")
     @Test
-    void update() {
+    void update1() {
         // given
         String title = "title";
         String category = "category";
@@ -153,6 +173,74 @@ class ProductTest {
             () -> assertThat(product.getTitle()).isEqualTo("foovar1"),
             () -> assertThat(product.getCategory()).isEqualTo(category),
             () -> assertThat(product.getAuthorName()).isEqualTo(authorName),
+            () -> assertThat(product.getDescription()).isEqualTo("foovar2")
+        );
+    }
+
+    @DisplayName("작품 조건부 수정-2")
+    @Test
+    void update2() {
+        // given
+        String title = "title";
+        String category = "category";
+        String authorName = "authorName";
+        String description = "description";
+        Product product = createProductWithTitleCategoryAuthorNameDescription(title, category, authorName, description);
+
+        // when
+        product.update(null, "foovar1", "foovar2", null);
+
+        // then
+        assertAll(
+            () -> assertThat(product.getTitle()).isEqualTo(title),
+            () -> assertThat(product.getCategory()).isEqualTo("foovar1"),
+            () -> assertThat(product.getAuthorName()).isEqualTo("foovar2"),
+            () -> assertThat(product.getDescription()).isEqualTo(description)
+        );
+    }
+
+    @DisplayName("작품 카테고리를 빈 문자열로 수정한다")
+    @ValueSource(strings = {"", " "})
+    @ParameterizedTest
+    void canUpdateCategoryToBlank(String updateCategory) {
+        // given
+        String title = "title";
+        String category = "category";
+        String authorName = "authorName";
+        String description = "description";
+        Product product = createProductWithTitleCategoryAuthorNameDescription(title, category, authorName, description);
+
+        // when
+        product.update("foovar1", updateCategory, null, "foovar2");
+
+        // then
+        assertAll(
+            () -> assertThat(product.getTitle()).isEqualTo("foovar1"),
+            () -> assertThat(product.getCategory()).isEqualTo(""),
+            () -> assertThat(product.getAuthorName()).isEqualTo(authorName),
+            () -> assertThat(product.getDescription()).isEqualTo("foovar2")
+        );
+    }
+
+    @DisplayName("작가명을 빈 문자열로 수정한다")
+    @ValueSource(strings = {"", " "})
+    @ParameterizedTest
+    void updateAuthorNameToBlank(String updateAuthorName) {
+        // given
+        String title = "title";
+        String category = "category";
+        String authorName = "authorName";
+        String description = "description";
+        Product product = createProductWithTitleCategoryAuthorNameDescription(title, category, authorName, description);
+
+        // when
+        product.update("foovar1", null, updateAuthorName, "foovar2");
+
+        // then
+        assertAll(
+            () -> assertThat(product.getTitle()).isEqualTo("foovar1"),
+            () -> assertThat(product.getCategory()).isEqualTo(category),
+            () -> assertThat(product.getAuthorName()).isEqualTo(""),
             () -> assertThat(product.getDescription()).isEqualTo("foovar2")
         );
     }


### PR DESCRIPTION
## 연관된 이슈

- close #720 

## 작업 내용

### not null
category(작품 카테고리)와 authorName(작가명)은 선택 값으로 사용자가 입력을 안할 수 있습니다.
기존에는 미입력 시 null로 저장했지만, 논의 후 수정 로직과 정말 필요한 경우에만 null을 저장하자는 결정이 났습니다.
따라서 category와 authorName에 대한 로직을 not null 조건에 맞게끔 수정했습니다.

하지만 여전히 필수 입력 값은 아니기에 빈 문자열 혹은 공백 문자열 입력을 허용하고
빈 문자열로 저장하게끔 구현했습니다.

그 외 필수 입력 값인 title(작품명), description(작품 설명)은 여전히 빈 문자열과 공백 문자열 입력과 저장을 허용하지 않습니다.