### PR TITLE
fix: QA 사항 반영 및 스페이스 생성 API 요청 오류 해결

### DIFF
--- a/frontend/src/components/@common/modal/Modal.tsx
+++ b/frontend/src/components/@common/modal/Modal.tsx
@@ -49,7 +49,9 @@ const Content = ({
 
   return (
     <S.ModalContent $size={size} {...props}>
-      {hasTopCloseButton && <S.CloseButton onClick={() => onClose()} />}
+      {hasTopCloseButton && (
+        <S.CloseButton size={20} onClick={() => onClose()} />
+      )}
       {children}
     </S.ModalContent>
   );

--- a/frontend/src/components/layout/global/layout/Layout.tsx
+++ b/frontend/src/components/layout/global/layout/Layout.tsx
@@ -1,10 +1,7 @@
 import { Activity, useState } from 'react';
 import { IoSettingsSharp, IoShareOutline } from 'react-icons/io5';
 import { Outlet, useMatches, useNavigate, useParams } from 'react-router-dom';
-import {
-  createSpaceInfoRoute,
-  createSpaceMainRoute,
-} from '../../../../constants/routes';
+import { createSpaceInfoRoute, ROUTES } from '../../../../constants/routes';
 import type { AppRouteObject } from '../../../../types/route.type';
 import Header from '../../../@common/header/Header';
 import SpaceShareModal from '../../../specific/modal/spaceShareModal/SpaceShareModal';
@@ -47,7 +44,7 @@ const Layout = () => {
         <Header
           mode={isDarkPage ? 'dark' : 'light'}
           icons={matchedIcons}
-          onLogoClick={() => navigate(createSpaceMainRoute(spaceCode ?? ''))}
+          onLogoClick={() => navigate(ROUTES.MAIN)}
         />
       </Activity>
       <S.Container $isDarkPage={isDarkPage}>

--- a/frontend/src/constants/routes.ts
+++ b/frontend/src/constants/routes.ts
@@ -1,4 +1,5 @@
 export const ROUTES = {
+  MAIN: '/',
   HOST: {
     MY_PAGE: '/host/my-page',
     CREATE_SPACE: '/host/create-space',

--- a/frontend/src/hooks/domain/space/useSpaceCreate.ts
+++ b/frontend/src/hooks/domain/space/useSpaceCreate.ts
@@ -43,7 +43,14 @@ export const useSpaceCreate = () => {
   });
 
   const createSpace = async (createFunnelForm: CreateFunnelForm) => {
-    const { profileImage, ...createFunnelRequest } = createFunnelForm;
+    const { profileImage, ...rest } = createFunnelForm;
+    const createFunnelRequest: Partial<SpaceInfoFormData> = {
+      name: rest.name,
+      isPublic: rest.visibility === 'PUBLIC',
+      description: rest.description,
+      email: rest.email,
+      instagramUsername: rest.instagram,
+    };
 
     const formData = createFormData(
       createFunnelRequest,

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -8,7 +8,7 @@ const queryClient = new QueryClient();
 createRoot(document.getElementById('root')!).render(
   // <StrictMode>
   <QueryClientProvider client={queryClient}>
-    <App />,
+    <App />
   </QueryClientProvider>,
   // </StrictMode>,
 );

--- a/frontend/src/pages/host/spaceCreate/funnel/SpaceCreateFunnel.styles.ts
+++ b/frontend/src/pages/host/spaceCreate/funnel/SpaceCreateFunnel.styles.ts
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 
 export const Wrapper = styled.div`
   width: 100%;
-  height: ${({ theme }) => `calc(100dvh - ${parseInt(theme.layout.padding.topBottom, 10) * 2}px)`};
+  min-height: ${({ theme }) => `calc(100dvh - ${parseInt(theme.layout.padding.topBottom, 10) * 2}px)`};
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -15,4 +15,6 @@ export const TopContainer = styled.div`
 
 export const ContentContainer = styled.div`
   flex-grow: 1;
+  display: flex;
+  flex-direction: column;
 `;

--- a/frontend/src/pages/host/spaceCreate/funnel/funnelBasePage/FunnelBasePage.styles.ts
+++ b/frontend/src/pages/host/spaceCreate/funnel/funnelBasePage/FunnelBasePage.styles.ts
@@ -12,6 +12,8 @@ export const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  flex-grow: 1;
+  gap: 32px;
 `;
 
 export const TopContainer = styled.div`


### PR DESCRIPTION
## 연관된 이슈

- close #731 

## 작업 내용

### QA 사항 해결

- Layout 아래 쉼표 제거 https://github.com/woowacourse-teams/2025-PhotoGather/commit/3bad7e23c2d42f7d7a5dcdbf6a497a881bccbd11
- 모달 닫기 버튼 크기 증가 (16px -> 20px) https://github.com/woowacourse-teams/2025-PhotoGather/commit/bd2e1ccd098e92c4b12d6e6c49f6b3d596154f58
- 퍼널 내 정보확인 요소 간 gap 추가 https://github.com/woowacourse-teams/2025-PhotoGather/commit/edeeb0291f797bcf6eeefc9f173630943950cda6

### 스페이스 생성 API 요청 오류

- 퍼널에서 수집한 Form 값을 가공하지 않고 그대로 API로 쏘는 문제가 있었음
```tsx
// 퍼널에서 수집하는 형태
export interface CreateFunnelForm {
  name: string;
  description: string;
  visibility: SpaceVisibility;
  profileImage: LocalFile[];
  email: string;
  instagram: string;
}
```
```tsx
// 실제 요청
export interface SpaceInfoFormData {
  name: string;
  description: string;
  isPublic: boolean;
  email: string;
  instagramUsername: string;
}
```
<img width="1100" height="330" alt="image" src="https://github.com/user-attachments/assets/d2d55a2b-c642-44e1-b379-cd7bac435572" />

- 가공 후 보내도록 오류 수정 https://github.com/woowacourse-teams/2025-PhotoGather/commit/7bcbf169f3eaa2739ba3af7510edded8ded439c4
- 왜 타입스크립트에서 잡지 못했는지 별도 문서화 예정

### 기타

- 로고를 눌렀을 시 메인화면('/')으로 가도록 연결, 따라서 현재는 데모페이지가 표시됨