### PR TITLE
fix: 2차 스프린트 QA 반영

### DIFF
--- a/frontend/src/components/@common/buttons/button/Button.styles.ts
+++ b/frontend/src/components/@common/buttons/button/Button.styles.ts
@@ -42,7 +42,9 @@ export const buttonStyles = {
 
   tertiary: (theme: Theme) => css`
     color: ${theme.colors.gray04};
-    ${theme.typography.captionSmall}
+    ${theme.typography.captionSmall};
+    border-radius: 4px;
+    border: solid 1px ${theme.colors.gray02};
   `,
 
   danger: (theme: Theme) => css`

--- a/frontend/src/components/@common/buttons/iconButton/IconButton.styles.ts
+++ b/frontend/src/components/@common/buttons/iconButton/IconButton.styles.ts
@@ -1,9 +1,6 @@
 import { css, type Theme } from '@emotion/react';
 import styled from '@emotion/styled';
-import type {
-  IconButtonSize,
-  IconButtonVariant,
-} from '../../../../types/button.type';
+import type { IconButtonSize, IconButtonVariant } from '../../../../types/button.type';
 
 export const IconButtonSizes = {
   small: 20,

--- a/frontend/src/components/@common/imageSwiper/ImageSwiper.styles.ts
+++ b/frontend/src/components/@common/imageSwiper/ImageSwiper.styles.ts
@@ -15,9 +15,7 @@ export const NoImageComment = styled.h2`
   text-align: center;
 `;
 
-export const ImageSwiperContainer = styled.div<{
-  $size?: 'default' | 'large';
-}>`
+export const ImageSwiperContainer = styled.div`
   width: 100%;
   margin: 0 auto;
 

--- a/frontend/src/components/@common/imageSwiper/ImageSwiper.styles.ts
+++ b/frontend/src/components/@common/imageSwiper/ImageSwiper.styles.ts
@@ -29,7 +29,7 @@ export const ImageSwiperContainer = styled.div`
     position: relative;
   }
   & .swiper-slide {
-   max-width: 80%;
+    max-width: 80%;
     height: auto;
     display: flex;
     justify-content: center;

--- a/frontend/src/components/@common/imageSwiper/ImageSwiper.tsx
+++ b/frontend/src/components/@common/imageSwiper/ImageSwiper.tsx
@@ -15,15 +15,15 @@ interface ImageSwiperProps {
   imageInfo: LocalFile[];
   /** 현재 인덱스 업데이트 */
   updateCurrentIndex: (index: number) => void;
-  /** 슬라이드 크기 */
-  size?: 'default' | 'large';
+  /** 슬라이드 간격 (px) */
+  spaceBetween?: number;
 }
 
 const ImageSwiper = ({
   initialIndex,
   imageInfo,
   updateCurrentIndex,
-  size = 'default',
+  spaceBetween = 20,
 }: ImageSwiperProps) => {
   const swiperRef = useRef<SwiperRef>(null);
 
@@ -43,10 +43,11 @@ const ImageSwiper = ({
       </S.NoImageContainer>
     );
   return (
-    <S.ImageSwiperContainer $size={size}>
+    <S.ImageSwiperContainer>
       <Swiper
         /** swiper 스타일 설정 */
         slidesPerView="auto"
+        spaceBetween={spaceBetween}
         pagination={{ clickable: true, type: 'fraction' }}
         modules={[Navigation, Pagination, EffectCoverflow]}
         centeredSlides={true}

--- a/frontend/src/components/specific/editForm/EditForm.tsx
+++ b/frontend/src/components/specific/editForm/EditForm.tsx
@@ -94,7 +94,9 @@ const EditForm = () => {
   return (
     <S.Form onSubmit={handleSubmit(onSubmit)}>
       <PhotoPreviewButton
-        originalSrc={watch('isDeletePhoto') ? undefined : spaceInfo?.spacePhoto.path}
+        originalSrc={
+          watch('isDeletePhoto') ? undefined : spaceInfo?.spacePhoto.path
+        }
         previewFile={previewFile}
         uploadImage={handleFilesUploadClick}
         clearFiles={() => clearFiles(localFiles)}

--- a/frontend/src/components/specific/editForm/EditForm.tsx
+++ b/frontend/src/components/specific/editForm/EditForm.tsx
@@ -29,6 +29,7 @@ const EditForm = () => {
     isPublic: false,
     email: '',
     instagramUsername: '',
+    isDeletePhoto: false,
   };
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: isSpaceInfoLoading, spaceInfo 변경 시에만 리셋
@@ -40,6 +41,7 @@ const EditForm = () => {
         isPublic: spaceInfo.isPublic,
         email: spaceInfo.email,
         instagramUsername: spaceInfo.instagramUsername,
+        isDeletePhoto: false,
       });
     }
   }, [isSpaceInfoLoading, spaceInfo]);
@@ -75,6 +77,10 @@ const EditForm = () => {
     patchSpaceInfo(data);
   };
 
+  const handleDeleteImage = () => {
+    setValue('isDeletePhoto', true, { shouldDirty: true });
+  };
+
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setValue('email', e.target.value, {
       shouldValidate: false,
@@ -88,13 +94,11 @@ const EditForm = () => {
   return (
     <S.Form onSubmit={handleSubmit(onSubmit)}>
       <PhotoPreviewButton
-        originalSrc={spaceInfo?.spacePhoto.path}
+        originalSrc={watch('isDeletePhoto') ? undefined : spaceInfo?.spacePhoto.path}
         previewFile={previewFile}
         uploadImage={handleFilesUploadClick}
         clearFiles={() => clearFiles(localFiles)}
-        deleteImage={() => {
-          console.log('사진 삭제 로직');
-        }}
+        deleteImage={handleDeleteImage}
       />
       <TextInput
         {...register('name', {

--- a/frontend/src/components/specific/imageSwiperActions/ImageSwiperActions.tsx
+++ b/frontend/src/components/specific/imageSwiperActions/ImageSwiperActions.tsx
@@ -17,8 +17,8 @@ interface ImageSwiperActionsProps {
   updateCurrentIndex: (index: number) => void;
   /** 액션 버튼 */
   actions: ImageSwiperActionsType[];
-  /** 슬라이드 크기 */
-  size?: 'default' | 'large';
+  /** 슬라이드 간격 (px) */
+  spaceBetween?: number;
 }
 
 const ImageSwiperActions = ({
@@ -26,7 +26,7 @@ const ImageSwiperActions = ({
   updateCurrentIndex,
   imageInfo,
   actions,
-  size = 'default',
+  spaceBetween,
 }: ImageSwiperActionsProps) => {
   return (
     <S.Wrapper>
@@ -34,7 +34,7 @@ const ImageSwiperActions = ({
         initialIndex={initialIndex}
         imageInfo={imageInfo}
         updateCurrentIndex={updateCurrentIndex}
-        size={size}
+        spaceBetween={spaceBetween}
       />
       <S.ButtonContainer>
         {actions.map((action, index) => (

--- a/frontend/src/components/specific/modal/loadingModal/LoadingModal.style.ts
+++ b/frontend/src/components/specific/modal/loadingModal/LoadingModal.style.ts
@@ -1,0 +1,50 @@
+import styled from '@emotion/styled';
+import { fadeIn } from '../../../../animations/animations';
+import { keyframes } from '@emotion/react';
+
+const spin = keyframes`
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+`;
+
+export const Backdrop = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: ${({ theme }) => theme.colors.black};
+  opacity: 0.8;
+  z-index: 9999;
+`;
+
+export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  align-items: center;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  animation: ${fadeIn} 0.4s ease forwards;
+  z-index: 10000;
+`;
+
+export const TextContainer = styled.p`
+  color: ${({ theme }) => theme.colors.white};
+  ${({ theme }) => theme.typography.captionSmall};
+`;
+
+export const Spinner = styled.div`
+  width: 50px;
+  height: 50px;
+  border: 4px solid ${({ theme }) => theme.colors.gray02};
+  border-top: 4px solid ${({ theme }) => theme.colors.white};
+  border-radius: 50%;
+  animation: ${spin} 1s linear infinite;
+`;

--- a/frontend/src/components/specific/modal/loadingModal/LoadingModal.tsx
+++ b/frontend/src/components/specific/modal/loadingModal/LoadingModal.tsx
@@ -1,0 +1,21 @@
+import Modal from '../../../@common/modal/Modal';
+import * as S from './LoadingModal.style';
+
+interface LoadingModalProps {
+  isOpen: boolean;
+  text?: string;
+}
+
+const LoadingModal = ({ isOpen, text = '전송 중...' }: LoadingModalProps) => {
+  return (
+    <Modal isOpen={isOpen} onClose={() => {}} closeOnEscape={false}>
+      <Modal.Backdrop />
+      <S.Wrapper>
+        <S.Spinner />
+        <S.TextContainer>{text}</S.TextContainer>
+      </S.Wrapper>
+    </Modal>
+  );
+};
+
+export default LoadingModal;

--- a/frontend/src/components/specific/modal/photoModal/PhotoModal.tsx
+++ b/frontend/src/components/specific/modal/photoModal/PhotoModal.tsx
@@ -1,10 +1,11 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { MdDeleteOutline, MdDownload } from 'react-icons/md';
 import { guestbookService } from '../../../../apis/services/guestbook/guestbook.service';
 import { useToast } from '../../../../hooks/@common/useToast';
 import { theme } from '../../../../styles/theme';
 import type { Photo } from '../../../../types/photo.type';
+import { buildImageUrl } from '../../../../utils/buildImageUrl';
 import { buildThumbnailUrl } from '../../../../utils/buildThumbnailUrl';
 import { downloadByAnchor, saveImage } from '../../../../utils/saveImage';
 import Modal from '../../../@common/modal/Modal';
@@ -34,7 +35,12 @@ const PhotoModal = ({
   const queryClient = useQueryClient();
   const { showToast } = useToast();
 
-  // TODO: 타입 수정 필요
+  useEffect(() => {
+    if (isOpen) {
+      setCurrentIndex(initialPhotoIndex);
+    }
+  }, [isOpen, initialPhotoIndex]);
+
   const imageInfo = photoList.map((photo) => ({
     id: photo.id,
     originFile: new File([], photo.originalName),
@@ -73,7 +79,7 @@ const PhotoModal = ({
 
   const downloadMutation = useMutation({
     mutationFn: async (photo: Photo) => {
-      const response = await fetch(photo.path);
+      const response = await fetch(buildImageUrl(photo.path));
       const blob = await response.blob();
 
       const isMobile = /Mobi|Android|iPhone|iPad|iPod/i.test(

--- a/frontend/src/components/specific/modal/photoModal/PhotoModal.tsx
+++ b/frontend/src/components/specific/modal/photoModal/PhotoModal.tsx
@@ -135,7 +135,6 @@ const PhotoModal = ({
           imageInfo={imageInfo}
           updateCurrentIndex={setCurrentIndex}
           actions={actions}
-          size="large"
         />
       </S.Wrapper>
     </Modal>

--- a/frontend/src/components/specific/photoPreviewButton/PhotoPreviewButton.tsx
+++ b/frontend/src/components/specific/photoPreviewButton/PhotoPreviewButton.tsx
@@ -4,6 +4,7 @@ import defaultImage from '../../../@assets/images/default-image.png';
 import { Thumbnail } from '../../../pages/MainPage.common.styles';
 import * as C from '../../../styles/@common/PhotoInput.styles';
 import type { PreviewFile } from '../../../types/file.type';
+import { buildImageUrl } from '../../../utils/buildImageUrl';
 import { createImageErrorHandler } from '../../../utils/createImageErrorHandler';
 import { handleKeyboardClick } from '../../../utils/keyboard';
 import * as S from './PhotoPreviewButton.styles';
@@ -27,7 +28,7 @@ const PhotoPreviewButton = ({
   const fileInputId = useId();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const originalImagePath = `${import.meta.env.VITE_IMAGE_BASE_URL}${originalSrc}`;
+  const originalImagePath = buildImageUrl(originalSrc || '');
 
   const matchThumbnailImage = () =>
     previewFile[0]?.previewUrl || originalImagePath || defaultImage;

--- a/frontend/src/components/specific/photoPreviewButton/PhotoPreviewButton.tsx
+++ b/frontend/src/components/specific/photoPreviewButton/PhotoPreviewButton.tsx
@@ -35,11 +35,10 @@ const PhotoPreviewButton = ({
   const isPhotoExist = !!previewFile[0]?.previewUrl || !!originalSrc;
 
   const deletePhoto = () => {
+    clearFiles();
     if (originalSrc) {
       deleteImage();
     }
-    // TODO : 성공시 아래 로직 실행
-    clearFiles();
   };
 
   return (

--- a/frontend/src/components/specific/photoUploadButton/PhotoUploadButton.styles.ts
+++ b/frontend/src/components/specific/photoUploadButton/PhotoUploadButton.styles.ts
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 export const Wrapper = styled.label<{ $isActive: boolean }>`
   width: 100%;
   cursor: ${({ $isActive }) => ($isActive ? 'pointer' : 'default')};
-  position: relative;
+  position: static;
 `;
 
 export const Container = styled.div<{ $isActive: boolean }>`

--- a/frontend/src/components/specific/photoUploadButton/PhotoUploadButton.tsx
+++ b/frontend/src/components/specific/photoUploadButton/PhotoUploadButton.tsx
@@ -63,6 +63,7 @@ const PhotoUploadButton = ({
         onChange={handleChange}
         accept="image/*"
         disabled={disabled}
+        style={{ display: 'none' }}
       />
     </S.Wrapper>
   );

--- a/frontend/src/hooks/domain/guestbook/usePostGuestbook.ts
+++ b/frontend/src/hooks/domain/guestbook/usePostGuestbook.ts
@@ -1,3 +1,4 @@
+import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { guestbookService } from '../../../apis/services/guestbook/guestbook.service';
 import { ROUTES } from '../../../constants/routes';
@@ -53,9 +54,9 @@ const usePostGuestbook = ({
     };
   };
 
-  const submitForm = async (photos: LocalFile[]) => {
-    console.log(photos);
-    try {
+  const mutation = useMutation({
+    mutationFn: async (photos: LocalFile[]) => {
+      console.log(photos);
       const form = await createGuestbookForm(photos);
       const result = await guestbookService.createGuestbook(
         spaceCode ?? '',
@@ -66,21 +67,26 @@ const usePostGuestbook = ({
         throw new Error('createGuestbook is failed');
       }
 
+      return { photos };
+    },
+    onSuccess: (data) => {
       navigate(ROUTES.GUEST.CREATE_GUESTBOOK_COMPLETE, {
         state: {
           receiver: receiver,
           guestNickName: formData.nickname,
         },
       });
-      clearFiles(photos);
-    } catch (error) {
+      clearFiles(data.photos);
+    },
+    onError: (error) => {
       console.error(error);
       showToast({ text: '전송에 실패했습니다.', type: 'error' });
-    }
-  };
+    },
+  });
 
   return {
-    submitForm,
+    submitForm: mutation.mutate,
+    isLoading: mutation.isPending,
   };
 };
 

--- a/frontend/src/pages/guest/guestbookPage/funnel/GuestbookFunnel.styles.ts
+++ b/frontend/src/pages/guest/guestbookPage/funnel/GuestbookFunnel.styles.ts
@@ -8,7 +8,7 @@ export const Wrapper = styled.div`
   justify-content: center;
   height: 100%;
   min-height: ${({ theme }) =>
-    `calc(100dvh - ${parseInt(theme.layout.padding.topBottom, 10) * 2}px)`};
+    `calc(100dvh - ${parseInt(theme.layout.padding.topBottom, 10) * 2 + parseInt(theme.layout.headerHeight, 10)}px)`};
 `;
 
 export const DisplayInfoContainer = styled.div`

--- a/frontend/src/pages/guest/guestbookPage/funnel/GuestbookFunnel.tsx
+++ b/frontend/src/pages/guest/guestbookPage/funnel/GuestbookFunnel.tsx
@@ -1,4 +1,5 @@
 import { useParams } from 'react-router-dom';
+import LoadingModal from '../../../../components/specific/modal/loadingModal/LoadingModal';
 import useConfirmBeforeRefresh from '../../../../hooks/@common/useConfirmBeforeRefresh';
 import useFormFunnel from '../../../../hooks/domain/funnel/useFormFunnel';
 import usePostGuestbook from '../../../../hooks/domain/guestbook/usePostGuestbook';
@@ -29,7 +30,7 @@ const GuestBookFunnel = () => {
 
   const { spaceCode } = useParams<{ spaceCode: string }>();
 
-  const { submitForm } = usePostGuestbook({
+  const { submitForm, isLoading } = usePostGuestbook({
     spaceCode: spaceCode ?? '',
     receiver: MOCK_RECEIVER,
     formData: {
@@ -40,34 +41,37 @@ const GuestBookFunnel = () => {
   });
 
   return (
-    <S.Wrapper>
-      <S.DisplayInfoContainer>
-        <S.DisplayImage src={mockData.thumbnail} alt="전시 썸네일 이미지" />
-        <S.DisplayName>{mockData.title}</S.DisplayName>
-      </S.DisplayInfoContainer>
-      <DividerLine width="15%" />
-      <Funnel.Step name="nickname">
-        <NicknameElement
-          receiver={MOCK_RECEIVER}
-          initialValue={Funnel.form.nickname}
-          onNext={(nickname) => Funnel.goNextWithData('message', { nickname })}
-        />
-      </Funnel.Step>
-      <Funnel.Step name="message">
-        <MessageElement
-          receiver={MOCK_RECEIVER}
-          initialValue={Funnel.form.message}
-          onNext={(message) => Funnel.goNextWithData('photos', { message })}
-        />
-      </Funnel.Step>
-      <Funnel.Step name="photos">
-        <PhotosElement
-          receiver={MOCK_RECEIVER}
-          onNextButtonClick={(photos) => submitForm(photos)}
-          initialLocalFiles={Funnel.form.photos}
-        />
-      </Funnel.Step>
-    </S.Wrapper>
+    <>
+      <LoadingModal isOpen={isLoading} text="전송 중..." />
+      <S.Wrapper>
+        <S.DisplayInfoContainer>
+          <S.DisplayImage src={mockData.thumbnail} alt="전시 썸네일 이미지" />
+          <S.DisplayName>{mockData.title}</S.DisplayName>
+        </S.DisplayInfoContainer>
+        <DividerLine width="15%" />
+        <Funnel.Step name="nickname">
+          <NicknameElement
+            receiver={MOCK_RECEIVER}
+            initialValue={Funnel.form.nickname}
+            onNext={(nickname) => Funnel.goNextWithData('message', { nickname })}
+          />
+        </Funnel.Step>
+        <Funnel.Step name="message">
+          <MessageElement
+            receiver={MOCK_RECEIVER}
+            initialValue={Funnel.form.message}
+            onNext={(message) => Funnel.goNextWithData('photos', { message })}
+          />
+        </Funnel.Step>
+        <Funnel.Step name="photos">
+          <PhotosElement
+            receiver={MOCK_RECEIVER}
+            onNextButtonClick={(photos) => submitForm(photos)}
+            initialLocalFiles={Funnel.form.photos}
+          />
+        </Funnel.Step>
+      </S.Wrapper>
+    </>
   );
 };
 

--- a/frontend/src/pages/guest/guestbookPage/funnel/funnel.validators.ts
+++ b/frontend/src/pages/guest/guestbookPage/funnel/funnel.validators.ts
@@ -1,13 +1,20 @@
 import { CONSTRAINTS } from '../../../../constants/constraints';
-import { checkMaxLength } from '../../../../validators/form.validators';
+import {
+  checkMaxLength,
+  checkNoWhitespaceOnly,
+} from '../../../../validators/form.validators';
 
 export const funnelValidators = {
   message: {
-    maxLength: (value: string) =>
-      checkMaxLength(value, CONSTRAINTS.MAX_LENGTH.GUESTBOOK.MESSAGE),
+    validator: (value: string) => {
+      checkNoWhitespaceOnly(value);
+      checkMaxLength(value, CONSTRAINTS.MAX_LENGTH.GUESTBOOK.MESSAGE);
+    },
   },
   nickname: {
-    maxLength: (value: string) =>
-      checkMaxLength(value, CONSTRAINTS.MAX_LENGTH.GUESTBOOK.NICKNAME),
+    validator: (value: string) => {
+      checkNoWhitespaceOnly(value);
+      checkMaxLength(value, CONSTRAINTS.MAX_LENGTH.GUESTBOOK.NICKNAME);
+    },
   },
 };

--- a/frontend/src/pages/guest/guestbookPage/funnelElements/messageElement/MessageElement.tsx
+++ b/frontend/src/pages/guest/guestbookPage/funnelElements/messageElement/MessageElement.tsx
@@ -24,7 +24,7 @@ const MessageElement = ({
   };
   const { isError, errorMessage } = createErrorMessageWithValidators({
     value: message,
-    validators: [funnelValidators.message.maxLength],
+    validators: [funnelValidators.message.validator],
   });
 
   const isDisabled = isError || calculateValidLength(message) === 0;

--- a/frontend/src/pages/guest/guestbookPage/funnelElements/nicknameElement/NicknameElement.tsx
+++ b/frontend/src/pages/guest/guestbookPage/funnelElements/nicknameElement/NicknameElement.tsx
@@ -28,10 +28,10 @@ const NicknameElement = ({
   };
   const { isError, errorMessage } = createErrorMessageWithValidators({
     value: nickname,
-    validators: [funnelValidators.nickname.maxLength],
+    validators: [funnelValidators.nickname.validator],
   });
   const validLength = calculateValidLength(nickname);
-  const isDisabled = isError || validLength === 0;
+  const isDisabled = isError || calculateValidLength(nickname) === 0;
 
   return (
     <FunnelBasePage

--- a/frontend/src/pages/guest/guestbookPage/funnelElements/photosElement/PhotosElement.tsx
+++ b/frontend/src/pages/guest/guestbookPage/funnelElements/photosElement/PhotosElement.tsx
@@ -74,6 +74,7 @@ const PhotosElement = ({
             initialIndex={0}
             updateCurrentIndex={updateCurrentIndex}
             actions={swiperActions}
+            spaceBetween={-30}
           />
         )
       }

--- a/frontend/src/pages/host/guestbook/card/GuestbookCardPage.tsx
+++ b/frontend/src/pages/host/guestbook/card/GuestbookCardPage.tsx
@@ -210,9 +210,8 @@ const GuestbookCardPage = () => {
             />
             <Button
               type="button"
-              variant="secondary"
+              variant="tertiary"
               text="사진 전체 다운로드"
-              style={{ border: 'none' }}
             />
           </S.PhotoSection>
         )}

--- a/frontend/src/pages/host/guestbook/card/GuestbookCardPage.tsx
+++ b/frontend/src/pages/host/guestbook/card/GuestbookCardPage.tsx
@@ -59,7 +59,6 @@ const GuestbookCardPage = () => {
     navigate(createGuestbookRoute(spaceCode));
   };
 
-  // guestbookCard.photos가 변경되면 localPhotoList를 업데이트
   useEffect(() => {
     setLocalPhotoList(guestbookCard.photos);
   }, [guestbookCard.photos]);
@@ -131,22 +130,20 @@ const GuestbookCardPage = () => {
         isOpen={isOnboardingOpen}
         onClose={handleModalClose}
       />
+      <PhotoModal
+        isOpen={isPhotoModalOpen}
+        photoList={localPhotoList}
+        initialPhotoIndex={selectedPhotoIndex}
+        spaceCode={spaceCode}
+        guestbookCardId={guestbookCardId}
+        onClose={handlePhotoModalClose}
+        onDelete={handlePhotoDelete}
+      />
       <S.Wrapper
         onTouchStart={handleTouchStart}
         onTouchEnd={handleTouchEnd}
         onTouchCancel={handleTouchCancel}
       >
-        <Activity mode={isPhotoModalOpen ? 'visible' : 'hidden'}>
-          <PhotoModal
-            isOpen={isPhotoModalOpen}
-            photoList={localPhotoList}
-            initialPhotoIndex={selectedPhotoIndex}
-            spaceCode={spaceCode}
-            guestbookCardId={guestbookCardId}
-            onClose={handlePhotoModalClose}
-            onDelete={handlePhotoDelete}
-          />
-        </Activity>
         <S.DeleteButtonContainer>
           <Button
             type="button"

--- a/frontend/src/pages/host/spaceCreate/funnel/SpaceCreateFunnel.styles.ts
+++ b/frontend/src/pages/host/spaceCreate/funnel/SpaceCreateFunnel.styles.ts
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 export const Wrapper = styled.div`
   width: 100%;
   min-height: ${({ theme }) =>
-    `calc(100dvh - ${parseInt(theme.layout.padding.topBottom, 10) * 2}px)`};
+    `calc(100dvh - ${parseInt(theme.layout.padding.topBottom, 10) * 2 + parseInt(theme.layout.headerHeight, 10)}px)`};
   display: flex;
   flex-direction: column;
   justify-content: space-between;

--- a/frontend/src/pages/host/spaceCreate/funnel/funnel.validators.ts
+++ b/frontend/src/pages/host/spaceCreate/funnel/funnel.validators.ts
@@ -2,19 +2,25 @@ import { CONSTRAINTS } from '../../../../constants/constraints';
 import {
   checkEmailForm,
   checkMaxLength,
+  checkNoWhitespaceOnly,
 } from '../../../../validators/form.validators';
 
 export const funnelValidators = {
   profileImage: () => {},
   name: (value: string) => {
+    checkNoWhitespaceOnly(value);
     checkMaxLength(value, CONSTRAINTS.MAX_LENGTH.SPACE.NAME);
   },
   visibility: () => {},
   description: (value: string) => {
+    checkNoWhitespaceOnly(value);
     checkMaxLength(value, CONSTRAINTS.MAX_LENGTH.SPACE.DESCRIPTION);
   },
   email: (value: string) => {
+    checkNoWhitespaceOnly(value);
     checkEmailForm(value);
   },
-  instagram: () => {},
+  instagram: (value: string) => {
+    checkNoWhitespaceOnly(value);
+  },
 };

--- a/frontend/src/pages/host/spaceCreate/funnelElements/SpaceNameElement.tsx
+++ b/frontend/src/pages/host/spaceCreate/funnelElements/SpaceNameElement.tsx
@@ -18,7 +18,7 @@ const SpaceNameElement = ({
     value: name,
     validators: [funnelValidators.name],
   });
-  const isDisabled = isError;
+  const isDisabled = isError || calculateValidLength(name) === 0;
 
   return (
     <FunnelBasePage

--- a/frontend/src/pages/host/spaceCreate/funnelElements/SpaceNameElement.tsx
+++ b/frontend/src/pages/host/spaceCreate/funnelElements/SpaceNameElement.tsx
@@ -18,7 +18,7 @@ const SpaceNameElement = ({
     value: name,
     validators: [funnelValidators.name],
   });
-  const isDisabled = isError || validLength === 0;
+  const isDisabled = isError;
 
   return (
     <FunnelBasePage

--- a/frontend/src/pages/host/spaceInfoPage/SpaceInfoPage.tsx
+++ b/frontend/src/pages/host/spaceInfoPage/SpaceInfoPage.tsx
@@ -7,6 +7,7 @@ import InfoRow from '../../../components/specific/infoRow/InfoRow';
 import { createSpaceInfoEditRoute } from '../../../constants/routes';
 import useSpaceDelete from '../../../hooks/domain/space/useSpaceDelete';
 import useSpaceInfo from '../../../hooks/domain/space/useSpaceInfo';
+import { buildImageUrl } from '../../../utils/buildImageUrl';
 import * as S from './SpaceInfoPage.styles';
 
 const SpaceInfoPage = () => {
@@ -30,6 +31,8 @@ const SpaceInfoPage = () => {
     spaceCode: spaceCode ?? '',
   });
 
+  console.log(spaceInfo);
+
   return (
     <S.Wrapper>
       <DeleteModal
@@ -39,9 +42,7 @@ const SpaceInfoPage = () => {
         buttonDisabled={isPending}
       />
       <S.Title>스페이스 정보</S.Title>
-      <Thumbnail
-        src={`${import.meta.env.VITE_IMAGE_BASE_URL}${spaceInfo?.spacePhoto.path}`}
-      />
+      <Thumbnail src={buildImageUrl(spaceInfo.spacePhoto.path)} />
       <S.InfoRowContainer>
         <InfoRow label="스페이스 이름" value={spaceInfo.name} />
         <InfoRow

--- a/frontend/src/pages/host/workDetail/HostWorkDetail.tsx
+++ b/frontend/src/pages/host/workDetail/HostWorkDetail.tsx
@@ -127,7 +127,7 @@ const HostWorkDetail = () => {
         </C.WorkContainer>
         <S.BottomSectionContainer>
           <Button
-            text="작품 소개 수정하기"
+            text="수정하기"
             onClick={() => navigate(createWorkEditRoute(spaceCode))}
           />
         </S.BottomSectionContainer>

--- a/frontend/src/pages/host/workForm/WorkForm.tsx
+++ b/frontend/src/pages/host/workForm/WorkForm.tsx
@@ -132,6 +132,7 @@ const WorkForm = () => {
               maxCount={CONSTRAINTS.MAX_LENGTH.WORK.CATEGORY}
               placeholder="카테고리를 입력하세요"
               validLength={calculateValidLength(watch('category'))}
+              errorMessage={errors.category?.message}
             />
           </S.FormLabelContainer>
 
@@ -144,6 +145,7 @@ const WorkForm = () => {
               maxCount={CONSTRAINTS.MAX_LENGTH.WORK.DESIGNER}
               validLength={calculateValidLength(watch('designer'))}
               placeholder="작가명을 입력하세요"
+              errorMessage={errors.designer?.message}
             />
           </S.FormLabelContainer>
 
@@ -158,6 +160,7 @@ const WorkForm = () => {
               placeholder="작품 설명을 입력하세요"
               rows={6}
               validLength={calculateValidLength(watch('description'))}
+              errorMessage={errors.description?.message}
             />
           </S.FormLabelContainer>
 

--- a/frontend/src/pages/host/workForm/WorkForm.tsx
+++ b/frontend/src/pages/host/workForm/WorkForm.tsx
@@ -215,8 +215,8 @@ const WorkForm = () => {
           <S.ButtonContainer>
             <Button
               type="submit"
-              text={isEditMode ? '작품 소개 수정하기' : '작품 소개 등록하기'}
-              variant="tertiary"
+              text={isEditMode ? '수정하기' : '등록하기'}
+              variant="fixed"
               disabled={!isAllValid}
             />
           </S.ButtonContainer>

--- a/frontend/src/router/router.tsx
+++ b/frontend/src/router/router.tsx
@@ -63,7 +63,6 @@ const routes: AppRouteObject[] = [
             path: 'create-space',
             element: <SpaceCreateFunnel />,
             handle: {
-              noHeader: true,
               noFooter: true,
             },
           },
@@ -106,7 +105,7 @@ const routes: AppRouteObject[] = [
             path: ':spaceCode/create-guestbook',
             element: <GuestBookFunnel />,
             handle: {
-              noHeader: true,
+              noFooter: true,
             },
           },
           {

--- a/frontend/src/types/domain/space.type.ts
+++ b/frontend/src/types/domain/space.type.ts
@@ -25,4 +25,5 @@ export interface SpaceInfoFormData {
   isPublic: boolean;
   email: string;
   instagramUsername: string;
+  isDeletePhoto?: boolean;
 }

--- a/frontend/src/utils/buildImageUrl.ts
+++ b/frontend/src/utils/buildImageUrl.ts
@@ -1,0 +1,7 @@
+export const buildImageUrl = (path: string): string => {
+  const baseUrl = import.meta.env.VITE_IMAGE_BASE_URL || '';
+
+  const parsedPath = path.replace(/^photogather\//, '');
+
+  return `${baseUrl}/${parsedPath}`;
+};

--- a/frontend/src/utils/buildThumbnailUrl.ts
+++ b/frontend/src/utils/buildThumbnailUrl.ts
@@ -12,9 +12,10 @@ export const buildThumbnailUrl = ({
   replacePath = 'product',
   preset = '800',
 }: BuildThumbnailUrlProps): string => {
-  const lastDotIndex = path.lastIndexOf('.');
+  const parsedPath = path.replace(/^photogather\//, '');
+  const lastDotIndex = parsedPath.lastIndexOf('.');
   const pathWithoutExt =
-    lastDotIndex !== -1 ? path.substring(0, lastDotIndex) : path;
+    lastDotIndex !== -1 ? parsedPath.substring(0, lastDotIndex) : parsedPath;
 
   const thumbnailPath = pathWithoutExt.replace(
     `/${replacePath}/`,
@@ -22,5 +23,5 @@ export const buildThumbnailUrl = ({
   );
 
   const baseUrl = import.meta.env.VITE_IMAGE_BASE_URL || '';
-  return `${baseUrl}${thumbnailPath}_x${preset}.webp`;
+  return `${baseUrl}/${thumbnailPath}_x${preset}.webp`;
 };

--- a/frontend/src/validators/form.validators.ts
+++ b/frontend/src/validators/form.validators.ts
@@ -12,6 +12,12 @@ export const checkMaxLength = (value: string, maxLength: number) => {
   }
 };
 
+export const checkNoWhitespaceOnly = (value: string) => {
+  if (value.length > 0 && value.trim() === '') {
+    throw new Error('공백만 입력할 수 없습니다.');
+  }
+};
+
 export const checkEmailForm = (value: string) => {
   if (value.length !== 0 && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)) {
     throw new Error('올바른 이메일 형식을 입력해 주세요.');

--- a/frontend/src/validators/form.validators.ts
+++ b/frontend/src/validators/form.validators.ts
@@ -1,7 +1,7 @@
 import { calculateValidLength } from '../utils/grapheme';
 
 export const checkInputEmpty = (value: string) => {
-  if (value.length === 0) {
+  if (value.trim() === '' || value.length === 0) {
     throw new Error('필수 항목입니다.');
   }
 };


### PR DESCRIPTION
## 연관된 이슈

- close #786 

## 작업 내용

### 작품 소개 수정
- fixed 버튼 스타일 수정
- input, textarea 필드 errormessage 나타나도록 수정
- 공백 예외처리

<img  height="400" alt="image" src="https://github.com/user-attachments/assets/7ba258a6-a27c-44dd-b917-03e3be7c8178" />

### 스페이스 정보 수정
- 사진 삭제
<img height="400" alt="image" src="https://github.com/user-attachments/assets/4d223118-fceb-4db9-9e47-0664a032e781" />

### 생성 퍼널
- 헤더 추가
- 푸터 제거 (불필요한 스크롤 발생)

<img height="400" alt="image" src="https://github.com/user-attachments/assets/f07b4f08-ea71-4e3b-9077-eef16eca78d7" />

### 방명록 조회
- 이미지 다운로드 정상화
- 전체 다운로드 보더 되돌림 -> 상단으로 올리자니, 너무 주요 컨텐츠 같아서 일단 하단에 두되, 잘 안보인다는 피드백만 반영하였습니다.
<img height="400" alt="image" src="https://github.com/user-attachments/assets/eba99c57-f941-4e9b-b84b-425439370ce2" />
<img height="400" alt="image" src="https://github.com/user-attachments/assets/a4fe0c27-fd9f-4a78-878f-e55b9cb3ed88" />

### 방명록 작성 퍼널
- 로딩 ui 추가
<img  height="400" alt="image" src="https://github.com/user-attachments/assets/9db07fe0-9b6d-47ee-b41a-e6530dcb3950" />
