### PR TITLE
refactor: 스페이스 사진 삭제 비동기 이벤트 처리

### DIFF
--- a/backend/forgather/src/main/java/com/forgather/domain/guestbook/repository/GuestBookCardRepository.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/guestbook/repository/GuestBookCardRepository.java
@@ -1,5 +1,6 @@
 package com.forgather.domain.guestbook.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
@@ -30,4 +31,6 @@ public interface GuestBookCardRepository {
     }
 
     Page<GuestBookCard> findAllBySpace(Space space, Pageable pageable);
+
+    List<GuestBookCard> findAllBySpace(Space space);
 }

--- a/backend/forgather/src/main/java/com/forgather/domain/guestbook/service/GuestBookService.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/guestbook/service/GuestBookService.java
@@ -123,6 +123,14 @@ public class GuestBookService {
     }
 
     @Transactional
+    public void deleteAllCardsBySpace(Host host, Space space) {
+        validateSpaceHost(host, space);
+        for (GuestBookCard guestBookCard : guestBookCardRepository.findAllBySpace(space)) {
+            deleteCard(host, space.getCode(), guestBookCard.getId());
+        }
+    }
+
+    @Transactional
     public void deleteCard(Host host, String spaceCode, Long guestBookCardId) {
         Space space = spaceRepository.getByCodeOrThrow(spaceCode);
         validateSpaceHost(host, space);

--- a/backend/forgather/src/main/java/com/forgather/domain/product/service/ProductService.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/product/service/ProductService.java
@@ -121,6 +121,16 @@ public class ProductService {
         productRepository.delete(product);
     }
 
+    @Transactional
+    public void deleteIfExists(Host host, Space space) {
+        validateSpaceHost(host, space);
+        Optional<Product> product = productRepository.findBySpace(space);
+        if (product.isPresent()) {
+            deleteAllProductPhotos(product.get());
+            productRepository.delete(product.get());
+        }
+    }
+
     /**
      * product와 연관된 모든 ProductPhoto 삭제
      */

--- a/backend/forgather/src/main/java/com/forgather/domain/space/service/SpaceService.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/space/service/SpaceService.java
@@ -10,6 +10,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.forgather.domain.guestbook.repository.GuestBookCardRepository;
+import com.forgather.domain.guestbook.service.GuestBookService;
+import com.forgather.domain.product.service.ProductService;
 import com.forgather.domain.space.dto.CreateSpaceRequest;
 import com.forgather.domain.space.dto.CreateSpaceResponse;
 import com.forgather.domain.space.dto.HostSpaceResponse;
@@ -40,6 +42,8 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class SpaceService {
 
+    private final ProductService productService;
+    private final GuestBookService guestBookService;
     private final SpaceRepository spaceRepository;
     private final SpacePhotoRepository spacePhotoRepository;
     private final SpaceHostMapRepository spaceHostMapRepository;
@@ -148,10 +152,16 @@ public class SpaceService {
         Space space = spaceRepository.getByCodeOrThrow(spaceCode);
         validateSpaceHost(space, host);
 
+        deleteGuestBookAndProduct(host, space);
         spaceHostMapRepository.deleteBySpace(space);
         spacePhotoRepository.findBySpace(space)
             .ifPresent(this::deleteSpacePhoto);
         spaceRepository.delete(space);
+    }
+
+    private void deleteGuestBookAndProduct(Host host, Space space) {
+        guestBookService.deleteAllCardsBySpace(host, space);
+        productService.deleteIfExists(host, space);
     }
 
     private void deleteSpacePhoto(SpacePhoto spacePhoto) {

--- a/backend/forgather/src/main/java/com/forgather/domain/space/service/SpaceService.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/space/service/SpaceService.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.Comparator;
 import java.util.List;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -20,6 +21,7 @@ import com.forgather.domain.space.model.SpacePhoto;
 import com.forgather.domain.space.repository.SpacePhotoRepository;
 import com.forgather.domain.space.repository.SpaceRepository;
 import com.forgather.domain.upload.domain.ContentsStorage;
+import com.forgather.domain.upload.event.DeletePhotoEvent;
 import com.forgather.global.auth.model.Host;
 import com.forgather.global.auth.model.SpaceHostMap;
 import com.forgather.global.auth.repository.SpaceHostMapRepository;
@@ -44,6 +46,7 @@ public class SpaceService {
     private final GuestBookCardRepository guestBookCardRepository;
     private final RandomCodeGenerator codeGenerator;
     private final ContentsStorage contentsStorage;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public CreateSpaceResponse create(CreateSpaceRequest request, MultipartFile file, Host host) {
@@ -137,9 +140,7 @@ public class SpaceService {
         SpacePhoto existingPhoto = spacePhotoRepository.findBySpace(space)
             .orElseThrow(() -> new BaseException("삭제할 스페이스 사진이 존재하지 않습니다."));
 
-        String path = existingPhoto.getPath();
-        spacePhotoRepository.delete(existingPhoto);
-        contentsStorage.deleteContent(path);
+        deleteSpacePhoto(existingPhoto);
     }
 
     @Transactional
@@ -149,11 +150,13 @@ public class SpaceService {
 
         spaceHostMapRepository.deleteBySpace(space);
         spacePhotoRepository.findBySpace(space)
-            .ifPresent(spacePhoto -> {
-                spacePhotoRepository.delete(spacePhoto);
-                contentsStorage.deleteContent(spacePhoto.getPath());
-            });
+            .ifPresent(this::deleteSpacePhoto);
         spaceRepository.delete(space);
+    }
+
+    private void deleteSpacePhoto(SpacePhoto spacePhoto) {
+        spacePhotoRepository.delete(spacePhoto);
+        eventPublisher.publishEvent(new DeletePhotoEvent(this, spacePhoto));
     }
 
     @Transactional(readOnly = true)

--- a/backend/forgather/src/test/java/com/forgather/acceptance/SpaceAcceptanceTest.java
+++ b/backend/forgather/src/test/java/com/forgather/acceptance/SpaceAcceptanceTest.java
@@ -112,7 +112,6 @@ class SpaceAcceptanceTest extends AcceptanceTest {
             .header("Authorization", "Bearer " + token)
             .multiPart("request", request, "application/json")
             .multiPart("file", file.getOriginalFilename(), file.getBytes(), file.getContentType())
-            .sessionAttr("host_id", host.getId())
             .when()
             .post("/spaces")
             .then()
@@ -138,7 +137,6 @@ class SpaceAcceptanceTest extends AcceptanceTest {
         CreateSpaceResponse response = RestAssuredMockMvc.given()
             .header("Authorization", "Bearer " + token)
             .multiPart("request", request, "application/json")
-            .sessionAttr("host_id", host.getId())
             .when()
             .post("/spaces")
             .then()
@@ -163,7 +161,6 @@ class SpaceAcceptanceTest extends AcceptanceTest {
         // when
         var response = RestAssuredMockMvc.given()
             .multiPart("request", request, "application/json")
-            .sessionAttr("host_id", host.getId())
             .when()
             .post("/spaces")
             .then()

--- a/backend/forgather/src/test/java/com/forgather/acceptance/SpaceAcceptanceTest.java
+++ b/backend/forgather/src/test/java/com/forgather/acceptance/SpaceAcceptanceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -26,8 +27,13 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.forgather.domain.guestbook.model.Guest;
+import com.forgather.domain.guestbook.model.GuestBookCard;
+import com.forgather.domain.guestbook.repository.GuestBookCardPhotoRepository;
 import com.forgather.domain.guestbook.repository.GuestBookCardRepository;
 import com.forgather.domain.guestbook.repository.GuestRepository;
+import com.forgather.domain.product.model.Product;
+import com.forgather.domain.product.repository.ProductPhotoRepository;
+import com.forgather.domain.product.repository.ProductRepository;
 import com.forgather.domain.space.dto.CreateSpaceRequest;
 import com.forgather.domain.space.dto.CreateSpaceResponse;
 import com.forgather.domain.space.dto.HostSpaceResponse;
@@ -40,7 +46,10 @@ import com.forgather.domain.space.repository.SpacePhotoRepository;
 import com.forgather.domain.space.repository.SpaceRepository;
 import com.forgather.domain.upload.domain.ContentsStorage;
 import com.forgather.fixture.GuestBookCardFixture;
+import com.forgather.fixture.GuestBookCardPhotoFixture;
 import com.forgather.fixture.GuestFixture;
+import com.forgather.fixture.ProductFixture;
+import com.forgather.fixture.ProductPhotoFixture;
 import com.forgather.fixture.SpaceFixture;
 import com.forgather.fixture.SpacePhotoFixture;
 import com.forgather.global.auth.model.Host;
@@ -74,6 +83,15 @@ class SpaceAcceptanceTest extends AcceptanceTest {
 
     @Autowired
     private GuestBookCardRepository guestBookCardRepository;
+
+    @Autowired
+    private GuestBookCardPhotoRepository guestBookCardPhotoRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private ProductPhotoRepository productPhotoRepository;
 
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
@@ -228,6 +246,44 @@ class SpaceAcceptanceTest extends AcceptanceTest {
             () -> assertThat(response.statusCode()).isEqualTo(204),
             () -> assertThat(spaceRepository.findByCode(space.getCode())).isEmpty(),
             () -> assertThat(spacePhotoRepository.findBySpace(space)).isEmpty(),
+
+            () -> await().atMost(ofSeconds(6))
+                .untilAsserted(() -> verify(contentsStorage, atLeast(1)).deletePhotos(anyList()))
+        );
+    }
+
+    @DisplayName("스페이스, 작품, 방명록 모두 삭제한다.")
+    @Test
+    void deleteSpaceWithRelatedThings() {
+        // given
+        Space space = spaceRepository.save(SpaceFixture.createSpace());
+        spacePhotoRepository.save(SpacePhotoFixture.createSpacePhotoWithSpace(space));
+        spaceHostMapRepository.save(new SpaceHostMap(space, host));
+        Product product = productRepository.save(ProductFixture.createProductWithSpace(space));
+        productPhotoRepository.save(ProductPhotoFixture.createProductPhotoWithProduct(product));
+        Guest guest = guestRepository.save(GuestFixture.createGuest());
+        GuestBookCard guestBookCard = guestBookCardRepository.save(
+            GuestBookCardFixture.createGuestBookCard(space, guest, "message"));
+        guestBookCardPhotoRepository.saveAll(List.of(
+            GuestBookCardPhotoFixture.createGuestBookCardPhotoWithGuestBookCard(guestBookCard)));
+
+        // when
+        var response = RestAssuredMockMvc.given()
+            .header("Authorization", "Bearer " + token)
+            .when()
+            .delete("/spaces/{spaceCode}", space.getCode())
+            .then()
+            .extract();
+
+        // then
+        assertAll(
+            () -> assertThat(response.statusCode()).isEqualTo(204),
+            () -> assertThat(spaceRepository.findByCode(space.getCode())).isEmpty(),
+            () -> assertThat(spacePhotoRepository.findBySpace(space)).isEmpty(),
+            () -> assertThat(productRepository.findBySpace(space)).isEmpty(),
+            () -> assertThat(productPhotoRepository.findAllByProduct(product)).isEmpty(),
+            () -> assertThat(guestBookCardRepository.findAllBySpace(space)).isEmpty(),
+            () -> assertThat(guestBookCardPhotoRepository.findAllByGuestBookCard(guestBookCard)).isEmpty(),
 
             () -> await().atMost(ofSeconds(6))
                 .untilAsserted(() -> verify(contentsStorage, atLeast(1)).deletePhotos(anyList()))

--- a/backend/forgather/src/test/java/com/forgather/acceptance/SpaceAcceptanceTest.java
+++ b/backend/forgather/src/test/java/com/forgather/acceptance/SpaceAcceptanceTest.java
@@ -1,9 +1,15 @@
 package com.forgather.acceptance;
 
 import static com.forgather.fixture.HostFixture.createHost;
+import static java.time.Duration.ofSeconds;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
 
@@ -72,11 +78,11 @@ class SpaceAcceptanceTest extends AcceptanceTest {
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
 
-    @MockitoBean
-    private ContentsStorage contentsStorage;
-
     @Autowired
     private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private ContentsStorage contentsStorage;
 
     private Host host;
     private String token;
@@ -221,7 +227,10 @@ class SpaceAcceptanceTest extends AcceptanceTest {
         assertAll(
             () -> assertThat(response.statusCode()).isEqualTo(204),
             () -> assertThat(spaceRepository.findByCode(space.getCode())).isEmpty(),
-            () -> assertThat(spacePhotoRepository.findBySpace(space)).isEmpty()
+            () -> assertThat(spacePhotoRepository.findBySpace(space)).isEmpty(),
+
+            () -> await().atMost(ofSeconds(6))
+                .untilAsserted(() -> verify(contentsStorage, atLeast(1)).deletePhotos(anyList()))
         );
     }
 
@@ -305,7 +314,10 @@ class SpaceAcceptanceTest extends AcceptanceTest {
             () -> assertThat(result.instagramUsername()).isEqualTo("forgather_official_new"),
             () -> assertThat(result.email()).isEqualTo("forgather_new@forgather.me"),
             () -> assertThat(spacePhotoRepository.getBySpaceOrEmpty(space).getOriginalName()).isEqualTo("new.jpg"),
-            () -> assertThat(result.guestBookCardCount()).isZero()
+            () -> assertThat(result.guestBookCardCount()).isZero(),
+
+            () -> await().atMost(ofSeconds(6))
+                .untilAsserted(() -> verify(contentsStorage, atLeast(1)).deletePhotos(anyList()))
         );
     }
 
@@ -340,7 +352,9 @@ class SpaceAcceptanceTest extends AcceptanceTest {
             () -> assertThat(response.isPublic()).isTrue(),
             () -> assertThat(response.instagramUsername()).isEqualTo("instagramUsername"),
             () -> assertThat(response.email()).isEqualTo("email@forgather.me"),
-            () -> assertThat(response.spacePhoto().path()).isEqualTo("path")
+            () -> assertThat(response.spacePhoto().path()).isEqualTo("path"),
+
+            () -> verify(contentsStorage, never()).deletePhotos(anyList())
         );
     }
 

--- a/backend/forgather/src/test/java/com/forgather/fixture/GuestBookCardPhotoFixture.java
+++ b/backend/forgather/src/test/java/com/forgather/fixture/GuestBookCardPhotoFixture.java
@@ -18,4 +18,8 @@ public class GuestBookCardPhotoFixture {
         ReflectionTestUtils.setField(guestBookCardPhoto, "id", id);
         return guestBookCardPhoto;
     }
+
+    public static GuestBookCardPhoto createGuestBookCardPhotoWithGuestBookCard(GuestBookCard guestBookCard) {
+        return new GuestBookCardPhoto("originalName", "path", 1024L, guestBookCard);
+    }
 }

--- a/backend/forgather/src/test/java/com/forgather/fixture/ProductPhotoFixture.java
+++ b/backend/forgather/src/test/java/com/forgather/fixture/ProductPhotoFixture.java
@@ -4,6 +4,7 @@ import static com.forgather.fixture.ProductFixture.createProduct;
 
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.forgather.domain.product.model.Product;
 import com.forgather.domain.product.model.ProductPhoto;
 
 public class ProductPhotoFixture {
@@ -26,5 +27,9 @@ public class ProductPhotoFixture {
         ProductPhoto productPhoto = new ProductPhoto(createProduct(), "originalName", path, 1024L, 1);
         ReflectionTestUtils.setField(productPhoto, "id", id);
         return productPhoto;
+    }
+
+    public static ProductPhoto createProductPhotoWithProduct(Product product) {
+        return new ProductPhoto(product, "originalName", "path", 1024L, 1);
     }
 }


### PR DESCRIPTION
## 연관된 이슈

- close #799

## 작업 내용

- s3 이미지 파일 삭제 이벤트를 발행해 트랜잭션 커밋 후 비동기 처리를 도입한다
- 스페이스 삭제 때 스페이스 사진, 작품, 작품 사진, 방명록 카드, 방명록 카드 사진을 모두 삭제한다