### PR TITLE
refactor: 방명록을 볼 때 refetch를 하도록 변경

### DIFF
--- a/frontend/src/apis/helper.ts
+++ b/frontend/src/apis/helper.ts
@@ -1,5 +1,13 @@
 import { AUTH_COOKIES } from '../constants/cookie';
+import type { Method } from '../types/api.type';
 import { CookieUtils } from '../utils/cookie';
+
+interface MatchHeadersProps {
+  body: unknown;
+  headers: Record<string, string>;
+  method: Method;
+  token?: string;
+}
 
 export const matchBody = (body: unknown) => {
   if (!body) {
@@ -11,13 +19,14 @@ export const matchBody = (body: unknown) => {
   return JSON.stringify(body);
 };
 
-export const matchHeaders = (
-  body: unknown,
-  headers: Record<string, string>,
-  token?: string,
-) => {
+export const matchHeaders = ({
+  body,
+  headers,
+  method,
+  token = undefined,
+}: MatchHeadersProps) => {
   const mergedHeaders = { ...headers };
-  if (body instanceof FormData) {
+  if (body instanceof FormData || method === 'GET') {
     delete mergedHeaders['Content-Type'];
     delete mergedHeaders['content-type'];
   } else {

--- a/frontend/src/apis/http.ts
+++ b/frontend/src/apis/http.ts
@@ -15,7 +15,12 @@ const request = async <T>(
   const doFetch = async (newToken?: string) => {
     const response = await fetch(url, {
       method,
-      headers: matchHeaders(body, headers ?? {}, newToken ?? token),
+      headers: matchHeaders({
+        body,
+        headers: headers ?? {},
+        method,
+        token: newToken ?? token,
+      }),
       body: matchBody(body),
     });
     return response;

--- a/frontend/src/components/@common/line/Line.styles.ts
+++ b/frontend/src/components/@common/line/Line.styles.ts
@@ -12,5 +12,6 @@ export const Line = styled.div<{ $width: number }>`
 `;
 
 export const ButtonContainer = styled.div`
+  min-width: 20px;
   max-width: 64px;
 `;

--- a/frontend/src/hooks/domain/guestbook/useGuestbookList.ts
+++ b/frontend/src/hooks/domain/guestbook/useGuestbookList.ts
@@ -20,9 +20,14 @@ const useGuestbookList = (spaceCode: string) => {
 
   const { data, fetchNextPage, isLoading, isError } = useInfiniteQuery({
     queryKey: ['guestbookList', spaceCode],
-    queryFn: ({ pageParam }) => fetchGuestbookListByPage(pageParam),
+    queryFn: ({ pageParam = 1 }) => fetchGuestbookListByPage(pageParam),
     initialPageParam: 1,
-    getNextPageParam: (lastGuestbookList) => lastGuestbookList.currentPage + 1,
+    getNextPageParam: (lastGuestbookList) => {
+      const isLastPage =
+        lastGuestbookList.currentPage >= lastGuestbookList.totalPages;
+
+      return isLastPage ? undefined : lastGuestbookList.currentPage + 1;
+    },
   });
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: isError 변경 시에만 토스트 띄우기

--- a/frontend/src/hooks/domain/guestbook/useGuestbookList.ts
+++ b/frontend/src/hooks/domain/guestbook/useGuestbookList.ts
@@ -28,6 +28,8 @@ const useGuestbookList = (spaceCode: string) => {
 
       return isLastPage ? undefined : lastGuestbookList.currentPage + 1;
     },
+    refetchOnMount: 'always',
+    staleTime: 0,
   });
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: isError 변경 시에만 토스트 띄우기

--- a/frontend/src/pages/MainPage.common.styles.ts
+++ b/frontend/src/pages/MainPage.common.styles.ts
@@ -34,6 +34,7 @@ export const Name = styled.h1`
 export const Introduction = styled.p`
   ${({ theme }) => theme.typography.bodyRegular}
   color: ${({ theme }) => theme.colors.gray04};
+  white-space: pre-line;
 `;
 
 export const IconButtonContainer = styled.div`


### PR DESCRIPTION
## 연관된 이슈

- close #820 

## 작업 내용

- https://github.com/woowacourse-teams/2025-PhotoGather/commit/b4dc7d5a89a42a8a0d856b8e255b0a904cd1130d 방명록을 볼 때 refetch를 하도록 변경, 이를 통해 방명록의 읽음 여부를 바로 반영하도록 처리 가능

  - useQuery의 refetchOnMount, staleTime 속성 활용
- https://github.com/woowacourse-teams/2025-PhotoGather/commit/43b078c88b494f25698fcb1ab442b219fd05ee60 Line 양 옆에 min-width 속성을 넣어 이동 중 Line이 중앙에 항상 정렬되도록 변경
- https://github.com/woowacourse-teams/2025-PhotoGather/commit/6e719181fef48edd580cb4a1fdbd4cc1c0c46afc 스페이스 설명의 개행 처리가 되지 않던 현상 수정
- https://github.com/woowacourse-teams/2025-PhotoGather/commit/987dd3621299426fcfe2b401611b69b55e41c52d 서버에게 계속해 증가하는 Page 요청을 보내는 현상 수정

  - useInfiniteQuery의 getNextPageParam 속성 값 수정, 항상 다음 페이지를 가져오도록 하는 게 아니라 불러올 페이지가 없을 경우 페이지를 불러오지 않도록 변경
- https://github.com/woowacourse-teams/2025-PhotoGather/pull/826/commits/ac7442f351edce759155222a81b42dfaab7a0908 GET 요청일 때 content-type 속성 제거

  - (레오의 무리한 요구사항 해결)
  - Request Header에 Content-type이 있을 경우 body에 무엇이 있다고 판단해 서버 로그에 값을 찍어주고 있음. 하지만 현재 로직은 GET에도 content-type을 기본적으로 꽂아주는 구조이기에 로그에 빈 값이 자꾸 출력됨
  - Content-type 속성을 없애지 않아도 정상적으로 구동은 되지만, get 요청이라 body에 값이 없음에도 Content-type이 있는 건 이상하다고 판단, 클라이언트 단에서 GET 요청을 보낼 때 값을 전달하지 않도록 변경