### PR TITLE
feature: 방명록 조회

### DIFF
--- a/backend/forgather/src/main/java/com/forgather/domain/guestbook/controller/GuestBookController.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/guestbook/controller/GuestBookController.java
@@ -39,15 +39,13 @@ public class GuestBookController {
     private final GuestBookService guestBookService;
 
     /**
-     * TODO
      * 공개 검증 (게스트)
-     * 페이지네이션
      * 읽음/안읽음 여부 (호스트)
      * 사진 존재 여부
      */
     @Operation(summary = "방명록 조회", description = "페이지네이션 1페이지부터 시작 / 공개 스페이스가 아닌 경우 호스트만 조회 가능")
     @GetMapping
-    public ResponseEntity<GuestBookResponse> getCards(
+    public ResponseEntity<GuestBookResponse> readGuestBook(
         @PathVariable(value = "spaceCode") String spaceCode,
         @Schema(example = """
             {
@@ -58,9 +56,11 @@ public class GuestBookController {
               ]
             }
             """)
-        @PageableDefault(size = 15, sort = {"createdAt", "id"}, direction = Sort.Direction.DESC) Pageable pageable
+        @PageableDefault(size = 15, sort = {"createdAt", "id"}, direction = Sort.Direction.DESC) Pageable pageable,
+        @LoginHost(required = false) Host host
     ) {
-        return ResponseEntity.ok(null);
+        GuestBookResponse response = guestBookService.read(host, spaceCode, pageable);
+        return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "방명록 카드 조회", description = "공개 스페이스가 아닌 경우 호스트만 조회 가능")

--- a/backend/forgather/src/main/java/com/forgather/domain/guestbook/controller/GuestBookController.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/guestbook/controller/GuestBookController.java
@@ -24,6 +24,8 @@ import com.forgather.global.auth.annotation.LoginHost;
 import com.forgather.global.auth.model.Host;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -38,25 +40,33 @@ public class GuestBookController {
 
     private final GuestBookService guestBookService;
 
-    /**
-     * 공개 검증 (게스트)
-     * 읽음/안읽음 여부 (호스트)
-     * 사진 존재 여부
-     */
-    @Operation(summary = "방명록 조회", description = "페이지네이션 1페이지부터 시작 / 공개 스페이스가 아닌 경우 호스트만 조회 가능")
+    @Operation(summary = "방명록 조회",
+        description = "공개 스페이스가 아닌 경우 호스트만 조회 가능, 방문자는 isRead 필드 누락",
+        parameters = {
+            @Parameter(
+                name = "page",
+                description = "페이지 번호 (1부터 시작)",
+                example = "1"
+            ),
+            @Parameter(
+                name = "size",
+                description = "페이지 크기",
+                example = "15"
+            ),
+            @Parameter(
+                name = "sort",
+                description = "정렬 조건 (여러개 지정 가능) (id,desc 포함 필수)",
+                example = "createdAt,desc",
+                array = @ArraySchema(schema = @Schema(type = "string"))
+            )
+        }
+    )
     @GetMapping
     public ResponseEntity<GuestBookResponse> readGuestBook(
         @PathVariable(value = "spaceCode") String spaceCode,
-        @Schema(example = """
-            {
-              "page": 1,
-              "size": 15,
-              "sort": [
-                "createdAt", "id"
-              ]
-            }
-            """)
-        @PageableDefault(size = 15, sort = {"createdAt", "id"}, direction = Sort.Direction.DESC) Pageable pageable,
+        @Parameter(hidden = true)
+        @PageableDefault(size = 15, sort = {"createdAt", "id"}, direction = Sort.Direction.DESC)
+        Pageable pageable,
         @LoginHost(required = false) Host host
     ) {
         GuestBookResponse response = guestBookService.read(host, spaceCode, pageable);

--- a/backend/forgather/src/main/java/com/forgather/domain/guestbook/dto/GuestBookCardSimpleResponse.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/guestbook/dto/GuestBookCardSimpleResponse.java
@@ -1,5 +1,7 @@
 package com.forgather.domain.guestbook.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record GuestBookCardSimpleResponse(
@@ -13,6 +15,7 @@ public record GuestBookCardSimpleResponse(
     Boolean containsPhoto,
 
     @Schema(description = "호스트 읽음 여부", example = "false")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     Boolean isRead
 ) {
 }

--- a/backend/forgather/src/main/java/com/forgather/domain/guestbook/dto/GuestBookResponse.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/guestbook/dto/GuestBookResponse.java
@@ -2,6 +2,8 @@ package com.forgather.domain.guestbook.dto;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record GuestBookResponse(
@@ -27,7 +29,7 @@ public record GuestBookResponse(
             }
           ]
         """)
-    List<GuestBookCardSimpleResponse>  guestBookCards,
+    List<GuestBookCardSimpleResponse> guestBookCards,
 
     @Schema(description = "현재 페이지 번호", example = "1")
     int currentPage,
@@ -36,9 +38,17 @@ public record GuestBookResponse(
     int pageSize,
 
     @Schema(description = "총 방명록 카드 개수", example = "3")
-    int totalCount,
+    long totalCount,
 
     @Schema(description = "총 페이지 수", example = "1")
     int totalPages
 ) {
+
+    public GuestBookResponse(Page<GuestBookCardSimpleResponse> guestBookCards) {
+        this(guestBookCards.toList(),
+            guestBookCards.getNumber() + 1,
+            guestBookCards.getSize(),
+            guestBookCards.getTotalElements(),
+            guestBookCards.getTotalPages());
+    }
 }

--- a/backend/forgather/src/main/java/com/forgather/domain/guestbook/repository/GuestBookCardPhotoRepository.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/guestbook/repository/GuestBookCardPhotoRepository.java
@@ -11,4 +11,6 @@ public interface GuestBookCardPhotoRepository {
     List<GuestBookCardPhoto> findAllByGuestBookCard(GuestBookCard guestBookCard);
 
     void deleteAll(Iterable<? extends GuestBookCardPhoto> photos);
+
+    Boolean existsByGuestBookCard(GuestBookCard guestBookCard);
 }

--- a/backend/forgather/src/main/java/com/forgather/domain/guestbook/repository/GuestBookCardRepository.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/guestbook/repository/GuestBookCardRepository.java
@@ -2,6 +2,8 @@ package com.forgather.domain.guestbook.repository;
 
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 
 import com.forgather.domain.guestbook.model.GuestBookCard;
@@ -26,4 +28,6 @@ public interface GuestBookCardRepository {
         return findById(id)
             .orElseThrow(() -> new NotFoundException("존재하지 않는 방명록 카드입니다. id: " + id));
     }
+
+    Page<GuestBookCard> findAllBySpace(Space space, Pageable pageable);
 }

--- a/backend/forgather/src/main/java/com/forgather/domain/guestbook/service/GuestBookService.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/guestbook/service/GuestBookService.java
@@ -6,11 +6,15 @@ import static com.forgather.domain.upload.domain.UploadCategory.GUESTBOOK;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.forgather.domain.guestbook.dto.DeleteGuestBookCardPhotosRequest;
 import com.forgather.domain.guestbook.dto.GuestBookCardResponse;
+import com.forgather.domain.guestbook.dto.GuestBookCardSimpleResponse;
+import com.forgather.domain.guestbook.dto.GuestBookResponse;
 import com.forgather.domain.guestbook.dto.WriteGuestBookCardPhotoRequest;
 import com.forgather.domain.guestbook.dto.WriteGuestBookCardRequest;
 import com.forgather.domain.guestbook.dto.WriteGuestBookCardResponse;
@@ -72,6 +76,33 @@ public class GuestBookService {
             photos.add(photo);
         }
         return new GuestBookCardPhotos(photos);
+    }
+
+    public GuestBookResponse read(Host host, String spaceCode, Pageable pageable) {
+        Space space = spaceRepository.getByCodeOrThrow(spaceCode);
+        validateCanRead(space, host);
+        Page<GuestBookCard> guestBookCards = guestBookCardRepository.findAllBySpace(space, pageable);
+        Page<GuestBookCardSimpleResponse> simpleResponses;
+        if (host != null && isSpaceHost(space, host)) {
+            simpleResponses = guestBookCards.map(
+                guestBookCard -> new GuestBookCardSimpleResponse(
+                    guestBookCard.getId(),
+                    guestBookCard.getNickname(),
+                    guestBookCardPhotoRepository.existsByGuestBookCard(guestBookCard),
+                    guestBookCard.isRead()
+                )
+            );
+        } else {
+            simpleResponses = guestBookCards.map(
+                guestBookCard -> new GuestBookCardSimpleResponse(
+                    guestBookCard.getId(),
+                    guestBookCard.getNickname(),
+                    guestBookCardPhotoRepository.existsByGuestBookCard(guestBookCard),
+                    null
+                )
+            );
+        }
+        return new GuestBookResponse(simpleResponses);
     }
 
     public GuestBookCardResponse readCard(Host host, String spaceCode, Long guestBookCardId) {

--- a/backend/forgather/src/main/java/com/forgather/domain/guestbook/service/GuestBookService.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/guestbook/service/GuestBookService.java
@@ -82,26 +82,15 @@ public class GuestBookService {
         Space space = spaceRepository.getByCodeOrThrow(spaceCode);
         validateCanRead(space, host);
         Page<GuestBookCard> guestBookCards = guestBookCardRepository.findAllBySpace(space, pageable);
-        Page<GuestBookCardSimpleResponse> simpleResponses;
-        if (host != null && isSpaceHost(space, host)) {
-            simpleResponses = guestBookCards.map(
-                guestBookCard -> new GuestBookCardSimpleResponse(
-                    guestBookCard.getId(),
-                    guestBookCard.getNickname(),
-                    guestBookCardPhotoRepository.existsByGuestBookCard(guestBookCard),
-                    guestBookCard.isRead()
-                )
-            );
-        } else {
-            simpleResponses = guestBookCards.map(
-                guestBookCard -> new GuestBookCardSimpleResponse(
-                    guestBookCard.getId(),
-                    guestBookCard.getNickname(),
-                    guestBookCardPhotoRepository.existsByGuestBookCard(guestBookCard),
-                    null
-                )
-            );
-        }
+        boolean isHost = host != null && isSpaceHost(space, host);
+        Page<GuestBookCardSimpleResponse> simpleResponses = guestBookCards.map(
+            guestBookCard -> new GuestBookCardSimpleResponse(
+                guestBookCard.getId(),
+                guestBookCard.getNickname(),
+                guestBookCardPhotoRepository.existsByGuestBookCard(guestBookCard),
+                isHost ? guestBookCard.isRead() : null
+            )
+        );
         return new GuestBookResponse(simpleResponses);
     }
 

--- a/backend/forgather/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
+++ b/backend/forgather/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
@@ -132,10 +132,10 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
 
     @DisplayName("방명록은 각 방명록 카드의 방문자 닉네임과 사진 여부를 포함한다")
     @Test
-    void guestBookContainsNicknameAnd() {
+    void guestBookContainsNicknameAndPhoto() {
         // given
         WriteGuestBookCardResponse writeResponse = writeGuestBookCard(publicSpace);
-        WriteGuestBookCardResponse writeResponseWithNoPhoto = writeGuesetBookCardWithNoPhoto(publicSpace);
+        WriteGuestBookCardResponse writeResponseWithNoPhoto = writeGuestBookCardWithNoPhoto(publicSpace);
 
         // when
         GuestBookResponse result = RestAssuredMockMvc.given()
@@ -389,7 +389,7 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
             .as(WriteGuestBookCardResponse.class);
     }
 
-    private WriteGuestBookCardResponse writeGuesetBookCardWithNoPhoto(Space space) {
+    private WriteGuestBookCardResponse writeGuestBookCardWithNoPhoto(Space space) {
         WriteGuestBookCardRequest writeRequestWithNoPicture = new WriteGuestBookCardRequest(
             "nickname2",
             "message2",

--- a/backend/forgather/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
+++ b/backend/forgather/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.forgather.domain.guestbook.dto.DeleteGuestBookCardPhotosRequest;
 import com.forgather.domain.guestbook.dto.GuestBookCardResponse;
+import com.forgather.domain.guestbook.dto.GuestBookResponse;
 import com.forgather.domain.guestbook.dto.WriteGuestBookCardPhotoRequest;
 import com.forgather.domain.guestbook.dto.WriteGuestBookCardRequest;
 import com.forgather.domain.guestbook.dto.WriteGuestBookCardResponse;
@@ -32,9 +33,10 @@ import io.restassured.module.mockmvc.RestAssuredMockMvc;
 /**
  * TODO
  * 비공개 스페이스 & 호스트 -> 방명록 조회 가능
- * 미읽음 스페이스 호스트 조회 -> 읽음 처리
+ * 비공개 스페이스 & 호스트 -> 방명록 조회 시 읽음 여부 포함
+ * 비공개 스페이스 & 호스트 -> 방명록 카드 조회 가능
+ * 미읽음 호스트 조회 -> 읽음 처리
  * 호스트가 아니면 방명록 카드 삭제 불가
- * 다른 스페이스에 대한 작업
  * 호스트가 아니면 방명록 카드 사진 삭제 불가
  */
 @AutoConfigureMockMvc
@@ -68,6 +70,120 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
         spaceRepository.save(publicSpace);
         spaceRepository.save(privateSpace);
         RestAssuredMockMvc.mockMvc(mockMvc);
+    }
+
+    @DisplayName("공개 스페이스인 경우 방문자도 방명록 카드를 조회할 수 있다")
+    @Test
+    void guestCanReadGuestBookInPublicSpace() {
+        // given
+        writeGuestBookCard(publicSpace);
+        writeGuestBookCard(publicSpace);
+
+        // when
+        GuestBookResponse result = RestAssuredMockMvc.given()
+            .accept(ContentType.JSON)
+            .queryParam("page", 1)
+            .queryParam("size", 15)
+            .queryParam("sort", "createdAt,desc")
+            .queryParam("sort", "id,desc")
+            .when()
+            .get("/spaces/%s/guestbook".formatted(publicSpace.getCode()))
+            .then()
+            .statusCode(200)
+            .extract()
+            .body()
+            .as(GuestBookResponse.class);
+
+        // then
+        assertAll(
+            () -> assertThat(result.guestBookCards()).size().isEqualTo(2),
+            () -> assertThat(result.currentPage()).isEqualTo(1),
+            () -> assertThat(result.pageSize()).isEqualTo(15),
+            () -> assertThat(result.totalCount()).isEqualTo(2),
+            () -> assertThat(result.totalPages()).isEqualTo(1)
+        );
+    }
+
+    @DisplayName("방문자가 공개 스페이스의 방명록을 조회할 경우 방명록 카드 읽음 여부는 알지 못한다")
+    @Test
+    void guestCannotKnowIsCardRead() {
+        // given
+        writeGuestBookCard(publicSpace);
+
+        // when
+        boolean result = RestAssuredMockMvc.given()
+            .accept(ContentType.JSON)
+            .queryParam("page", 1)
+            .queryParam("size", 15)
+            .queryParam("sort", "createdAt,desc")
+            .queryParam("sort", "id,desc")
+            .when()
+            .get("/spaces/%s/guestbook".formatted(publicSpace.getCode()))
+            .then()
+            .statusCode(200)
+            .extract()
+            .body()
+            .asString()
+            .contains("\"isRead\"");
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @DisplayName("방명록은 각 방명록 카드의 방문자 닉네임과 사진 여부를 포함한다")
+    @Test
+    void guestBookContainsNicknameAnd() {
+        // given
+        WriteGuestBookCardResponse writeResponse = writeGuestBookCard(publicSpace);
+        WriteGuestBookCardResponse writeResponseWithNoPhoto = writeGuesetBookCardWithNoPhoto(publicSpace);
+
+        // when
+        GuestBookResponse result = RestAssuredMockMvc.given()
+            .accept(ContentType.JSON)
+            .queryParam("page", 1)
+            .queryParam("size", 15)
+            .queryParam("sort", "createdAt,desc")
+            .queryParam("sort", "id,desc")
+            .when()
+            .get("/spaces/%s/guestbook".formatted(publicSpace.getCode()))
+            .then()
+            .statusCode(200)
+            .extract()
+            .body()
+            .as(GuestBookResponse.class);
+
+        // then
+        assertAll(
+            () -> assertThat(result.guestBookCards()).size().isEqualTo(2),
+            () -> assertThat(result.guestBookCards().getFirst().nickname()).isEqualTo(writeResponseWithNoPhoto.nickname()),
+            () -> assertThat(result.guestBookCards().getFirst().containsPhoto()).isFalse(),
+            () -> assertThat(result.guestBookCards().getFirst().isRead()).isNull(),
+            () -> assertThat(result.guestBookCards().getLast().nickname()).isEqualTo(writeResponse.nickname()),
+            () -> assertThat(result.guestBookCards().getLast().containsPhoto()).isTrue(),
+            () -> assertThat(result.guestBookCards().getLast().isRead()).isNull(),
+            () -> assertThat(result.currentPage()).isEqualTo(1),
+            () -> assertThat(result.pageSize()).isEqualTo(15),
+            () -> assertThat(result.totalCount()).isEqualTo(2),
+            () -> assertThat(result.totalPages()).isEqualTo(1)
+        );
+    }
+
+    @DisplayName("비공개 스페이스인 경우 방문자는 방명록을 조회할 수 없다")
+    @Test
+    void throwExceptionWhenGuestReadGuestBookInPrivateSpace() {
+        // when, then
+        RestAssuredMockMvc.given()
+            .accept(ContentType.JSON)
+            .queryParam("page", 1)
+            .queryParam("size", 15)
+            .queryParam("sort", "createdAt,desc")
+            .queryParam("sort", "id,desc")
+            .log().all()
+            .when()
+            .get("/spaces/%s/guestbook".formatted(privateSpace.getCode()))
+            .then()
+            .statusCode(403)
+            .body("message", containsString("방문자는 비공개 스페이스의 방명록을 조회할 수 없습니다."));
     }
 
     @DisplayName("공개 스페이스인 경우 방문자도 방명록 카드를 조회할 수 있다")
@@ -262,6 +378,25 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
     private WriteGuestBookCardResponse writeGuestBookCard(Space space) {
         return RestAssuredMockMvc.given()
             .body(writeRequest)
+            .contentType(ContentType.JSON)
+            .accept(ContentType.JSON)
+            .when()
+            .post("/spaces/%s/guestbook".formatted(space.getCode()))
+            .then()
+            .statusCode(201)
+            .extract()
+            .body()
+            .as(WriteGuestBookCardResponse.class);
+    }
+
+    private WriteGuestBookCardResponse writeGuesetBookCardWithNoPhoto(Space space) {
+        WriteGuestBookCardRequest writeRequestWithNoPicture = new WriteGuestBookCardRequest(
+            "nickname2",
+            "message2",
+            List.of()
+        );
+        return RestAssuredMockMvc.given()
+            .body(writeRequestWithNoPicture)
             .contentType(ContentType.JSON)
             .accept(ContentType.JSON)
             .when()


### PR DESCRIPTION
## 연관된 이슈

- close #768 

## 작업 내용
- 방명록 조회 api 구현
  - 공개 스페이스일 경우에만 방문자가 방명록을 조회할 수 있다.
  - 방문자일 경우 방명록 조회 시 읽음 여부를 알 수 없다. (isRead 필드 아예 json에서 누락)
- 스웨거 호출 방식(페이지네이션) 수정 