### PR TITLE
refactor: 작품 설명, 방명록 메세지의 db 컬럼 변경

### DIFF
--- a/backend/forgather/src/main/java/com/forgather/domain/product/model/Product.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/product/model/Product.java
@@ -39,8 +39,7 @@ public class Product extends BaseTimeEntity {
     @Column(name = "author_name", nullable = false)
     private String authorName;
 
-    // 1000자 제한이나, 이모지를 고려해 4000자
-    @Column(name = "description", length = 4000, nullable = false)
+    @Column(name = "description", length = 1000, nullable = false)
     private String description;
 
     /**

--- a/backend/forgather/src/main/java/com/forgather/domain/product/model/Product.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/product/model/Product.java
@@ -39,7 +39,8 @@ public class Product extends BaseTimeEntity {
     @Column(name = "author_name", nullable = false)
     private String authorName;
 
-    @Column(name = "description", nullable = false)
+    // 1000자 제한이나, 이모지를 고려해 4000자
+    @Column(name = "description", length = 4000, nullable = false)
     private String description;
 
     /**

--- a/backend/forgather/src/main/java/com/forgather/domain/space/model/GuestBookCard.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/space/model/GuestBookCard.java
@@ -33,6 +33,7 @@ public class GuestBookCard extends BaseTimeEntity {
     @JoinColumn(name = "guest_id", nullable = false)
     private Guest guest;
 
-    @Column(name = "message", nullable = false)
+    // 300자 제한이나, 확장과 이모지를 고려해서 2000
+    @Column(name = "message", length = 2000, nullable = false)
     private String message;
 }

--- a/backend/forgather/src/main/java/com/forgather/domain/space/model/GuestBookCard.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/space/model/GuestBookCard.java
@@ -33,7 +33,6 @@ public class GuestBookCard extends BaseTimeEntity {
     @JoinColumn(name = "guest_id", nullable = false)
     private Guest guest;
 
-    // 300자 제한이나, 확장과 이모지를 고려해서 2000
-    @Column(name = "message", length = 2000, nullable = false)
+    @Column(name = "message", length = 500, nullable = false)
     private String message;
 }

--- a/backend/forgather/src/main/resources/db/migration/V3__update_description_message_column_type.sql
+++ b/backend/forgather/src/main/resources/db/migration/V3__update_description_message_column_type.sql
@@ -1,0 +1,10 @@
+-- product.description
+-- VARCHAR 바이트 제한 수정(애플리케이션 = 1000자, db는 이모지(4바이트)를 고려해서 4000자)
+ALTER TABLE `product`
+    MODIFY COLUMN `description` VARCHAR(4000) NOT NULL;
+
+-- guest_book_card.message
+-- VARCHAR 바이트 제한 수정(애플리케이션 = 300자, db는 확장을 고려해서 500자, 이모지(4바이트)를 고려해서 2000자)
+-- null -> not null 변경
+ALTER TABLE `guest_book_card`
+    MODIFY COLUMN `message` VARCHAR(2000) NOT NULL;

--- a/backend/forgather/src/main/resources/db/migration/V3__update_description_message_column_type.sql
+++ b/backend/forgather/src/main/resources/db/migration/V3__update_description_message_column_type.sql
@@ -1,10 +1,10 @@
 -- product.description
--- VARCHAR 바이트 제한 수정(애플리케이션 = 1000자, db는 이모지(4바이트)를 고려해서 4000자)
+-- VARCHAR 문자수 1000자로 수정
 ALTER TABLE `product`
-    MODIFY COLUMN `description` VARCHAR(4000) NOT NULL;
+    MODIFY COLUMN `description` VARCHAR(1000) NOT NULL;
 
 -- guest_book_card.message
--- VARCHAR 바이트 제한 수정(애플리케이션 = 300자, db는 확장을 고려해서 500자, 이모지(4바이트)를 고려해서 2000자)
+-- VARCHAR 문자수 500자로 수정
 -- null -> not null 변경
 ALTER TABLE `guest_book_card`
-    MODIFY COLUMN `message` VARCHAR(2000) NOT NULL;
+    MODIFY COLUMN `message` VARCHAR(500) NOT NULL;

--- a/backend/forgather/src/test/java/com/forgather/acceptance/ProductAcceptanceTest.java
+++ b/backend/forgather/src/test/java/com/forgather/acceptance/ProductAcceptanceTest.java
@@ -168,6 +168,28 @@ class ProductAcceptanceTest extends AcceptanceTest {
             .body("message", containsString("이미 등록된"));
     }
 
+    @DisplayName("작품 설명을 1000자까지 작성할 수 있다")
+    @Test
+    void doesNotThrowAnyExceptionWhenMaxDescriptionLength() {
+        // given
+        RegisterProductRequest registerRequest = new RegisterProductRequest(
+            "title",
+            "category",
+            "authorName",
+            "1234567890".repeat(100),
+            List.of()
+        );
+        // when, then
+        RestAssuredMockMvc.given()
+            .body(registerRequest)
+            .contentType(ContentType.JSON)
+            .accept(ContentType.JSON)
+            .when()
+            .post("/spaces/%s/products".formatted(space.getCode()))
+            .then()
+            .statusCode(201);
+    }
+
     @DisplayName("작품 정보 수정")
     @Test
     void update() {


### PR DESCRIPTION
## 연관된 이슈

- close #735 

## 작업 내용

기획과 애플리케이션 로직 상에서는 작품 설명을 1000자까지 입력 가능합니다.
하지만 DB 컬럼은 varchar(255)로, 한글 기준 256자가 넘어가면 db단 예외가 발생하고 있습니다.
따라서 db 컬럼 타입을 수정해주어야 했습니다.
(방명록 메세지도 300자로, 마찬가지)

---

### VARCHAR vs TEXT

TEXT와는 달리 VARCHAR는 레코드 당 65,535 바이트 제한이 존재합니다.
하지만 product 테이블은 컬럼 수가 많지 않고 크기도 상대적으로 크지 않아 고려하지 않아도 된다고 판단했습니다.

또 다른 차이는 메모리 관리 방식에 있습니다.
TEXT는 버퍼에서 매번 메모리 동적 할당/해제를 하는 반면, VARCHAR는 메모리를 미리 할당하고 재사용하는 구조입니다.
description 컬럼은 매번 읽는 컬럼이기 때문에 트래픽이 증가할 때 VARCHAR가 성능 측면에서 유리할 것으로 판단했습니다.

따라서 VARCHAR의 문자 수를 늘리는 방식을 선택했습니다.

다만 작품 정보에 입력하는 컬럼 수와 크기가 상대적으로 커진다면, TEXT 타입 사용을 고려해볼 수도 있을 것 같네요.
(방명록 메세지도 마찬가지)