### PR TITLE
feature: 방명록 api 호스트 검증

### DIFF
--- a/backend/forgather/src/main/java/com/forgather/domain/guestbook/controller/GuestBookController.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/guestbook/controller/GuestBookController.java
@@ -111,7 +111,7 @@ public class GuestBookController {
         @PathVariable(value = "spaceCode") String spaceCode,
         @PathVariable(value = "guestBookCardId") Long guestBookCardId,
         @RequestBody DeleteGuestBookCardPhotosRequest request,
-        @LoginHost(required = false) Host host // TODO true로 전환
+        @LoginHost(required = true) Host host
     ) {
         guestBookService.deleteCardPhotos(host, spaceCode, guestBookCardId, request);
         return ResponseEntity.noContent().build();

--- a/backend/forgather/src/main/java/com/forgather/domain/guestbook/controller/GuestBookController.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/guestbook/controller/GuestBookController.java
@@ -99,7 +99,7 @@ public class GuestBookController {
     public ResponseEntity<Void> deleteCard(
         @PathVariable(value = "spaceCode") String spaceCode,
         @PathVariable(value = "guestBookCardId") Long guestBookCardId,
-        @LoginHost(required = false) Host host // TODO true로 전환
+        @LoginHost(required = true) Host host
     ) {
         guestBookService.deleteCard(host, spaceCode, guestBookCardId);
         return ResponseEntity.noContent().build();

--- a/backend/forgather/src/main/java/com/forgather/domain/guestbook/controller/GuestBookController.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/guestbook/controller/GuestBookController.java
@@ -27,6 +27,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -40,6 +41,7 @@ public class GuestBookController {
 
     private final GuestBookService guestBookService;
 
+    @SecurityRequirement(name = "bearerAuth")
     @Operation(summary = "방명록 조회",
         description = "공개 스페이스가 아닌 경우 호스트만 조회 가능, 방문자는 isRead 필드 누락",
         parameters = {
@@ -73,6 +75,7 @@ public class GuestBookController {
         return ResponseEntity.ok(response);
     }
 
+    @SecurityRequirement(name = "bearerAuth")
     @Operation(summary = "방명록 카드 조회", description = "공개 스페이스가 아닌 경우 호스트만 조회 가능")
     @GetMapping("/{guestBookCardId}")
     public ResponseEntity<GuestBookCardResponse> readCard(
@@ -94,7 +97,8 @@ public class GuestBookController {
         return ResponseEntity.status(CREATED).body(response);
     }
 
-    @Operation(summary = "방명록 카드 삭제 (호스트)")
+    @SecurityRequirement(name = "bearerAuth")
+    @Operation(summary = "방명록 카드 삭제")
     @DeleteMapping("/{guestBookCardId}")
     public ResponseEntity<Void> deleteCard(
         @PathVariable(value = "spaceCode") String spaceCode,
@@ -105,7 +109,8 @@ public class GuestBookController {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "방명록 카드 사진 선택 삭제 (호스트)")
+    @SecurityRequirement(name = "bearerAuth")
+    @Operation(summary = "방명록 카드 사진 선택 삭제")
     @DeleteMapping("/{guestBookCardId}/photos")
     public ResponseEntity<Void> deleteCardPhotos(
         @PathVariable(value = "spaceCode") String spaceCode,

--- a/backend/forgather/src/main/java/com/forgather/domain/guestbook/model/GuestBookCardPhotos.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/guestbook/model/GuestBookCardPhotos.java
@@ -41,7 +41,7 @@ public class GuestBookCardPhotos {
         Set<Long> photosIdSet = new HashSet<>(photos.stream().map(Photo::getId).toList());
         for (Long deleteId : deleteIds) {
             if (!photosIdSet.contains(deleteId)) {
-                throw new BaseException("방명록 카드에 존재하지 않는 사진입니다. deletePhotoId: " + deleteId);
+                throw new BaseException("해당 방명록 카드에 존재하지 않는 사진입니다. deletePhotoId: " + deleteId);
             }
         }
     }

--- a/backend/forgather/src/main/java/com/forgather/domain/guestbook/service/GuestBookService.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/guestbook/service/GuestBookService.java
@@ -136,6 +136,7 @@ public class GuestBookService {
         deleteGuestBookCardPhotos(photos);
     }
 
+    @Transactional
     public void deleteCardPhotos(
         Host host,
         String spaceCode,
@@ -143,7 +144,7 @@ public class GuestBookService {
         DeleteGuestBookCardPhotosRequest request
     ) {
         Space space = spaceRepository.getByCodeOrThrow(spaceCode);
-        // validateSpaceHost(host, space); // TODO 검증 활성화
+        validateSpaceHost(host, space);
         GuestBookCardPhotos guestBookCardPhotos = getGuestBookCardPhotos(space, guestBookCardId);
         List<GuestBookCardPhoto> deletedPhotos = guestBookCardPhotos.deleteByIds(request.deletePhotoIds());
         deleteGuestBookCardPhotos(deletedPhotos);

--- a/backend/forgather/src/main/java/com/forgather/domain/guestbook/service/GuestBookService.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/guestbook/service/GuestBookService.java
@@ -2,6 +2,7 @@ package com.forgather.domain.guestbook.service;
 
 import static com.forgather.domain.upload.domain.FilePathGenerator.generateContentsFilePath;
 import static com.forgather.domain.upload.domain.UploadCategory.GUESTBOOK;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -124,7 +125,7 @@ public class GuestBookService {
     @Transactional
     public void deleteCard(Host host, String spaceCode, Long guestBookCardId) {
         Space space = spaceRepository.getByCodeOrThrow(spaceCode);
-        // validateSpaceHost(host, space); // TODO 검증 활성화
+        validateSpaceHost(host, space);
         GuestBookCard guestBookCard = getGuestBookCard(guestBookCardId, space);
         deleteGuestBookCardPhotos(guestBookCard);
         guestBookCardRepository.delete(guestBookCard);
@@ -175,7 +176,7 @@ public class GuestBookService {
 
     private boolean isSpaceHost(Space space, Host host) {
         if (space == null || host == null) {
-            throw new BaseNullPointerException("스페이스와 호스트는 null일 수 없습니다.");
+            throw new BaseNullPointerException("스페이스와 호스트는 null일 수 없습니다.", INTERNAL_SERVER_ERROR);
         }
         return spaceHostMapRepository.findBySpaceAndHost(space, host).isPresent();
     }

--- a/backend/forgather/src/main/java/com/forgather/global/config/SwaggerConfig.java
+++ b/backend/forgather/src/main/java/com/forgather/global/config/SwaggerConfig.java
@@ -9,7 +9,6 @@ import org.springframework.context.annotation.Configuration;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
-import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 
@@ -32,7 +31,7 @@ public class SwaggerConfig {
                         .description("JWT 토큰을 입력하세요")
                 )
             )
-            .addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
+            // .addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
             .servers(List.of(
                 new Server().url(serverUrl).description("API Server")
             ));

--- a/backend/forgather/src/main/java/com/forgather/global/exception/GlobalExceptionHandler.java
+++ b/backend/forgather/src/main/java/com/forgather/global/exception/GlobalExceptionHandler.java
@@ -132,7 +132,7 @@ public class GlobalExceptionHandler {
         logClientWarning(e);
         return ResponseEntity.status(UNAUTHORIZED)
             .contentType(APPLICATION_JSON)
-            .body(ErrorResponse.from("인증에 실패했습니다."));
+            .body(ErrorResponse.from(e.getMessage()));
     }
 
     @ExceptionHandler(ForbiddenException.class)
@@ -148,7 +148,7 @@ public class GlobalExceptionHandler {
         logClientWarning(e);
         return ResponseEntity.status(e.getStatusCode())
             .contentType(APPLICATION_JSON)
-            .body(ErrorResponse.from("인증 토큰이 유효하지 않습니다."));
+            .body(ErrorResponse.from(e.getMessage()));
     }
 
     /**

--- a/backend/forgather/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
+++ b/backend/forgather/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
@@ -67,10 +67,8 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
 
     private Space publicSpace;
     private Space privateSpace;
-    private Host host;
     private String accessToken;
     private String anotherAccessToken;
-    private Host anotherHost;
     private WriteGuestBookCardRequest writeRequest = new WriteGuestBookCardRequest(
         "nickname",
         "message",
@@ -88,8 +86,8 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
         spaceRepository.save(publicSpace);
         spaceRepository.save(privateSpace);
 
-        host = HostFixture.createHost();
-        anotherHost = HostFixture.createHost();
+        Host host = HostFixture.createHost();
+        Host anotherHost = HostFixture.createHost();
         hostRepository.save(host);
         hostRepository.save(anotherHost);
         accessToken = jwtTokenProvider.generateAccessToken(host.getId());
@@ -269,7 +267,6 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
                 .when()
                 .get("/spaces/%s/guestbook".formatted(publicSpace.getCode()))
                 .then()
-                .log().all()
                 .statusCode(200)
                 .extract()
                 .body()

--- a/backend/forgather/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
+++ b/backend/forgather/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
@@ -364,6 +364,40 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
                 .then()
                 .statusCode(200);
         }
+
+        @DisplayName("호스트가 방명록 카드를 조회하면 읽음 처리된다")
+        @Test
+        void markCardAsReadWhenHostRead() {
+            // given
+            WriteGuestBookCardResponse writeResponse = writeGuestBookCard(publicSpace);
+
+            // when
+            RestAssuredMockMvc.given()
+                .header("Authorization", "Bearer " + accessToken)
+                .accept(ContentType.JSON)
+                .when()
+                .get("/spaces/%s/guestbook/%d".formatted(publicSpace.getCode(), writeResponse.id()))
+                .then()
+                .statusCode(200);
+
+            // then
+            GuestBookResponse result = RestAssuredMockMvc.given()
+                .header("Authorization", "Bearer " + accessToken)
+                .accept(ContentType.JSON)
+                .queryParam("page", 1)
+                .queryParam("size", 15)
+                .queryParam("sort", "createdAt,desc")
+                .queryParam("sort", "id,desc")
+                .when()
+                .get("/spaces/%s/guestbook".formatted(publicSpace.getCode()))
+                .then()
+                .statusCode(200)
+                .extract()
+                .body()
+                .as(GuestBookResponse.class);
+
+            assertThat(result.guestBookCards().getFirst().isRead()).isTrue();
+        }
     }
 
     @DisplayName("방명록 카드 작성")

--- a/backend/forgather/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
+++ b/backend/forgather/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
@@ -543,6 +543,7 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
 
             // when
             RestAssuredMockMvc.given()
+                .header("Authorization", "Bearer " + accessToken)
                 .contentType(ContentType.JSON)
                 .body(request)
                 .when()
@@ -564,6 +565,53 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(response.photos()).size().isEqualTo(1),
                 () -> assertThat(response.photos().getFirst().id()).isEqualTo(writeResponse.photos().get(1).id())
             );
+        }
+
+        @DisplayName("방문자가 방명록 카드 사진을 삭제하면 예외를 던진다")
+        @Test
+        void throwExceptionWhenGuestDeleteCardPhotos() {
+            // given
+            WriteGuestBookCardResponse writeResponse = writeGuestBookCard(publicSpace);
+            DeleteGuestBookCardPhotosRequest request = new DeleteGuestBookCardPhotosRequest(
+                List.of(
+                    writeResponse.photos().get(0).id(),
+                    writeResponse.photos().get(2).id()
+                )
+            );
+
+            // when
+            RestAssuredMockMvc.given()
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when()
+                .delete("/spaces/%s/guestbook/%d/photos".formatted(publicSpace.getCode(), writeResponse.id()))
+                .then()
+                .statusCode(401)
+                .body("message", containsString("로그인이 필요합니다."));
+        }
+
+        @DisplayName("다른 호스트의 방명록 카드 사진을 삭제하면 예외를 던진다")
+        @Test
+        void throwExceptionWhenAnotherHostDeleteCardPhotos() {
+            // given
+            WriteGuestBookCardResponse writeResponse = writeGuestBookCard(publicSpace);
+            DeleteGuestBookCardPhotosRequest request = new DeleteGuestBookCardPhotosRequest(
+                List.of(
+                    writeResponse.photos().get(0).id(),
+                    writeResponse.photos().get(2).id()
+                )
+            );
+
+            // when
+            RestAssuredMockMvc.given()
+                .header("Authorization", "Bearer " + anotherAccessToken)
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when()
+                .delete("/spaces/%s/guestbook/%d/photos".formatted(publicSpace.getCode(), writeResponse.id()))
+                .then()
+                .statusCode(403)
+                .body("message", containsString("해당 스페이스에 대한 접근 권한이 없습니다."));
         }
     }
 

--- a/backend/forgather/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
+++ b/backend/forgather/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
@@ -37,13 +37,6 @@ import com.forgather.global.auth.util.JwtTokenProvider;
 import io.restassured.http.ContentType;
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
 
-/**
- * TODO
- * 비공개 스페이스 & 호스트 -> 방명록 조회 시 읽음 여부 포함
- * 비공개 스페이스 & 호스트 -> 방명록 카드 조회 가능
- * 미읽음 호스트 조회 -> 읽음 처리
- * 호스트가 아니면 방명록 카드 사진 삭제 불가
- */
 @AutoConfigureMockMvc
 public class GuestBookCardAcceptanceTest extends AcceptanceTest {
 

--- a/backend/forgather/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
+++ b/backend/forgather/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
@@ -610,6 +610,29 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
                 .statusCode(403)
                 .body("message", containsString("해당 스페이스에 대한 접근 권한이 없습니다."));
         }
+
+        @DisplayName("다른 방명록 카드의 사진을 삭제하면 예외를 던진다")
+        @Test
+        void throwExceptionWhenDeletePhotosInAnotherCard() {
+            // given
+            WriteGuestBookCardResponse writeResponse = writeGuestBookCard(publicSpace);
+            DeleteGuestBookCardPhotosRequest request = new DeleteGuestBookCardPhotosRequest(
+                List.of(
+                    writeResponse.photos().get(2).id() + 1
+                )
+            );
+
+            // when
+            RestAssuredMockMvc.given()
+                .header("Authorization", "Bearer " + accessToken)
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when()
+                .delete("/spaces/%s/guestbook/%d/photos".formatted(publicSpace.getCode(), writeResponse.id()))
+                .then()
+                .statusCode(400)
+                .body("message", containsString("해당 방명록 카드에 존재하지 않는 사진입니다."));
+        }
     }
 
     private WriteGuestBookCardResponse writeGuestBookCard(Space space) {

--- a/backend/forgather/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
+++ b/backend/forgather/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
@@ -10,6 +10,7 @@ import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -100,213 +101,272 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
         RestAssuredMockMvc.mockMvc(mockMvc);
     }
 
-    @DisplayName("공개 스페이스인 경우 방문자도 방명록을 조회할 수 있다")
-    @Test
-    void guestCanReadGuestBookInPublicSpace() {
-        // given
-        writeGuestBookCard(publicSpace);
-        writeGuestBookCard(publicSpace);
+    @DisplayName("방명록 조회")
+    @Nested
+    class readGuestBook {
+        @DisplayName("공개 스페이스인 경우 방문자도 방명록을 조회할 수 있다")
+        @Test
+        void guestCanReadGuestBookInPublicSpace() {
+            // given
+            writeGuestBookCard(publicSpace);
+            writeGuestBookCard(publicSpace);
 
-        // when
-        GuestBookResponse result = RestAssuredMockMvc.given()
-            .accept(ContentType.JSON)
-            .queryParam("page", 1)
-            .queryParam("size", 15)
-            .queryParam("sort", "createdAt,desc")
-            .queryParam("sort", "id,desc")
-            .when()
-            .get("/spaces/%s/guestbook".formatted(publicSpace.getCode()))
-            .then()
-            .statusCode(200)
-            .extract()
-            .body()
-            .as(GuestBookResponse.class);
+            // when
+            GuestBookResponse result = RestAssuredMockMvc.given()
+                .accept(ContentType.JSON)
+                .queryParam("page", 1)
+                .queryParam("size", 15)
+                .queryParam("sort", "createdAt,desc")
+                .queryParam("sort", "id,desc")
+                .when()
+                .get("/spaces/%s/guestbook".formatted(publicSpace.getCode()))
+                .then()
+                .statusCode(200)
+                .extract()
+                .body()
+                .as(GuestBookResponse.class);
 
-        // then
-        assertAll(
-            () -> assertThat(result.guestBookCards()).size().isEqualTo(2),
-            () -> assertThat(result.currentPage()).isEqualTo(1),
-            () -> assertThat(result.pageSize()).isEqualTo(15),
-            () -> assertThat(result.totalCount()).isEqualTo(2),
-            () -> assertThat(result.totalPages()).isEqualTo(1)
-        );
+            // then
+            assertAll(
+                () -> assertThat(result.guestBookCards()).size().isEqualTo(2),
+                () -> assertThat(result.currentPage()).isEqualTo(1),
+                () -> assertThat(result.pageSize()).isEqualTo(15),
+                () -> assertThat(result.totalCount()).isEqualTo(2),
+                () -> assertThat(result.totalPages()).isEqualTo(1)
+            );
+        }
+
+        @DisplayName("방문자가 공개 스페이스의 방명록을 조회할 경우 방명록 카드 읽음 여부는 알지 못한다")
+        @Test
+        void guestCannotKnowIsCardRead() {
+            // given
+            writeGuestBookCard(publicSpace);
+
+            // when
+            boolean result = RestAssuredMockMvc.given()
+                .accept(ContentType.JSON)
+                .queryParam("page", 1)
+                .queryParam("size", 15)
+                .queryParam("sort", "createdAt,desc")
+                .queryParam("sort", "id,desc")
+                .when()
+                .get("/spaces/%s/guestbook".formatted(publicSpace.getCode()))
+                .then()
+                .statusCode(200)
+                .extract()
+                .body()
+                .asString()
+                .contains("\"isRead\"");
+
+            // then
+            assertThat(result).isFalse();
+        }
+
+        @DisplayName("방문자 조회 시 방명록은 각 방명록 카드의 방문자 닉네임과 사진 여부를 포함한다")
+        @Test
+        void guestBookContainsNicknameAndPhoto() {
+            // given
+            WriteGuestBookCardResponse writeResponse = writeGuestBookCard(publicSpace);
+            WriteGuestBookCardResponse writeResponseWithNoPhoto = writeGuestBookCardWithNoPhoto(publicSpace);
+
+            // when
+            GuestBookResponse result = RestAssuredMockMvc.given()
+                .accept(ContentType.JSON)
+                .queryParam("page", 1)
+                .queryParam("size", 15)
+                .queryParam("sort", "createdAt,desc")
+                .queryParam("sort", "id,desc")
+                .when()
+                .get("/spaces/%s/guestbook".formatted(publicSpace.getCode()))
+                .then()
+                .statusCode(200)
+                .extract()
+                .body()
+                .as(GuestBookResponse.class);
+
+            // then
+            assertAll(
+                () -> assertThat(result.guestBookCards()).size().isEqualTo(2),
+                () -> assertThat(result.guestBookCards().getFirst().nickname()).isEqualTo(writeResponseWithNoPhoto.nickname()),
+                () -> assertThat(result.guestBookCards().getFirst().containsPhoto()).isFalse(),
+                () -> assertThat(result.guestBookCards().getFirst().isRead()).isNull(),
+                () -> assertThat(result.guestBookCards().getLast().nickname()).isEqualTo(writeResponse.nickname()),
+                () -> assertThat(result.guestBookCards().getLast().containsPhoto()).isTrue(),
+                () -> assertThat(result.guestBookCards().getLast().isRead()).isNull(),
+                () -> assertThat(result.currentPage()).isEqualTo(1),
+                () -> assertThat(result.pageSize()).isEqualTo(15),
+                () -> assertThat(result.totalCount()).isEqualTo(2),
+                () -> assertThat(result.totalPages()).isEqualTo(1)
+            );
+        }
+
+        @DisplayName("비공개 스페이스인 경우 방문자는 방명록을 조회할 수 없다")
+        @Test
+        void throwExceptionWhenGuestReadGuestBookInPrivateSpace() {
+            // when, then
+            RestAssuredMockMvc.given()
+                .accept(ContentType.JSON)
+                .queryParam("page", 1)
+                .queryParam("size", 15)
+                .queryParam("sort", "createdAt,desc")
+                .queryParam("sort", "id,desc")
+                .when()
+                .get("/spaces/%s/guestbook".formatted(privateSpace.getCode()))
+                .then()
+                .statusCode(403)
+                .body("message", containsString("방문자는 비공개 스페이스의 방명록을 조회할 수 없습니다."));
+        }
+
+        @DisplayName("호스트는 자신의 비공개 스페이스 방명록을 조회할 수 있다")
+        @Test
+        void hostCanReadGuestBookInPrivateSpace() {
+            // when, then
+            RestAssuredMockMvc.given()
+                .header("Authorization", "Bearer " + accessToken)
+                .accept(ContentType.JSON)
+                .queryParam("page", 1)
+                .queryParam("size", 15)
+                .queryParam("sort", "createdAt,desc")
+                .queryParam("sort", "id,desc")
+                .when()
+                .get("/spaces/%s/guestbook".formatted(privateSpace.getCode()))
+                .then()
+                .statusCode(200);
+        }
+
+        @DisplayName("다른 호스트의 비공개 스페이스 방명록을 조회하면 예외를 던진다")
+        @Test
+        void throwExceptionWhenAnotherHostReadGuestBookInPrivateSpace() {
+            // when, then
+            RestAssuredMockMvc.given()
+                .header("Authorization", "Bearer " + anotherAccessToken)
+                .accept(ContentType.JSON)
+                .queryParam("page", 1)
+                .queryParam("size", 15)
+                .queryParam("sort", "createdAt,desc")
+                .queryParam("sort", "id,desc")
+                .when()
+                .get("/spaces/%s/guestbook".formatted(privateSpace.getCode()))
+                .then()
+                .statusCode(403)
+                .body("message", containsString("방문자는 비공개 스페이스의 방명록을 조회할 수 없습니다."));
+        }
+
+        @DisplayName("호스트가 방명록을 조회할 경우 방명록 카드 읽음 여부를 알 수 있다")
+        @Test
+        void hostCanKnowIsCardRead() {
+            // given
+            writeGuestBookCard(publicSpace);
+
+            // when
+            boolean result = RestAssuredMockMvc.given()
+                .header("Authorization", "Bearer " + accessToken)
+                .accept(ContentType.JSON)
+                .queryParam("page", 1)
+                .queryParam("size", 15)
+                .queryParam("sort", "createdAt,desc")
+                .queryParam("sort", "id,desc")
+                .when()
+                .get("/spaces/%s/guestbook".formatted(publicSpace.getCode()))
+                .then()
+                .log().all()
+                .statusCode(200)
+                .extract()
+                .body()
+                .asString()
+                .contains("\"isRead\"");
+
+            // then
+            assertThat(result).isTrue();
+        }
     }
 
-    @DisplayName("방문자가 공개 스페이스의 방명록을 조회할 경우 방명록 카드 읽음 여부는 알지 못한다")
-    @Test
-    void guestCannotKnowIsCardRead() {
-        // given
-        writeGuestBookCard(publicSpace);
+    @DisplayName("방명록 카드 조회")
+    @Nested
+    class readGuestBookCard {
+        @DisplayName("공개 스페이스인 경우 방문자는 방명록 카드를 조회할 수 있다")
+        @Test
+        void guestCanReadCardInPublicSpace() {
+            // given
+            WriteGuestBookCardResponse writeResponse = writeGuestBookCard(publicSpace);
 
-        // when
-        boolean result = RestAssuredMockMvc.given()
-            .accept(ContentType.JSON)
-            .queryParam("page", 1)
-            .queryParam("size", 15)
-            .queryParam("sort", "createdAt,desc")
-            .queryParam("sort", "id,desc")
-            .when()
-            .get("/spaces/%s/guestbook".formatted(publicSpace.getCode()))
-            .then()
-            .statusCode(200)
-            .extract()
-            .body()
-            .asString()
-            .contains("\"isRead\"");
+            // when
+            GuestBookCardResponse result = RestAssuredMockMvc.given()
+                .accept(ContentType.JSON)
+                .when()
+                .get("/spaces/%s/guestbook/%d".formatted(publicSpace.getCode(), writeResponse.id()))
+                .then()
+                .statusCode(200)
+                .extract()
+                .body()
+                .as(GuestBookCardResponse.class);
 
-        // then
-        assertThat(result).isFalse();
-    }
+            // then
+            assertAll(
+                () -> assertThat(result.id()).isNotNull(),
+                () -> assertThat(result.nickname()).isEqualTo(writeRequest.nickname()),
+                () -> assertThat(result.message()).isEqualTo(writeRequest.message()),
+                () -> assertThat(result.createdAt()).isBetween(LocalDateTime.now().minusMinutes(1), LocalDateTime.now()),
 
-    @DisplayName("방문자 조회 시 방명록은 각 방명록 카드의 방문자 닉네임과 사진 여부를 포함한다")
-    @Test
-    void guestBookContainsNicknameAndPhoto() {
-        // given
-        WriteGuestBookCardResponse writeResponse = writeGuestBookCard(publicSpace);
-        WriteGuestBookCardResponse writeResponseWithNoPhoto = writeGuestBookCardWithNoPhoto(publicSpace);
+                () -> assertThat(result.photos().get(0).originalName()).isEqualTo("photo1.jpg"),
+                () -> assertThat(result.photos().get(0).path()).endsWith("/spaces/1234567890/guestbook/abc.jpg"),
 
-        // when
-        GuestBookResponse result = RestAssuredMockMvc.given()
-            .accept(ContentType.JSON)
-            .queryParam("page", 1)
-            .queryParam("size", 15)
-            .queryParam("sort", "createdAt,desc")
-            .queryParam("sort", "id,desc")
-            .when()
-            .get("/spaces/%s/guestbook".formatted(publicSpace.getCode()))
-            .then()
-            .statusCode(200)
-            .extract()
-            .body()
-            .as(GuestBookResponse.class);
+                () -> assertThat(result.photos().get(1).originalName()).isEqualTo("photo2.jpg"),
+                () -> assertThat(result.photos().get(1).path()).endsWith("/spaces/1234567890/guestbook/def.jpg"),
 
-        // then
-        assertAll(
-            () -> assertThat(result.guestBookCards()).size().isEqualTo(2),
-            () -> assertThat(result.guestBookCards().getFirst().nickname()).isEqualTo(writeResponseWithNoPhoto.nickname()),
-            () -> assertThat(result.guestBookCards().getFirst().containsPhoto()).isFalse(),
-            () -> assertThat(result.guestBookCards().getFirst().isRead()).isNull(),
-            () -> assertThat(result.guestBookCards().getLast().nickname()).isEqualTo(writeResponse.nickname()),
-            () -> assertThat(result.guestBookCards().getLast().containsPhoto()).isTrue(),
-            () -> assertThat(result.guestBookCards().getLast().isRead()).isNull(),
-            () -> assertThat(result.currentPage()).isEqualTo(1),
-            () -> assertThat(result.pageSize()).isEqualTo(15),
-            () -> assertThat(result.totalCount()).isEqualTo(2),
-            () -> assertThat(result.totalPages()).isEqualTo(1)
-        );
-    }
+                () -> assertThat(result.photos().get(2).originalName()).isEqualTo("photo3.jpg"),
+                () -> assertThat(result.photos().get(2).path()).endsWith("/spaces/1234567890/guestbook/ghi.jpg")
+            );
+        }
 
-    @DisplayName("비공개 스페이스인 경우 방문자는 방명록을 조회할 수 없다")
-    @Test
-    void throwExceptionWhenGuestReadGuestBookInPrivateSpace() {
-        // when, then
-        RestAssuredMockMvc.given()
-            .accept(ContentType.JSON)
-            .queryParam("page", 1)
-            .queryParam("size", 15)
-            .queryParam("sort", "createdAt,desc")
-            .queryParam("sort", "id,desc")
-            .when()
-            .get("/spaces/%s/guestbook".formatted(privateSpace.getCode()))
-            .then()
-            .statusCode(403)
-            .body("message", containsString("방문자는 비공개 스페이스의 방명록을 조회할 수 없습니다."));
-    }
+        @DisplayName("비공개 스페이스인 경우 방문자는 방명록 카드를 조회할 수 없다")
+        @Test
+        void throwExceptionWhenGuestReadCardInPrivateSpace() {
+            // given
+            WriteGuestBookCardResponse writeResponse = writeGuestBookCard(privateSpace);
 
-    @DisplayName("호스트는 자신의 비공개 스페이스 방명록을 조회할 수 있다")
-    @Test
-    void hostCanReadGuestBookInPrivateSpace() {
-        // when, then
-        RestAssuredMockMvc.given()
-            .header("Authorization", "Bearer " + accessToken)
-            .accept(ContentType.JSON)
-            .queryParam("page", 1)
-            .queryParam("size", 15)
-            .queryParam("sort", "createdAt,desc")
-            .queryParam("sort", "id,desc")
-            .when()
-            .get("/spaces/%s/guestbook".formatted(privateSpace.getCode()))
-            .then()
-            .statusCode(200);
-    }
+            // when, then
+            RestAssuredMockMvc.given()
+                .accept(ContentType.JSON)
+                .when()
+                .get("/spaces/%s/guestbook/%d".formatted(privateSpace.getCode(), writeResponse.id()))
+                .then()
+                .statusCode(403)
+                .body("message", containsString("방문자는 비공개 스페이스의 방명록을 조회할 수 없습니다."));
+        }
 
-    @DisplayName("호스트가 방명록을 조회할 경우 방명록 카드 읽음 여부를 알 수 있다")
-    @Test
-    void hostCanKnowIsCardRead() {
-        // given
-        writeGuestBookCard(publicSpace);
+        @DisplayName("다른 호스트의 비공개 스페이스 방명록 카드를 조회할 수 없다")
+        @Test
+        void throwExceptionWhenAnotherHostReadCardInPrivateSpace() {
+            // given
+            WriteGuestBookCardResponse writeResponse = writeGuestBookCard(privateSpace);
 
-        // when
-        boolean result = RestAssuredMockMvc.given()
-            .header("Authorization", "Bearer " + accessToken)
-            .accept(ContentType.JSON)
-            .queryParam("page", 1)
-            .queryParam("size", 15)
-            .queryParam("sort", "createdAt,desc")
-            .queryParam("sort", "id,desc")
-            .when()
-            .get("/spaces/%s/guestbook".formatted(publicSpace.getCode()))
-            .then()
-            .log().all()
-            .statusCode(200)
-            .extract()
-            .body()
-            .asString()
-            .contains("\"isRead\"");
+            // when, then
+            RestAssuredMockMvc.given()
+                .header("Authorization", "Bearer " + anotherAccessToken)
+                .accept(ContentType.JSON)
+                .when()
+                .get("/spaces/%s/guestbook/%d".formatted(privateSpace.getCode(), writeResponse.id()))
+                .then()
+                .statusCode(403)
+                .body("message", containsString("방문자는 비공개 스페이스의 방명록을 조회할 수 없습니다."));
+        }
 
-        // then
-        assertThat(result).isTrue();
-    }
+        @DisplayName("호스트는 비공개 스페이스의 방명록 카드를 조회할 수 있다")
+        @Test
+        void hostCanReadCardInPublicSpace() {
+            // given
+            WriteGuestBookCardResponse writeResponse = writeGuestBookCard(privateSpace);
 
-    @DisplayName("공개 스페이스인 경우 방문자도 방명록 카드를 조회할 수 있다")
-    @Test
-    void guestCanReadCardInPublicSpace() {
-        // given
-        WriteGuestBookCardResponse writeResponse = writeGuestBookCard(publicSpace);
-
-        // when
-        GuestBookCardResponse result = RestAssuredMockMvc.given()
-            .accept(ContentType.JSON)
-            .when()
-            .get("/spaces/%s/guestbook/%d".formatted(publicSpace.getCode(), writeResponse.id()))
-            .then()
-            .statusCode(200)
-            .extract()
-            .body()
-            .as(GuestBookCardResponse.class);
-
-        // then
-        assertAll(
-            () -> assertThat(result.id()).isNotNull(),
-            () -> assertThat(result.nickname()).isEqualTo(writeRequest.nickname()),
-            () -> assertThat(result.message()).isEqualTo(writeRequest.message()),
-            () -> assertThat(result.createdAt()).isBetween(LocalDateTime.now().minusMinutes(1), LocalDateTime.now()),
-
-            () -> assertThat(result.photos().get(0).originalName()).isEqualTo("photo1.jpg"),
-            () -> assertThat(result.photos().get(0).path()).endsWith("/spaces/1234567890/guestbook/abc.jpg"),
-
-            () -> assertThat(result.photos().get(1).originalName()).isEqualTo("photo2.jpg"),
-            () -> assertThat(result.photos().get(1).path()).endsWith("/spaces/1234567890/guestbook/def.jpg"),
-
-            () -> assertThat(result.photos().get(2).originalName()).isEqualTo("photo3.jpg"),
-            () -> assertThat(result.photos().get(2).path()).endsWith("/spaces/1234567890/guestbook/ghi.jpg")
-        );
-    }
-
-    @DisplayName("비공개 스페이스인 경우 방문자는 방명록 카드를 조회할 수 없다")
-    @Test
-    void throwExceptionWhenGuestReadCardInPrivateSpace() {
-        // given
-        WriteGuestBookCardResponse writeResponse = writeGuestBookCard(privateSpace);
-
-        // when, then
-        RestAssuredMockMvc.given()
-            .accept(ContentType.JSON)
-            .when()
-            .get("/spaces/%s/guestbook/%d".formatted(privateSpace.getCode(), writeResponse.id()))
-            .then()
-            .statusCode(403)
-            .body("message", containsString("방문자는 비공개 스페이스의 방명록을 조회할 수 없습니다."));
+            // when, then
+            RestAssuredMockMvc.given()
+                .header("Authorization", "Bearer " + accessToken)
+                .accept(ContentType.JSON)
+                .when()
+                .get("/spaces/%s/guestbook/%d".formatted(privateSpace.getCode(), writeResponse.id()))
+                .then()
+                .statusCode(200);
+        }
     }
 
     @DisplayName("방명록 카드 작성")

--- a/backend/forgather/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
+++ b/backend/forgather/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
@@ -351,7 +351,7 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
 
         @DisplayName("호스트는 비공개 스페이스의 방명록 카드를 조회할 수 있다")
         @Test
-        void hostCanReadCardInPublicSpace() {
+        void hostCanReadCardInPrivateSpace() {
             // given
             WriteGuestBookCardResponse writeResponse = writeGuestBookCard(privateSpace);
 

--- a/backend/forgather/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
+++ b/backend/forgather/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
@@ -23,9 +23,15 @@ import com.forgather.domain.guestbook.dto.WriteGuestBookCardPhotoRequest;
 import com.forgather.domain.guestbook.dto.WriteGuestBookCardRequest;
 import com.forgather.domain.guestbook.dto.WriteGuestBookCardResponse;
 import com.forgather.domain.space.model.Space;
+import com.forgather.domain.space.repository.HostRepository;
 import com.forgather.domain.space.repository.SpaceRepository;
 import com.forgather.domain.upload.AwsS3Cloud;
+import com.forgather.fixture.HostFixture;
 import com.forgather.fixture.SpaceFixture;
+import com.forgather.global.auth.model.Host;
+import com.forgather.global.auth.model.SpaceHostMap;
+import com.forgather.global.auth.repository.SpaceHostMapRepository;
+import com.forgather.global.auth.util.JwtTokenProvider;
 
 import io.restassured.http.ContentType;
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
@@ -36,7 +42,6 @@ import io.restassured.module.mockmvc.RestAssuredMockMvc;
  * 비공개 스페이스 & 호스트 -> 방명록 조회 시 읽음 여부 포함
  * 비공개 스페이스 & 호스트 -> 방명록 카드 조회 가능
  * 미읽음 호스트 조회 -> 읽음 처리
- * 호스트가 아니면 방명록 카드 삭제 불가
  * 호스트가 아니면 방명록 카드 사진 삭제 불가
  */
 @AutoConfigureMockMvc
@@ -48,11 +53,22 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
     @Autowired
     private SpaceRepository spaceRepository;
 
+    @Autowired
+    private HostRepository hostRepository;
+
+    @Autowired
+    private SpaceHostMapRepository spaceHostMapRepository;
+
     @MockitoBean
     private AwsS3Cloud awsS3Cloud;
 
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
     private Space publicSpace;
     private Space privateSpace;
+    private Host host;
+    private Host anotherHost;
     private WriteGuestBookCardRequest writeRequest = new WriteGuestBookCardRequest(
         "nickname",
         "message",
@@ -69,6 +85,15 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
         privateSpace = SpaceFixture.createPrivateSpace();
         spaceRepository.save(publicSpace);
         spaceRepository.save(privateSpace);
+
+        host = HostFixture.createHost();
+        anotherHost = HostFixture.createHost();
+        hostRepository.save(host);
+        hostRepository.save(anotherHost);
+
+        spaceHostMapRepository.save(new SpaceHostMap(publicSpace, host));
+        spaceHostMapRepository.save(new SpaceHostMap(privateSpace, host));
+
         RestAssuredMockMvc.mockMvc(mockMvc);
     }
 
@@ -320,10 +345,12 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
     @Test
     void deleteCard() {
         // given
+        String accessToken = jwtTokenProvider.generateAccessToken(host.getId());
         WriteGuestBookCardResponse writeResponse = writeGuestBookCard(publicSpace);
 
         // when
         RestAssuredMockMvc.given()
+            .header("Authorization", "Bearer " + accessToken)
             .when()
             .delete("/spaces/%s/guestbook/%d".formatted(publicSpace.getCode(), writeResponse.id()))
             .then()
@@ -336,6 +363,55 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
             .get("/spaces/%s/guestbook/%d".formatted(publicSpace.getCode(), writeResponse.id()))
             .then()
             .statusCode(404);
+    }
+
+    @DisplayName("방문자는 방명록 카드를 삭제하지 못한다")
+    @Test
+    void throwExceptionWhenGuestDeleteCard() {
+        // given
+        WriteGuestBookCardResponse writeResponse = writeGuestBookCard(publicSpace);
+
+        // when, then
+        RestAssuredMockMvc.given()
+            .when()
+            .delete("/spaces/%s/guestbook/%d".formatted(publicSpace.getCode(), writeResponse.id()))
+            .then()
+            .statusCode(401)
+            .body("message", containsString("로그인이 필요합니다."));
+    }
+
+    @DisplayName("다른 호스트의 스페이스에 속한 방명록 카드를 삭제하지 못한다")
+    @Test
+    void throwExceptionWhenAnotherHostDeleteCard() {
+        // given
+        String accessToken = jwtTokenProvider.generateAccessToken(anotherHost.getId());
+        WriteGuestBookCardResponse writeResponse = writeGuestBookCard(publicSpace);
+
+        // when, then
+        RestAssuredMockMvc.given()
+            .header("Authorization", "Bearer " + accessToken)
+            .when()
+            .delete("/spaces/%s/guestbook/%d".formatted(publicSpace.getCode(), writeResponse.id()))
+            .then()
+            .statusCode(403)
+            .body("message", containsString("해당 스페이스에 대한 접근 권한이 없습니다."));
+    }
+
+    @DisplayName("다른 스페이스에 속한 방명록 카드를 삭제하지 못한다")
+    @Test
+    void throwExceptionWhenDeleteCardOnAnotherSpace() {
+        // given
+        String accessToken = jwtTokenProvider.generateAccessToken(host.getId());
+        WriteGuestBookCardResponse writeResponse = writeGuestBookCard(publicSpace);
+
+        // when, then
+        RestAssuredMockMvc.given()
+            .header("Authorization", "Bearer " + accessToken)
+            .when()
+            .delete("/spaces/%s/guestbook/%d".formatted(privateSpace.getCode(), writeResponse.id()))
+            .then()
+            .statusCode(404)
+            .body("message", containsString("해당 스페이스에 존재하지 않는 방명록 카드입니다."));
     }
 
     @DisplayName("방명록 카드 사진을 일부 삭제한다")

--- a/backend/forgather/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
+++ b/backend/forgather/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
@@ -370,189 +370,201 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
     }
 
     @DisplayName("방명록 카드 작성")
-    @Test
-    void write() {
-        // when
-        WriteGuestBookCardResponse result = writeGuestBookCard(publicSpace);
+    @Nested
+    class writeGuestBookCard {
+        @DisplayName("방명록 카드 작성")
+        @Test
+        void write() {
+            // when
+            WriteGuestBookCardResponse result = writeGuestBookCard(publicSpace);
 
-        // then
-        assertAll(
-            () -> assertThat(result.id()).isNotNull(),
-            () -> assertThat(result.nickname()).isEqualTo(writeRequest.nickname()),
-            () -> assertThat(result.message()).isEqualTo(writeRequest.message()),
-            () -> assertThat(result.isRead()).isFalse(),
-            () -> assertThat(result.createdAt()).isBetween(LocalDateTime.now().minusMinutes(1), LocalDateTime.now()),
+            // then
+            assertAll(
+                () -> assertThat(result.id()).isNotNull(),
+                () -> assertThat(result.nickname()).isEqualTo(writeRequest.nickname()),
+                () -> assertThat(result.message()).isEqualTo(writeRequest.message()),
+                () -> assertThat(result.isRead()).isFalse(),
+                () -> assertThat(result.createdAt()).isBetween(LocalDateTime.now().minusMinutes(1), LocalDateTime.now()),
 
-            () -> assertThat(result.photos().get(0).originalName()).isEqualTo("photo1.jpg"),
-            () -> assertThat(result.photos().get(0).path()).endsWith(
-                "/spaces/%s/guestbook/abc.jpg".formatted(publicSpace.getCode())),
+                () -> assertThat(result.photos().get(0).originalName()).isEqualTo("photo1.jpg"),
+                () -> assertThat(result.photos().get(0).path()).endsWith(
+                    "/spaces/%s/guestbook/abc.jpg".formatted(publicSpace.getCode())),
 
-            () -> assertThat(result.photos().get(1).originalName()).isEqualTo("photo2.jpg"),
-            () -> assertThat(result.photos().get(1).path()).endsWith(
-                "/spaces/%s/guestbook/def.jpg".formatted(publicSpace.getCode())),
+                () -> assertThat(result.photos().get(1).originalName()).isEqualTo("photo2.jpg"),
+                () -> assertThat(result.photos().get(1).path()).endsWith(
+                    "/spaces/%s/guestbook/def.jpg".formatted(publicSpace.getCode())),
 
-            () -> assertThat(result.photos().get(2).originalName()).isEqualTo("photo3.jpg"),
-            () -> assertThat(result.photos().get(2).path()).endsWith(
-                "/spaces/%s/guestbook/ghi.jpg".formatted(publicSpace.getCode()))
-        );
+                () -> assertThat(result.photos().get(2).originalName()).isEqualTo("photo3.jpg"),
+                () -> assertThat(result.photos().get(2).path()).endsWith(
+                    "/spaces/%s/guestbook/ghi.jpg".formatted(publicSpace.getCode()))
+            );
+        }
+
+        @DisplayName("방문자 닉네임이 10자를 초과하면 예외를 던진다")
+        @Test
+        void throwExceptionWhenNicknameExceedMaxLength() {
+            // given
+            WriteGuestBookCardRequest request = new WriteGuestBookCardRequest(
+                "12345678901",
+                "message",
+                List.of(
+                    new WriteGuestBookCardPhotoRequest("photo1.jpg", "abc.jpg", 1024L),
+                    new WriteGuestBookCardPhotoRequest("photo2.jpg", "def.jpg", 2048L),
+                    new WriteGuestBookCardPhotoRequest("photo3.jpg", "ghi.jpg", 4096L)
+                )
+            );
+
+            // when, then
+            RestAssuredMockMvc.given()
+                .body(request)
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .when()
+                .post("/spaces/%s/guestbook".formatted(publicSpace.getCode()))
+                .then()
+                .statusCode(400)
+                .body("message", containsString("방문자 닉네임은 최대 10자까지 입력 가능합니다."));
+        }
+
+        @DisplayName("방명록 카드 사진이 20개를 초과하면 예외를 던진다")
+        @Test
+        void throwExceptionWhenPhotoExceedMaxSize() {
+            // given
+            List<WriteGuestBookCardPhotoRequest> photos = IntStream.range(0, 21)
+                .mapToObj(i -> new WriteGuestBookCardPhotoRequest("photo.jpg", "abc.jpg", 1024L))
+                .toList();
+            WriteGuestBookCardRequest request = new WriteGuestBookCardRequest(
+                "nickname",
+                "message",
+                photos
+            );
+
+            // when, then
+            RestAssuredMockMvc.given()
+                .body(request)
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .when()
+                .post("/spaces/%s/guestbook".formatted(publicSpace.getCode()))
+                .then()
+                .statusCode(400)
+                .body("message", containsString("방명록 카드 사진은 최대"));
+        }
     }
 
-    @DisplayName("방문자 닉네임이 10자를 초과하면 예외를 던진다")
-    @Test
-    void throwExceptionWhenNicknameExceedMaxLength() {
-        // given
-        WriteGuestBookCardRequest request = new WriteGuestBookCardRequest(
-            "12345678901",
-            "message",
-            List.of(
-                new WriteGuestBookCardPhotoRequest("photo1.jpg", "abc.jpg", 1024L),
-                new WriteGuestBookCardPhotoRequest("photo2.jpg", "def.jpg", 2048L),
-                new WriteGuestBookCardPhotoRequest("photo3.jpg", "ghi.jpg", 4096L)
-            )
-        );
+    @DisplayName("방명록 카드 삭제")
+    @Nested
+    class deleteGuestBookCard {
+        @DisplayName("방명록 카드를 삭제한다")
+        @Test
+        void deleteCard() {
+            // given
+            WriteGuestBookCardResponse writeResponse = writeGuestBookCard(publicSpace);
 
-        // when, then
-        RestAssuredMockMvc.given()
-            .body(request)
-            .contentType(ContentType.JSON)
-            .accept(ContentType.JSON)
-            .when()
-            .post("/spaces/%s/guestbook".formatted(publicSpace.getCode()))
-            .then()
-            .statusCode(400)
-            .body("message", containsString("방문자 닉네임은 최대 10자까지 입력 가능합니다."));
+            // when
+            RestAssuredMockMvc.given()
+                .header("Authorization", "Bearer " + accessToken)
+                .when()
+                .delete("/spaces/%s/guestbook/%d".formatted(publicSpace.getCode(), writeResponse.id()))
+                .then()
+                .statusCode(204);
+
+            // then
+            RestAssuredMockMvc.given()
+                .accept(ContentType.JSON)
+                .when()
+                .get("/spaces/%s/guestbook/%d".formatted(publicSpace.getCode(), writeResponse.id()))
+                .then()
+                .statusCode(404);
+        }
+
+        @DisplayName("방문자는 방명록 카드를 삭제하지 못한다")
+        @Test
+        void throwExceptionWhenGuestDeleteCard() {
+            // given
+            WriteGuestBookCardResponse writeResponse = writeGuestBookCard(publicSpace);
+
+            // when, then
+            RestAssuredMockMvc.given()
+                .when()
+                .delete("/spaces/%s/guestbook/%d".formatted(publicSpace.getCode(), writeResponse.id()))
+                .then()
+                .statusCode(401)
+                .body("message", containsString("로그인이 필요합니다."));
+        }
+
+        @DisplayName("다른 호스트의 스페이스에 속한 방명록 카드를 삭제하지 못한다")
+        @Test
+        void throwExceptionWhenAnotherHostDeleteCard() {
+            // given
+            WriteGuestBookCardResponse writeResponse = writeGuestBookCard(publicSpace);
+
+            // when, then
+            RestAssuredMockMvc.given()
+                .header("Authorization", "Bearer " + anotherAccessToken)
+                .when()
+                .delete("/spaces/%s/guestbook/%d".formatted(publicSpace.getCode(), writeResponse.id()))
+                .then()
+                .statusCode(403)
+                .body("message", containsString("해당 스페이스에 대한 접근 권한이 없습니다."));
+        }
+
+        @DisplayName("다른 스페이스에 속한 방명록 카드를 삭제하지 못한다")
+        @Test
+        void throwExceptionWhenDeleteCardOnAnotherSpace() {
+            // given
+            WriteGuestBookCardResponse writeResponse = writeGuestBookCard(publicSpace);
+
+            // when, then
+            RestAssuredMockMvc.given()
+                .header("Authorization", "Bearer " + accessToken)
+                .when()
+                .delete("/spaces/%s/guestbook/%d".formatted(privateSpace.getCode(), writeResponse.id()))
+                .then()
+                .statusCode(404)
+                .body("message", containsString("해당 스페이스에 존재하지 않는 방명록 카드입니다."));
+        }
     }
 
-    @DisplayName("방명록 카드 사진이 20개를 초과하면 예외를 던진다")
-    @Test
-    void throwExceptionWhenPhotoExceedMaxSize() {
-        // given
-        List<WriteGuestBookCardPhotoRequest> photos = IntStream.range(0, 21)
-            .mapToObj(i -> new WriteGuestBookCardPhotoRequest("photo.jpg", "abc.jpg", 1024L))
-            .toList();
-        WriteGuestBookCardRequest request = new WriteGuestBookCardRequest(
-            "nickname",
-            "message",
-            photos
-        );
+    @DisplayName("방명록 카드 사진 삭제")
+    @Nested
+    class deleteGuestBookCardPhotos {
+        @DisplayName("방명록 카드 사진을 일부 삭제한다")
+        @Test
+        void deleteCardPhotos() {
+            // given
+            WriteGuestBookCardResponse writeResponse = writeGuestBookCard(publicSpace);
+            DeleteGuestBookCardPhotosRequest request = new DeleteGuestBookCardPhotosRequest(
+                List.of(
+                    writeResponse.photos().get(0).id(),
+                    writeResponse.photos().get(2).id()
+                )
+            );
 
-        // when, then
-        RestAssuredMockMvc.given()
-            .body(request)
-            .contentType(ContentType.JSON)
-            .accept(ContentType.JSON)
-            .when()
-            .post("/spaces/%s/guestbook".formatted(publicSpace.getCode()))
-            .then()
-            .statusCode(400)
-            .body("message", containsString("방명록 카드 사진은 최대"));
-    }
+            // when
+            RestAssuredMockMvc.given()
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when()
+                .delete("/spaces/%s/guestbook/%d/photos".formatted(publicSpace.getCode(), writeResponse.id()))
+                .then()
+                .statusCode(204);
 
-    @DisplayName("방명록 카드를 삭제한다")
-    @Test
-    void deleteCard() {
-        // given
-        WriteGuestBookCardResponse writeResponse = writeGuestBookCard(publicSpace);
-
-        // when
-        RestAssuredMockMvc.given()
-            .header("Authorization", "Bearer " + accessToken)
-            .when()
-            .delete("/spaces/%s/guestbook/%d".formatted(publicSpace.getCode(), writeResponse.id()))
-            .then()
-            .statusCode(204);
-
-        // then
-        RestAssuredMockMvc.given()
-            .accept(ContentType.JSON)
-            .when()
-            .get("/spaces/%s/guestbook/%d".formatted(publicSpace.getCode(), writeResponse.id()))
-            .then()
-            .statusCode(404);
-    }
-
-    @DisplayName("방문자는 방명록 카드를 삭제하지 못한다")
-    @Test
-    void throwExceptionWhenGuestDeleteCard() {
-        // given
-        WriteGuestBookCardResponse writeResponse = writeGuestBookCard(publicSpace);
-
-        // when, then
-        RestAssuredMockMvc.given()
-            .when()
-            .delete("/spaces/%s/guestbook/%d".formatted(publicSpace.getCode(), writeResponse.id()))
-            .then()
-            .statusCode(401)
-            .body("message", containsString("로그인이 필요합니다."));
-    }
-
-    @DisplayName("다른 호스트의 스페이스에 속한 방명록 카드를 삭제하지 못한다")
-    @Test
-    void throwExceptionWhenAnotherHostDeleteCard() {
-        // given
-        WriteGuestBookCardResponse writeResponse = writeGuestBookCard(publicSpace);
-
-        // when, then
-        RestAssuredMockMvc.given()
-            .header("Authorization", "Bearer " + anotherAccessToken)
-            .when()
-            .delete("/spaces/%s/guestbook/%d".formatted(publicSpace.getCode(), writeResponse.id()))
-            .then()
-            .statusCode(403)
-            .body("message", containsString("해당 스페이스에 대한 접근 권한이 없습니다."));
-    }
-
-    @DisplayName("다른 스페이스에 속한 방명록 카드를 삭제하지 못한다")
-    @Test
-    void throwExceptionWhenDeleteCardOnAnotherSpace() {
-        // given
-        WriteGuestBookCardResponse writeResponse = writeGuestBookCard(publicSpace);
-
-        // when, then
-        RestAssuredMockMvc.given()
-            .header("Authorization", "Bearer " + accessToken)
-            .when()
-            .delete("/spaces/%s/guestbook/%d".formatted(privateSpace.getCode(), writeResponse.id()))
-            .then()
-            .statusCode(404)
-            .body("message", containsString("해당 스페이스에 존재하지 않는 방명록 카드입니다."));
-    }
-
-    @DisplayName("방명록 카드 사진을 일부 삭제한다")
-    @Test
-    void deleteCardPhotos() {
-        // given
-        WriteGuestBookCardResponse writeResponse = writeGuestBookCard(publicSpace);
-        DeleteGuestBookCardPhotosRequest request = new DeleteGuestBookCardPhotosRequest(
-            List.of(
-                writeResponse.photos().get(0).id(),
-                writeResponse.photos().get(2).id()
-            )
-        );
-
-        // when
-        RestAssuredMockMvc.given()
-            .contentType(ContentType.JSON)
-            .body(request)
-            .when()
-            .delete("/spaces/%s/guestbook/%d/photos".formatted(publicSpace.getCode(), writeResponse.id()))
-            .then()
-            .statusCode(204);
-
-        // then
-        GuestBookCardResponse response = RestAssuredMockMvc.given()
-            .accept(ContentType.JSON)
-            .when()
-            .get("/spaces/%s/guestbook/%d".formatted(publicSpace.getCode(), writeResponse.id()))
-            .then()
-            .statusCode(200)
-            .extract()
-            .body()
-            .as(GuestBookCardResponse.class);
-        assertAll(
-            () -> assertThat(response.photos()).size().isEqualTo(1),
-            () -> assertThat(response.photos().getFirst().id()).isEqualTo(writeResponse.photos().get(1).id())
-        );
+            // then
+            GuestBookCardResponse response = RestAssuredMockMvc.given()
+                .accept(ContentType.JSON)
+                .when()
+                .get("/spaces/%s/guestbook/%d".formatted(publicSpace.getCode(), writeResponse.id()))
+                .then()
+                .statusCode(200)
+                .extract()
+                .body()
+                .as(GuestBookCardResponse.class);
+            assertAll(
+                () -> assertThat(response.photos()).size().isEqualTo(1),
+                () -> assertThat(response.photos().getFirst().id()).isEqualTo(writeResponse.photos().get(1).id())
+            );
+        }
     }
 
     private WriteGuestBookCardResponse writeGuestBookCard(Space space) {

--- a/backend/forgather/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
+++ b/backend/forgather/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
@@ -38,7 +38,6 @@ import io.restassured.module.mockmvc.RestAssuredMockMvc;
 
 /**
  * TODO
- * 비공개 스페이스 & 호스트 -> 방명록 조회 가능
  * 비공개 스페이스 & 호스트 -> 방명록 조회 시 읽음 여부 포함
  * 비공개 스페이스 & 호스트 -> 방명록 카드 조회 가능
  * 미읽음 호스트 조회 -> 읽음 처리
@@ -68,6 +67,8 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
     private Space publicSpace;
     private Space privateSpace;
     private Host host;
+    private String accessToken;
+    private String anotherAccessToken;
     private Host anotherHost;
     private WriteGuestBookCardRequest writeRequest = new WriteGuestBookCardRequest(
         "nickname",
@@ -90,6 +91,8 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
         anotherHost = HostFixture.createHost();
         hostRepository.save(host);
         hostRepository.save(anotherHost);
+        accessToken = jwtTokenProvider.generateAccessToken(host.getId());
+        anotherAccessToken = jwtTokenProvider.generateAccessToken(anotherHost.getId());
 
         spaceHostMapRepository.save(new SpaceHostMap(publicSpace, host));
         spaceHostMapRepository.save(new SpaceHostMap(privateSpace, host));
@@ -97,7 +100,7 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
         RestAssuredMockMvc.mockMvc(mockMvc);
     }
 
-    @DisplayName("공개 스페이스인 경우 방문자도 방명록 카드를 조회할 수 있다")
+    @DisplayName("공개 스페이스인 경우 방문자도 방명록을 조회할 수 있다")
     @Test
     void guestCanReadGuestBookInPublicSpace() {
         // given
@@ -155,7 +158,7 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
         assertThat(result).isFalse();
     }
 
-    @DisplayName("방명록은 각 방명록 카드의 방문자 닉네임과 사진 여부를 포함한다")
+    @DisplayName("방문자 조회 시 방명록은 각 방명록 카드의 방문자 닉네임과 사진 여부를 포함한다")
     @Test
     void guestBookContainsNicknameAndPhoto() {
         // given
@@ -203,12 +206,56 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
             .queryParam("size", 15)
             .queryParam("sort", "createdAt,desc")
             .queryParam("sort", "id,desc")
-            .log().all()
             .when()
             .get("/spaces/%s/guestbook".formatted(privateSpace.getCode()))
             .then()
             .statusCode(403)
             .body("message", containsString("방문자는 비공개 스페이스의 방명록을 조회할 수 없습니다."));
+    }
+
+    @DisplayName("호스트는 자신의 비공개 스페이스 방명록을 조회할 수 있다")
+    @Test
+    void hostCanReadGuestBookInPrivateSpace() {
+        // when, then
+        RestAssuredMockMvc.given()
+            .header("Authorization", "Bearer " + accessToken)
+            .accept(ContentType.JSON)
+            .queryParam("page", 1)
+            .queryParam("size", 15)
+            .queryParam("sort", "createdAt,desc")
+            .queryParam("sort", "id,desc")
+            .when()
+            .get("/spaces/%s/guestbook".formatted(privateSpace.getCode()))
+            .then()
+            .statusCode(200);
+    }
+
+    @DisplayName("호스트가 방명록을 조회할 경우 방명록 카드 읽음 여부를 알 수 있다")
+    @Test
+    void hostCanKnowIsCardRead() {
+        // given
+        writeGuestBookCard(publicSpace);
+
+        // when
+        boolean result = RestAssuredMockMvc.given()
+            .header("Authorization", "Bearer " + accessToken)
+            .accept(ContentType.JSON)
+            .queryParam("page", 1)
+            .queryParam("size", 15)
+            .queryParam("sort", "createdAt,desc")
+            .queryParam("sort", "id,desc")
+            .when()
+            .get("/spaces/%s/guestbook".formatted(publicSpace.getCode()))
+            .then()
+            .log().all()
+            .statusCode(200)
+            .extract()
+            .body()
+            .asString()
+            .contains("\"isRead\"");
+
+        // then
+        assertThat(result).isTrue();
     }
 
     @DisplayName("공개 스페이스인 경우 방문자도 방명록 카드를 조회할 수 있다")
@@ -345,7 +392,6 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
     @Test
     void deleteCard() {
         // given
-        String accessToken = jwtTokenProvider.generateAccessToken(host.getId());
         WriteGuestBookCardResponse writeResponse = writeGuestBookCard(publicSpace);
 
         // when
@@ -384,12 +430,11 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
     @Test
     void throwExceptionWhenAnotherHostDeleteCard() {
         // given
-        String accessToken = jwtTokenProvider.generateAccessToken(anotherHost.getId());
         WriteGuestBookCardResponse writeResponse = writeGuestBookCard(publicSpace);
 
         // when, then
         RestAssuredMockMvc.given()
-            .header("Authorization", "Bearer " + accessToken)
+            .header("Authorization", "Bearer " + anotherAccessToken)
             .when()
             .delete("/spaces/%s/guestbook/%d".formatted(publicSpace.getCode(), writeResponse.id()))
             .then()
@@ -401,7 +446,6 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
     @Test
     void throwExceptionWhenDeleteCardOnAnotherSpace() {
         // given
-        String accessToken = jwtTokenProvider.generateAccessToken(host.getId());
         WriteGuestBookCardResponse writeResponse = writeGuestBookCard(publicSpace);
 
         // when, then

--- a/backend/forgather/src/test/java/com/forgather/domain/guestbook/model/GuestBookCardPhotosTest.java
+++ b/backend/forgather/src/test/java/com/forgather/domain/guestbook/model/GuestBookCardPhotosTest.java
@@ -64,6 +64,6 @@ class GuestBookCardPhotosTest {
         // when, then
         assertThatThrownBy(() -> guestBookCardPhotos.deleteByIds(List.of(1L, 4L)))
             .isInstanceOf(BaseException.class)
-            .hasMessageContaining("방명록 카드에 존재하지 않는 사진입니다.");
+            .hasMessageContaining("해당 방명록 카드에 존재하지 않는 사진입니다.");
     }
 }


### PR DESCRIPTION
## 연관된 이슈

- close #804 

## 작업 내용
### 방명록 조회
- 호스트만 비공개 스페이스의 방명록을 조회할 수 있다.
- 호스트만 방명록에서 각 방명록 카드의 읽음 여부를 확인할 수 있다.

### 방명록 카드 조회
- 호스트만 비공개 스페이스의 방명록 카드를 조회할 수 있다.

### 방명록 카드 삭제
- 호스트만 방명록 카드를 삭제할 수 있다.

### 방명록 카드 사진 삭제
- 호스트만 방명록 카드 사진을 삭제할 수 있다.