### PR TITLE
feature: 방명록 카드 삭제 api

### DIFF
--- a/backend/forgather/src/main/java/com/forgather/domain/guestbook/controller/GuestBookController.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/guestbook/controller/GuestBookController.java
@@ -49,7 +49,6 @@ public class GuestBookController {
     @GetMapping
     public ResponseEntity<GuestBookResponse> getCards(
         @PathVariable(value = "spaceCode") String spaceCode,
-
         @Schema(example = """
             {
               "page": 1,
@@ -93,8 +92,10 @@ public class GuestBookController {
     @DeleteMapping("/{guestBookCardId}")
     public ResponseEntity<Void> deleteCard(
         @PathVariable(value = "spaceCode") String spaceCode,
-        @PathVariable(value = "guestBookCardId") Long guestBookCardId
+        @PathVariable(value = "guestBookCardId") Long guestBookCardId,
+        @LoginHost(required = false) Host host // TODO true로 전환
     ) {
+        guestBookService.deleteCard(host, spaceCode, guestBookCardId);
         return ResponseEntity.noContent().build();
     }
 

--- a/backend/forgather/src/main/java/com/forgather/domain/guestbook/repository/GuestBookCardPhotoRepository.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/guestbook/repository/GuestBookCardPhotoRepository.java
@@ -9,4 +9,6 @@ public interface GuestBookCardPhotoRepository {
     <S extends GuestBookCardPhoto> List<S> saveAll(Iterable<S> photos);
 
     List<GuestBookCardPhoto> findAllByGuestBookCard(GuestBookCard guestBookCard);
+
+    void deleteAll(Iterable<? extends GuestBookCardPhoto> photos);
 }

--- a/backend/forgather/src/main/java/com/forgather/domain/guestbook/repository/GuestBookCardRepository.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/guestbook/repository/GuestBookCardRepository.java
@@ -14,6 +14,8 @@ public interface GuestBookCardRepository {
 
     Optional<GuestBookCard> findById(Long id);
 
+    void delete(GuestBookCard guestBookCard);
+
     default GuestBookCard getByIdOrThrow(Long id) {
         if (id == null) {
             throw new BaseNullPointerException("방명록 카드의 id는 null일 수 없습니다.", HttpStatus.BAD_REQUEST);

--- a/backend/forgather/src/main/java/com/forgather/domain/guestbook/service/GuestBookService.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/guestbook/service/GuestBookService.java
@@ -25,7 +25,8 @@ import com.forgather.domain.space.repository.SpaceRepository;
 import com.forgather.domain.upload.domain.ContentsStorage;
 import com.forgather.global.auth.model.Host;
 import com.forgather.global.auth.repository.SpaceHostMapRepository;
-import com.forgather.global.exception.BaseException;
+import com.forgather.global.exception.BaseNullPointerException;
+import com.forgather.global.exception.ForbiddenException;
 import com.forgather.global.exception.NotFoundException;
 
 import lombok.RequiredArgsConstructor;
@@ -77,7 +78,7 @@ public class GuestBookService {
         validateCanRead(space, host);
 
         GuestBookCard guestBookCard = getGuestBookCard(guestBookCardId, space);
-        if (isSpaceHost(space, host)) {
+        if (host != null && isSpaceHost(space, host)) {
             guestBookCard.read();
         }
 
@@ -86,16 +87,37 @@ public class GuestBookService {
     }
 
     private void validateCanRead(Space space, Host host) {
-        if (isSpaceHost(space, host)) { // 스페이스 호스트
-            return;
-        }
         if (space.isPublic()) { // 공개 스페이스
             return;
         }
-        throw new BaseException("방문자는 비공개 스페이스의 방명록을 조회할 수 없습니다. spaceCode: " + space.getCode());
+        if (host != null && isSpaceHost(space, host)) { // 스페이스 호스트
+            return;
+        }
+        throw new ForbiddenException("방문자는 비공개 스페이스의 방명록을 조회할 수 없습니다. spaceCode: " + space.getCode());
+    }
+
+    @Transactional
+    public void deleteCard(Host host, String spaceCode, Long guestBookCardId) {
+        Space space = spaceRepository.getByCodeOrThrow(spaceCode);
+        // validateSpaceHost(host, space); // TODO 검증 활성화
+        GuestBookCard guestBookCard = getGuestBookCard(guestBookCardId, space);
+        deleteGuestBookCardPhotos(guestBookCard);
+        guestBookCardRepository.delete(guestBookCard);
+    }
+
+    private void validateSpaceHost(Host host, Space space) {
+        if (isSpaceHost(space, host)) {
+            return;
+        }
+        throw new ForbiddenException(
+            "해당 스페이스에 대한 접근 권한이 없습니다. spaceCode: %s, hostId: %d".formatted(space.getCode(), host.getId())
+        );
     }
 
     private boolean isSpaceHost(Space space, Host host) {
+        if (space == null || host == null) {
+            throw new BaseNullPointerException("스페이스와 호스트는 null일 수 없습니다.");
+        }
         return spaceHostMapRepository.findBySpaceAndHost(space, host).isPresent();
     }
 
@@ -108,5 +130,11 @@ public class GuestBookService {
             "해당 스페이스에 존재하지 않는 방명록 카드입니다. spaceCode: %s, guestBookCardId: %d"
                 .formatted(space.getCode(), guestBookCardId)
         );
+    }
+
+    private void deleteGuestBookCardPhotos(GuestBookCard guestBookCard) {
+        List<GuestBookCardPhoto> photos = guestBookCardPhotoRepository.findAllByGuestBookCard(guestBookCard);
+        guestBookCardPhotoRepository.deleteAll(photos);
+        contentsStorage.deletePhotos(photos);
     }
 }

--- a/backend/forgather/src/main/java/com/forgather/domain/product/service/ProductService.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/product/service/ProductService.java
@@ -99,6 +99,10 @@ public class ProductService {
         return new ProductResponse(product, photos.getAll());
     }
 
+    /**
+     * TODO
+     * s3에서 삭제했지만 트랜잭션 롤백 고려
+     */
     @Transactional
     public void delete(String spaceCode) {
         Product product = productRepository.getBySpaceCodeOrThrow(spaceCode);

--- a/backend/forgather/src/main/java/com/forgather/global/exception/GlobalExceptionHandler.java
+++ b/backend/forgather/src/main/java/com/forgather/global/exception/GlobalExceptionHandler.java
@@ -140,7 +140,7 @@ public class GlobalExceptionHandler {
         logClientWarning(e);
         return ResponseEntity.status(e.getStatusCode())
             .contentType(APPLICATION_JSON)
-            .body(ErrorResponse.from("접근 권한이 없습니다."));
+            .body(ErrorResponse.from(e.getMessage()));
     }
 
     @ExceptionHandler(UnauthorizedException.class)

--- a/backend/forgather/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
+++ b/backend/forgather/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
@@ -113,7 +113,7 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
             .when()
             .get("/spaces/%s/guestbook/%d".formatted(privateSpace.getCode(), writeResponse.id()))
             .then()
-            .statusCode(400)
+            .statusCode(403)
             .body("message", containsString("방문자는 비공개 스페이스의 방명록을 조회할 수 없습니다."));
     }
 

--- a/backend/forgather/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
+++ b/backend/forgather/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
@@ -32,6 +32,8 @@ import io.restassured.module.mockmvc.RestAssuredMockMvc;
  * TODO
  * 비공개 스페이스 & 호스트 -> 방명록 조회 가능
  * 미읽음 스페이스 호스트 조회 -> 읽음 처리
+ * 호스트가 아니면 방명록 카드 삭제 불가
+ * 다른 스페이스에 대한 작업
  */
 @AutoConfigureMockMvc
 public class GuestBookCardAcceptanceTest extends AcceptanceTest {
@@ -194,6 +196,28 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
             .then()
             .statusCode(400)
             .body("message", containsString("방명록 카드 사진은 최대"));
+    }
+
+    @DisplayName("방명록 카드를 삭제한다")
+    @Test
+    void deleteCard() {
+        // given
+        WriteGuestBookCardResponse writeResponse = writeGuestBookCard(publicSpace);
+
+        // when
+        RestAssuredMockMvc.given()
+            .when()
+            .delete("/spaces/%s/guestbook/%d".formatted(publicSpace.getCode(), writeResponse.id()))
+            .then()
+            .statusCode(204);
+
+        // then
+        RestAssuredMockMvc.given()
+            .accept(ContentType.JSON)
+            .when()
+            .get("/spaces/%s/guestbook/%d".formatted(publicSpace.getCode(), writeResponse.id()))
+            .then()
+            .statusCode(404);
     }
 
     private WriteGuestBookCardResponse writeGuestBookCard(Space space) {


### PR DESCRIPTION
## 연관된 이슈

- close #758 

## 작업 내용
- 방명록 카드 삭제는 스페이스의 호스트만 할 수 있다.
  - 현재는 개발 단계이므로 호스트 검증을 건너뛴다.