### PR TITLE
refactor: SpaceHome 페이지 접근성 개선

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0, user-scalable=no, maximum-scale=1"
+      content="width=device-width, initial-scale=1.0"
     />
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">

--- a/frontend/src/apis/createHeaders.ts
+++ b/frontend/src/apis/createHeaders.ts
@@ -6,11 +6,11 @@ export const createHeaders = (
   withTraceId: boolean = true,
   method?: string,
 ): HeadersInit => {
-  // const traceId = crypto.randomUUID().slice(0, 8);
+  const traceId = crypto.randomUUID().slice(0, 8);
 
   const headers: HeadersInit = withTraceId
     ? {
-        // 'trace-id': traceId,
+        'trace-id': traceId,
       }
     : {};
 

--- a/frontend/src/apis/createHeaders.ts
+++ b/frontend/src/apis/createHeaders.ts
@@ -10,7 +10,7 @@ export const createHeaders = (
 
   const headers: HeadersInit = withTraceId
     ? {
-        // 'trace-id': traceId, /
+        // 'trace-id': traceId,
       }
     : {};
 

--- a/frontend/src/apis/createHeaders.ts
+++ b/frontend/src/apis/createHeaders.ts
@@ -6,11 +6,11 @@ export const createHeaders = (
   withTraceId: boolean = true,
   method?: string,
 ): HeadersInit => {
-  const traceId = crypto.randomUUID().slice(0, 8);
+  // const traceId = crypto.randomUUID().slice(0, 8);
 
   const headers: HeadersInit = withTraceId
     ? {
-        'trace-id': traceId,
+        // 'trace-id': traceId, /
       }
     : {};
 

--- a/frontend/src/components/@common/buttons/floatingActionButton/FloatingActionButton.tsx
+++ b/frontend/src/components/@common/buttons/floatingActionButton/FloatingActionButton.tsx
@@ -22,9 +22,9 @@ const FloatingActionButton = ({
   return (
     <S.Wrapper
       {...buttonProps}
+      tabIndex={0}
       $variant={disabled ? 'disabled' : 'default'}
       onClick={onClick}
-      aria-disabled={disabled}
       disabled={disabled}
     >
       {label}

--- a/frontend/src/components/@common/buttons/floatingIconButton/FloatingIconButton.tsx
+++ b/frontend/src/components/@common/buttons/floatingIconButton/FloatingIconButton.tsx
@@ -6,15 +6,18 @@ interface FloatingIconButtonProps
   icon: React.ReactNode;
   /** 버튼 클릭했을 때 실행할 함수*/
   onClick: () => void;
+  /** 버튼 아이콘 라벨 */
+  ariaLabel: string;
 }
 
 const FloatingIconButton = ({
   icon,
   onClick,
+  ariaLabel,
   ...buttonProps
 }: FloatingIconButtonProps) => {
   return (
-    <S.Wrapper onClick={onClick} {...buttonProps}>
+    <S.Wrapper onClick={onClick} {...buttonProps} aria-label={ariaLabel}>
       {icon}
     </S.Wrapper>
   );

--- a/frontend/src/components/@common/imageLayout/imageElement/spaceManagerImageElement/SpaceManagerImageElement.tsx
+++ b/frontend/src/components/@common/imageLayout/imageElement/spaceManagerImageElement/SpaceManagerImageElement.tsx
@@ -43,7 +43,7 @@ const SpaceManagerImageElement = ({
     >
       <C.Image
         src={thumbnailUrl}
-        alt={alt}
+        alt={`2025-09-28 ${alt}`}
         className="clarity-mask-photo"
         loading="lazy"
       />

--- a/frontend/src/components/@common/imageLayout/imageElement/spaceManagerImageElement/SpaceManagerImageElement.tsx
+++ b/frontend/src/components/@common/imageLayout/imageElement/spaceManagerImageElement/SpaceManagerImageElement.tsx
@@ -31,19 +31,24 @@ const SpaceManagerImageElement = ({
   thumbnailUrl,
   isSelectMode,
 }: SpaceManagerImageElementProps) => {
+  const selectedLabel = isSelectMode
+    ? isSelected
+      ? '선택됨'
+      : '선택 안됨'
+    : '사진 크게 보기';
   return (
     // biome-ignore lint/a11y/useSemanticElements: button 시맨틱 태그 내부에 button이 존재할 수 없음
     <C.Wrapper
       role="button"
       tabIndex={0}
-      aria-label={isSelected ? '선택된 이미지' : '선택되지 않은 이미지'}
+      aria-label={`${alt} ${selectedLabel}`}
       $ratio={ratio}
       $width={width}
       onClick={() => onImageClick(data.id)}
     >
       <C.Image
         src={thumbnailUrl}
-        alt={`2025-09-28 ${alt}`}
+        alt=""
         className="clarity-mask-photo"
         loading="lazy"
       />

--- a/frontend/src/components/@common/imageLayout/imageGrid/spaceManagerImageGrid/SpaceManagerImageGrid.tsx
+++ b/frontend/src/components/@common/imageLayout/imageGrid/spaceManagerImageGrid/SpaceManagerImageGrid.tsx
@@ -24,7 +24,6 @@ const SpaceManagerImageGrid = ({
   selectedPhotoMap,
   isSelectMode,
 }: SpaceManagerImageGridProps) => {
-  console.log(photoData);
   return (
     <S.Wrapper $rowImageAmount={rowImageAmount}>
       {photoData.map((photo, index) => (

--- a/frontend/src/components/@common/imageLayout/imageGrid/spaceManagerImageGrid/SpaceManagerImageGrid.tsx
+++ b/frontend/src/components/@common/imageLayout/imageGrid/spaceManagerImageGrid/SpaceManagerImageGrid.tsx
@@ -24,9 +24,10 @@ const SpaceManagerImageGrid = ({
   selectedPhotoMap,
   isSelectMode,
 }: SpaceManagerImageGridProps) => {
+  console.log(photoData);
   return (
     <S.Wrapper $rowImageAmount={rowImageAmount}>
-      {photoData.map((photo) => (
+      {photoData.map((photo, index) => (
         <SpaceManagerImageElement
           key={photo.id}
           data={photo}
@@ -34,6 +35,8 @@ const SpaceManagerImageGrid = ({
           isSelected={selectedPhotoMap.get(photo.id) ?? false}
           isSelectMode={isSelectMode}
           onImageClick={() => onImageClick(photo.id)}
+          // TODO : 사진 메타데이터로 수정
+          alt={`2025년 9월 28일  사진 ${100 - index}`}
         />
       ))}
     </S.Wrapper>

--- a/frontend/src/components/layout/global/header/Header.styles.ts
+++ b/frontend/src/components/layout/global/header/Header.styles.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-export const Wrapper = styled.div`
+export const Wrapper = styled.header`
   display: flex;
   justify-content: space-between;
   align-items: start;

--- a/frontend/src/components/layout/global/header/Header.tsx
+++ b/frontend/src/components/layout/global/header/Header.tsx
@@ -51,7 +51,11 @@ const Header = ({
 
   return (
     <S.Wrapper>
-      <button type="button" onClick={() => navigate(ROUTES.MYPAGE)}>
+      <button
+        type="button"
+        onClick={() => navigate(ROUTES.MYPAGE)}
+        aria-label="메인 페이지로 이동"
+      >
         <Logo fill={theme.colors.white} width={100} />
       </button>
       {createActionButton()}

--- a/frontend/src/components/specific/space/spaceFooter/SpaceFooter.tsx
+++ b/frontend/src/components/specific/space/spaceFooter/SpaceFooter.tsx
@@ -26,6 +26,7 @@ const SpaceFooter = ({
       <S.TopButtonContainer $isVisible={!isAtPageTop}>
         {!isSelectMode && (
           <FloatingIconButton
+            ariaLabel="페이지 상단으로 이동"
             icon={<UpwardArrowIcon fill={theme.colors.white} />}
             onClick={goToTop}
           />

--- a/frontend/src/components/specific/space/spaceFooter/SpaceFooter.tsx
+++ b/frontend/src/components/specific/space/spaceFooter/SpaceFooter.tsx
@@ -29,6 +29,7 @@ const SpaceFooter = ({
             ariaLabel="페이지 상단으로 이동"
             icon={<UpwardArrowIcon fill={theme.colors.white} />}
             onClick={goToTop}
+            role="link"
           />
         )}
       </S.TopButtonContainer>

--- a/frontend/src/components/specific/space/spaceHeader/SpaceHeader.styles.ts
+++ b/frontend/src/components/specific/space/spaceHeader/SpaceHeader.styles.ts
@@ -20,9 +20,12 @@ export const TitleContainer = styled.div`
   gap: 8px;
 `;
 
-export const Title = styled.p`
+export const Title = styled.h1`
   ${({ theme }) => ({ ...theme.typography.header01 })};
   color: ${({ theme }) => theme.colors.white};
+  &:focus {
+    outline: none;
+  }
 `;
 
 export const IconContainer = styled.div`
@@ -35,7 +38,7 @@ export const TimerContainer = styled.div`
   gap: 7px;
 `;
 
-export const TextContainer = styled.p<{ $isWithinOneHour: boolean }>`
+export const TextContainer = styled.h2<{ $isWithinOneHour: boolean }>`
   ${({ theme }) => theme.typography.bodyRegular};
   color: ${({ theme, $isWithinOneHour }) =>
     $isWithinOneHour ? theme.colors.error : theme.colors.white};

--- a/frontend/src/components/specific/space/spaceHeader/SpaceHeader.styles.ts
+++ b/frontend/src/components/specific/space/spaceHeader/SpaceHeader.styles.ts
@@ -38,7 +38,7 @@ export const TimerContainer = styled.div`
   gap: 7px;
 `;
 
-export const TextContainer = styled.h2<{ $isWithinOneHour: boolean }>`
+export const TextContainer = styled.p<{ $isWithinOneHour: boolean }>`
   ${({ theme }) => theme.typography.bodyRegular};
   color: ${({ theme, $isWithinOneHour }) =>
     $isWithinOneHour ? theme.colors.error : theme.colors.white};

--- a/frontend/src/components/specific/space/spaceHeader/SpaceHeader.tsx
+++ b/frontend/src/components/specific/space/spaceHeader/SpaceHeader.tsx
@@ -18,7 +18,7 @@ SpaceHeader.TitleContainer = ({ children }: { children: React.ReactNode }) => (
 );
 
 SpaceHeader.Title = ({ children }: { children: React.ReactNode }) => (
-  <S.Title>{children}</S.Title>
+  <S.Title tabIndex={-1}>{children}</S.Title>
 );
 
 SpaceHeader.AccessType = ({ accessType }: { accessType: SpaceAccessType }) => (

--- a/frontend/src/components/specific/space/spaceHeader/managerSpaceHeader/ManagerHeader.tsx
+++ b/frontend/src/components/specific/space/spaceHeader/managerSpaceHeader/ManagerHeader.tsx
@@ -129,6 +129,9 @@ const ManagerHeader = ({
   ];
   return (
     <SpaceHeader>
+      <div id="page-announcer" aria-live="polite" className="sr-only">
+        현재 스페이스에 100장의 사진이 있습니다.
+      </div>
       <SpaceHeader.TitleSection>
         <SpaceHeader.TitleContainer>
           <SpaceHeader.Title>{spaceName}</SpaceHeader.Title>

--- a/frontend/src/components/specific/space/spaceHeader/managerSpaceHeader/ManagerHeader.tsx
+++ b/frontend/src/components/specific/space/spaceHeader/managerSpaceHeader/ManagerHeader.tsx
@@ -130,7 +130,7 @@ const ManagerHeader = ({
   return (
     <SpaceHeader>
       <div id="page-announcer" aria-live="polite" className="sr-only">
-        현재 스페이스에 100장의 사진이 있습니다.
+        100장의 사진이 있습니다.
       </div>
       <SpaceHeader.TitleSection>
         <SpaceHeader.TitleContainer>

--- a/frontend/src/hooks/domain/photos/usePhotosBySpaceCode.ts
+++ b/frontend/src/hooks/domain/photos/usePhotosBySpaceCode.ts
@@ -87,8 +87,6 @@ const usePhotosBySpaceCode = ({
   };
 
   const announcedPhotoLoad = (newCount: number) => {
-    console.log(currentPage.current, totalPages.current);
-
     if (!infiniteScrollAnnouncerRef.current) return;
 
     infiniteScrollAnnouncerRef.current.textContent = `${newCount}장의 사진이 추가되었습니다.`;

--- a/frontend/src/hooks/domain/photos/usePhotosBySpaceCode.ts
+++ b/frontend/src/hooks/domain/photos/usePhotosBySpaceCode.ts
@@ -27,6 +27,8 @@ const usePhotosBySpaceCode = ({
   const totalPages = useRef(1);
   const { tryFetch, loadingState } = useTaskHandler();
 
+  const infiniteScrollAnnouncerRef = useRef<HTMLDivElement>(null);
+
   const thumbnailPhotoMap = useMemo(() => {
     // TODO : thumbnail 이미지 참조 실패시 원본 이미지 참조하도록 설정
     if (!photosList) return new Map();
@@ -58,23 +60,38 @@ const usePhotosBySpaceCode = ({
   };
 
   const fetchPhotosList = async () => {
+    if (!infiniteScrollAnnouncerRef.current) return;
+
     const pageToFetch = currentPage.current;
     const response = await fetchFunc(spaceCode, {
       page: pageToFetch,
       size: PAGE_SIZE,
     });
+    console.log('Fetch');
 
     if (!response || !response.data) return;
+
+    const { photos, totalPages: updatedTotalPages } = response.data;
+    appendPhotosList(photos, updatedTotalPages);
+    if (currentPage.current > 1) {
+      announcedPhotoLoad(photos.length);
+    }
+
     currentPage.current += 1;
 
-    const { photos, totalPages } = response.data;
-    appendPhotosList(photos, totalPages);
-
-    if (currentPage.current < totalPages) {
+    if (currentPage.current < updatedTotalPages) {
       requestAnimationFrame(() => {
         reObserve();
       });
     }
+  };
+
+  const announcedPhotoLoad = (newCount: number) => {
+    console.log(currentPage.current, totalPages.current);
+
+    if (!infiniteScrollAnnouncerRef.current) return;
+
+    infiniteScrollAnnouncerRef.current.textContent = `${newCount}장의 사진이 추가되었습니다.`;
   };
 
   const tryFetchPhotosList = async () => {
@@ -98,6 +115,7 @@ const usePhotosBySpaceCode = ({
     photosList,
     photosListLoadingState: loadingState.photosList,
     updatePhotos,
+    infiniteScrollAnnouncerRef,
   };
 };
 

--- a/frontend/src/pages/manager/Manager.common.styles.ts
+++ b/frontend/src/pages/manager/Manager.common.styles.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-export const Wrapper = styled.div`
+export const Wrapper = styled.main`
   width: 100%;
   min-height: ${({ theme }) =>
     `calc(100vh - ${parseInt(theme.layout.padding.topBottom) * 2}px - ${theme.layout.headerHeight})`};

--- a/frontend/src/pages/manager/spaceHome/SpaceHomePage.tsx
+++ b/frontend/src/pages/manager/spaceHome/SpaceHomePage.tsx
@@ -166,7 +166,6 @@ const SpaceHomePage = () => {
     hasAccess,
   ]);
 
-
   useEffect(() => {
     setTimeout(() => {
       document.querySelector('h1')?.focus();
@@ -175,7 +174,6 @@ const SpaceHomePage = () => {
 
   const progressBarWidth =
     parseInt(theme.layout.width) - parseInt(theme.layout.padding.leftRight) * 8;
-
 
   const renderBodyContent = () => {
     if (isEarlyTime) return <EarlyPage openedAt={spaceInfo?.openedAt ?? ''} />;

--- a/frontend/src/pages/manager/spaceHome/SpaceHomePage.tsx
+++ b/frontend/src/pages/manager/spaceHome/SpaceHomePage.tsx
@@ -168,6 +168,12 @@ const SpaceHomePage = () => {
     photosListLoadingState,
   ]);
 
+  useEffect(() => {
+    setTimeout(() => {
+      document.querySelector('h1')?.focus();
+    }, 100);
+  }, []);
+
   const renderBodyContent = () => {
     if (isEarlyTime) return <EarlyPage openedAt={spaceInfo?.openedAt ?? ''} />;
     if (isSpaceExpired) return <ExpiredPage />;

--- a/frontend/src/pages/manager/spaceHome/SpaceHomePage.tsx
+++ b/frontend/src/pages/manager/spaceHome/SpaceHomePage.tsx
@@ -183,6 +183,7 @@ const SpaceHomePage = () => {
       return (
         <>
           <C.ImageManagementContainer>
+            <div className="sr-only"></div>
             <Button
               text="수신함 📩"
               variant="darkRounded"
@@ -196,6 +197,23 @@ const SpaceHomePage = () => {
               onToggleSelectMode={toggleSelectMode}
               onToggleAllSelected={toggleAllSelected}
             />
+            {!isSelectMode && (
+              <S.DownloadButtonContainer>
+                <FloatingActionButton
+                  label="모두 저장하기"
+                  icon={<DownloadIcon fill={theme.colors.gray06} />}
+                  onClick={() => {
+                    tryAllDownload();
+                    track.button('all_download_button', {
+                      page: 'space_home',
+                      section: 'space_home',
+                      action: 'download_all',
+                    });
+                  }}
+                  disabled={isDownloading}
+                />
+              </S.DownloadButtonContainer>
+            )}
             <SpaceManagerImageGrid
               isSelectMode={isSelectMode}
               selectedPhotoMap={selectedPhotoMap}
@@ -219,23 +237,6 @@ const SpaceHomePage = () => {
               onClick: () => trySelectedDownload(selectedPhotoIds),
             }}
           />
-          {!isSelectMode && (
-            <S.DownloadButtonContainer>
-              <FloatingActionButton
-                label="모두 저장하기"
-                icon={<DownloadIcon fill={theme.colors.gray06} />}
-                onClick={() => {
-                  tryAllDownload();
-                  track.button('all_download_button', {
-                    page: 'space_home',
-                    section: 'space_home',
-                    action: 'download_all',
-                  });
-                }}
-                disabled={isDownloading}
-              />
-            </S.DownloadButtonContainer>
-          )}
         </>
       );
   };
@@ -249,6 +250,7 @@ const SpaceHomePage = () => {
           currentAmount={currentProgress}
         />
       )}
+
       <div
         ref={infiniteScrollAnnouncerRef}
         aria-live="polite"

--- a/frontend/src/pages/manager/spaceHome/SpaceHomePage.tsx
+++ b/frontend/src/pages/manager/spaceHome/SpaceHomePage.tsx
@@ -183,7 +183,9 @@ const SpaceHomePage = () => {
       return (
         <>
           <C.ImageManagementContainer>
-            <div className="sr-only"></div>
+            <a href="#download-fab" className="skip-link">
+              모두 저장하기 바로가기
+            </a>
             <Button
               text="수신함 📩"
               variant="darkRounded"
@@ -200,6 +202,7 @@ const SpaceHomePage = () => {
             {!isSelectMode && (
               <S.DownloadButtonContainer>
                 <FloatingActionButton
+                  id="download-fab"
                   label="모두 저장하기"
                   icon={<DownloadIcon fill={theme.colors.gray06} />}
                   onClick={() => {

--- a/frontend/src/pages/manager/spaceHome/SpaceHomePage.tsx
+++ b/frontend/src/pages/manager/spaceHome/SpaceHomePage.tsx
@@ -59,6 +59,7 @@ const SpaceHomePage = () => {
     updatePhotos,
     isEndPage,
     thumbnailPhotoMap,
+    infiniteScrollAnnouncerRef,
   } = usePhotosBySpaceCode({
     reObserve,
     spaceCode: spaceInfo?.spaceCode ?? '',
@@ -163,9 +164,6 @@ const SpaceHomePage = () => {
     isSpaceExpired,
     isEarlyTime,
     hasAccess,
-    accessLoadingState,
-    spaceInfoLoadingState,
-    photosListLoadingState,
   ]);
 
   useEffect(() => {
@@ -251,7 +249,11 @@ const SpaceHomePage = () => {
           currentAmount={currentProgress}
         />
       )}
-
+      <div
+        ref={infiniteScrollAnnouncerRef}
+        aria-live="polite"
+        className="sr-only"
+      />
       <C.HeaderContainer ref={scrollTopTriggerRef}>
         <ManagerHeader
           spaceName={spaceInfo?.name ?? ''}

--- a/frontend/src/styles/global.ts
+++ b/frontend/src/styles/global.ts
@@ -58,4 +58,21 @@ export const global = css`
     clip-path: inset(50%);        
     white-space: nowrap;      
   }
+
+  .skip-link {
+    position: absolute;
+    top: -400px;      
+    left: 0;
+    background: #000; 
+    color: #fff;      
+    padding: 8px 16px;
+    z-index: 1000;
+    text-decoration: none;
+    border-radius: 4px;
+    font-size: 14px;
+  }
+  
+  .skip-link:focus {
+    top: 0;            
+  }
 `;

--- a/frontend/src/styles/global.ts
+++ b/frontend/src/styles/global.ts
@@ -54,25 +54,25 @@ export const global = css`
     padding: 0;
     border: 0;
     overflow: hidden;
-    clip: rect(0, 0, 0, 0);     
-    clip-path: inset(50%);        
-    white-space: nowrap;      
+    clip: rect(0, 0, 0, 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
   }
 
   .skip-link {
     position: absolute;
-    top: -400px;      
+    top: -400px;
     left: 0;
-    background: #000; 
-    color: #fff;      
+    background: #000;
+    color: #fff;
     padding: 8px 16px;
     z-index: 1000;
     text-decoration: none;
     border-radius: 4px;
     font-size: 14px;
   }
-  
+
   .skip-link:focus {
-    top: 0;            
+    top: 0;
   }
 `;

--- a/frontend/src/styles/global.ts
+++ b/frontend/src/styles/global.ts
@@ -46,4 +46,16 @@ export const global = css`
     overscroll-behavior: none;
     touch-action: none;
   }
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    border: 0;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);     
+    clip-path: inset(50%);        
+    white-space: nowrap;      
+  }
 `;

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -131,6 +131,7 @@ module.exports = (_, argv) => {
         },
       ],
       port: 3000,
+      allowedHosts: 'all',
       hot: true,
       open: true,
       historyApiFallback: true,


### PR DESCRIPTION
## 연관된 이슈

- close #627

## 작업 내용

## 1️⃣ 라이트하우스 기반

### 1. 라이트하우스 점수 개선 dfdbe196f6874cc22a16c8487d740d4a6acc96e6
a. 로고버튼 / 최상단 이동 버튼에 button에 명시적인 이름 지정
b. index.html meta태그에서 확대 / 축소를 금지하는 코드 삭제

<img width="718" height="31" alt="image" src="https://github.com/user-attachments/assets/9698fbeb-0b2e-40e5-9d56-d1f889968e0d" />


### 2. 전체 문서 구조 시맨틱 태그 변환
- space manager 페이지의 Wrapper를 main 태그를 사용하도록 변경
- Header 컴포넌트는 header 태그를 사용하도록 변경 


## 2️⃣ 스크린리더 기반

###  1. SpaceHome의 첫 Focus 제어 a2bb740dc1ced5eb8f4d53e595426647fd2f3bc9, ae00f0c5cf9b862878880e63b6ce5c1f289b8558
기존) 이전 화면의 Focus가 SpaceHome에 이동한 이후에도 유지되어 페이지 이동시 불필요한 요소에 focus가 가해짐. 이 때문에 페이지와 연관성이 없는 요소에 대한 label이 읽힘
변경 후) 해당 페이지의 h1 요소에 처음으로 초점이 가도록 설정, 그 외에 페이지에 접속 시 "사진을 볼 수 있는 앨범"이라는 메세지가 추가로 출력되도록 설정

<img width="200"  alt="image" src="https://github.com/user-attachments/assets/0477cef8-bc35-469b-99ac-793284d532c0" />

### 2.ImageElement 접근성 개선 6e1d258e63e5b519c84d73ea9b91a950a22fa8e0
기존) 
- 선택모드가 아닐 때에도 "선택되지 않음, 선택됨" 등의 선택 여부에 대한 label이 출력됨. 따라서 단순히 이미지를 탐색 중일 때도 불필요한 정보가 함께 읽히게 됨.
-  imageElement 컴포넌트의 경우 button 태그 하위에 image 태그가 존재. button 태그의 aria-label을 읽을 뿐, image의 alt 텍스트를 읽진 않음.

변경 후) 
- 선택 모드일 때만 선택 여부에 대해 출력하며, 선택모드가 아닐 때는 이미지 탐색시 이미지 alt 태그 및 "사진 크게 보기 버튼"이 함께 출력되도록 설정함
- button의 aria-label에 image 태그의 alt도 함께 추가하여, 이미지의 alt 태그와 버튼의 aria-label이 함께 읽힐 수 있도록 설정함
✅ alt 태그를 "사진 생성 일자" 및 "사진 생성 장소"를 함께 출력하도록 한다면 더 의미있는 alt 태그가 될 수 있음, API 명세가 바뀌어야 하므로 이 부분은 TODO로 남겨둠

### 3. 무한 스크롤 접근성 문제 해결 467e9472e49f2068951265e301a558966716d460
기존) 무한스크롤로 새로운 요소들을 fetch해와도, 페이지네이션이 업데이트되지 않아 새로운 요소가 불러와졌음을 파악할 수 있는 방법이 없음
변경 후) 페이지네이션을 임의로 제어할 수 없으나, "새로운 20장의 이미지가 불러와졌다"는 멘트를 통해 스크롤 가능 영역이 늘어났음을 명시


### 4. 다운로드버튼 접근성 개선
기존) 
- 다운로드 버튼에 접근하기 위해선 모든 ImageElement 요소를 순회한 이후에 가능함

변경 후)
- imageElement를 순회하기 전에 button이 먼저 탐색되도록 DOM 구조를 수정함 

- 곧바로 접근할 수 있는 skipLink를 생성함
- 사용자는 "로터" 기능을 통해 해당 링크에 접속하고, 링크를 통해 다운로드 버튼에 접근할 수 있는  새로운 접근 방식을 얻게 됨

<img width="435" height="225" alt="image" src="https://github.com/user-attachments/assets/78d2d1bf-a512-4c30-9b82-53c0c0323b6d" />
