### PR TITLE
refactor: 방명록 메세지 글자수 제한 400자로 변경

### DIFF
--- a/backend/forgather/src/main/java/com/forgather/domain/guestbook/controller/GuestBookController.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/guestbook/controller/GuestBookController.java
@@ -87,7 +87,7 @@ public class GuestBookController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "방명록 카드 작성", description = "방문자 닉네임(10자), 메세지(300자)")
+    @Operation(summary = "방명록 카드 작성", description = "방문자 닉네임(10자), 메세지(400자)")
     @PostMapping
     public ResponseEntity<WriteGuestBookCardResponse> writeCard(
         @PathVariable(value = "spaceCode") String spaceCode,

--- a/backend/forgather/src/main/java/com/forgather/domain/guestbook/dto/WriteGuestBookCardRequest.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/guestbook/dto/WriteGuestBookCardRequest.java
@@ -13,7 +13,7 @@ public record WriteGuestBookCardRequest(
     @Schema(description = "방문자 닉네임", example = "밍퐁루블", maxLength = 10)
     String nickname,
 
-    @Schema(description = "메세지", example = "전시 잘봤다~~ 너가 최고야 🤙", maxLength = 300)
+    @Schema(description = "메세지", example = "전시 잘봤다~~ 너가 최고야 🤙", maxLength = 400)
     String message,
 
     @Schema(description = "방명록 카드 사진 목록", example = """

--- a/backend/forgather/src/main/java/com/forgather/domain/guestbook/model/GuestBookCard.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/guestbook/model/GuestBookCard.java
@@ -67,8 +67,8 @@ public class GuestBookCard extends BaseTimeEntity {
 
     private void validateMessage(String message) {
         int length = TextLengthCounter.count(message);
-        if (length > 300) {
-            throw new BaseException("방명록 카드 메세지는 최대 300까지 입력 가능합니다. message.length: " + length);
+        if (length > 400) {
+            throw new BaseException("방명록 카드 메세지는 최대 400까지 입력 가능합니다. message.length: " + length);
         }
     }
 

--- a/backend/forgather/src/test/java/com/forgather/domain/guestbook/model/GuestBookCardTest.java
+++ b/backend/forgather/src/test/java/com/forgather/domain/guestbook/model/GuestBookCardTest.java
@@ -45,24 +45,24 @@ class GuestBookCardTest {
             .hasMessageContaining("방명록 카드 메세지는 null일 수 없습니다.");
     }
 
-    @DisplayName("메세지의 길이가 300자를 초과하면 예외를 던진다")
+    @DisplayName("메세지의 길이가 400자를 초과하면 예외를 던진다")
     @Test
     void throwExceptionWhenMessageExceedMaxLength() {
         // given
-        String message = "1234567890".repeat(30) + "c";
+        String message = "1234567890".repeat(40) + "c";
 
         // when, then
         assertThatThrownBy(() -> createGuestBookCardWithMessage(message))
             .isInstanceOf(BaseException.class)
-            .hasMessageContaining("방명록 카드 메세지는 최대 300까지 입력 가능합니다.");
+            .hasMessageContaining("방명록 카드 메세지는 최대 400까지 입력 가능합니다.");
     }
 
-    @DisplayName("메세지는 이모지를 한 글자로 간주해 300자까지 입력 가능하다")
+    @DisplayName("메세지는 이모지를 한 글자로 간주해 400자까지 입력 가능하다")
     @ValueSource(strings = {"😀", "👦", "👨", "‍👩‍", "‍👦", "‍👩‍👧‍", "👨‍👩‍👧", "👨‍👩‍👧‍👦"})
     @ParameterizedTest
     void countEmojiAsOneCharAtMessage(String emoji) {
         // given
-        String message = emoji.repeat(299) + "c";
+        String message = emoji.repeat(399) + "c";
 
         // when, then
         assertThatCode(() -> createGuestBookCardWithMessage(message)).doesNotThrowAnyException();


### PR DESCRIPTION
## 연관된 이슈

- close #819 

## 작업 내용
### 글자수 제한 증가
본래 기획은 300자 제한이었으나, qa 중 화면에서는 400자로 제한한 것을 확인했습니다.
팀 논의 결과 400자가 더 적절할 것이라는 결론이 났습니다.
따라서 글자수 제한을 400자로 변경했습니다. 