### PR TITLE
refactor: 인스타그램 형식 추가 및 스페이스 정보 설정 변경

### DIFF
--- a/frontend/src/components/@common/inputs/input.common.styles.ts
+++ b/frontend/src/components/@common/inputs/input.common.styles.ts
@@ -29,3 +29,8 @@ export const InputCount = styled.p`
   color: ${({ theme }) => theme.colors.gray03};
   ${({ theme }) => ({ ...theme.typography.captionSmall })};
 `;
+
+export const requiredDot = styled.span`
+  color: ${({ theme }) => theme.colors.error};
+  margin-left: 4px;
+`;

--- a/frontend/src/components/@common/inputs/textInput/TextInput.tsx
+++ b/frontend/src/components/@common/inputs/textInput/TextInput.tsx
@@ -20,7 +20,8 @@ const TextInput = ({
   return (
     <C.Wrapper>
       <C.Label htmlFor={inputProps.id}>
-        {label} {isRequired && '*'}
+        {label}
+        <C.requiredDot>{isRequired && '*'}</C.requiredDot>
       </C.Label>
       <S.InputField
         {...inputProps}

--- a/frontend/src/components/@common/inputs/textareaInput/TextareaInput.tsx
+++ b/frontend/src/components/@common/inputs/textareaInput/TextareaInput.tsx
@@ -22,7 +22,7 @@ const TextareaInput = ({
     <C.Wrapper>
       <C.Label htmlFor={textareaProps.id}>
         {label && label}
-        {isRequired && '*'}
+        <C.requiredDot>{isRequired && '*'}</C.requiredDot>
       </C.Label>
       <S.TextareaField {...textareaProps} $isError={!!errorMessage} />
       <C.InputFooterContainer>

--- a/frontend/src/components/specific/editForm/EditForm.tsx
+++ b/frontend/src/components/specific/editForm/EditForm.tsx
@@ -86,7 +86,7 @@ const EditForm = () => {
     setValue('isDeletePhoto', true, { shouldDirty: true });
   };
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleEmailChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setValue('email', e.target.value, {
       shouldValidate: false,
       shouldDirty: true,
@@ -142,7 +142,6 @@ const EditForm = () => {
         {...register('description', {
           validate: editFormValidators.description,
         })}
-        isRequired
         validLength={calculateValidLength(watch('description'))}
         label="스페이스 설명"
         placeholder="매일 1시부터 6시까지 상주합니다."
@@ -157,11 +156,14 @@ const EditForm = () => {
         placeholder="forgather@forgather.me"
         errorMessage={errors.email?.message}
         maxLength={CONSTRAINTS.MAX_LENGTH.SPACE.EMAIL}
-        onChange={handleChange}
+        onChange={handleEmailChange}
         onBlur={() => trigger('email')}
+        inputMode="email"
       />
       <TextInput
-        {...register('instagramUsername')}
+        {...register('instagramUsername', {
+          validate: editFormValidators.instagramUsername,
+        })}
         label="Instagram ID"
         placeholder="forgather_official"
         errorMessage={errors.instagramUsername?.message}

--- a/frontend/src/components/specific/editForm/editForm.validators.ts
+++ b/frontend/src/components/specific/editForm/editForm.validators.ts
@@ -3,6 +3,7 @@ import { createSafeValidator } from '../../../utils/validateForm';
 import {
   checkEmailForm,
   checkInputEmpty,
+  checkInstagramUsernameForm,
   checkMaxLength,
 } from '../../../validators/form.validators';
 
@@ -17,9 +18,13 @@ export const editFormValidators = {
     maxLength: createSafeValidator((value: string) =>
       checkMaxLength(value, CONSTRAINTS.MAX_LENGTH.SPACE.DESCRIPTION),
     ),
-    inputEmpty: createSafeValidator((value: string) => checkInputEmpty(value)),
   },
   email: {
     email: createSafeValidator((value: string) => checkEmailForm(value)),
+  },
+  instagramUsername: {
+    instagramUsername: createSafeValidator((value: string) =>
+      checkInstagramUsernameForm(value),
+    ),
   },
 };

--- a/frontend/src/constants/constraints.ts
+++ b/frontend/src/constants/constraints.ts
@@ -19,6 +19,7 @@ export const CONSTRAINTS = {
   },
   MAX_FILE_COUNT: 20,
   NOT_ALLOWED_FILE_TYPES: ['image/gif', 'image/svg', 'image/svg+xml'],
+  INSTAGRAM_USERNAME_REGEX: /^[a-zA-Z0-9_.]+$/,
   GUESTBOOK_PAGINATION_UNIT: 15,
   GUEST_BOOK_CARD_SWIPE_DISTANCE: 80,
   MAX_COUNT_FOR_REFRESH: 3,

--- a/frontend/src/pages/host/spaceCreate/funnel/SpaceCreateFunnel.tsx
+++ b/frontend/src/pages/host/spaceCreate/funnel/SpaceCreateFunnel.tsx
@@ -43,7 +43,7 @@ const SpaceCreateFunnel = () => {
         currentStep={currentStepIndex}
         maxStep={PROGRESS_STEP_LIST.length}
       />
-      <S.TopContainer></S.TopContainer>
+      <S.TopContainer />
       <S.ContentContainer>
         <Funnel.Step name="name">
           <SpaceNameElement

--- a/frontend/src/pages/host/spaceCreate/funnel/funnel.validators.ts
+++ b/frontend/src/pages/host/spaceCreate/funnel/funnel.validators.ts
@@ -1,6 +1,7 @@
 import { CONSTRAINTS } from '../../../../constants/constraints';
 import {
   checkEmailForm,
+  checkInstagramUsernameForm,
   checkMaxLength,
   checkNoWhitespaceOnly,
 } from '../../../../validators/form.validators';
@@ -22,5 +23,6 @@ export const funnelValidators = {
   },
   instagram: (value: string) => {
     checkNoWhitespaceOnly(value);
+    checkInstagramUsernameForm(value);
   },
 };

--- a/frontend/src/validators/form.validators.ts
+++ b/frontend/src/validators/form.validators.ts
@@ -23,3 +23,9 @@ export const checkEmailForm = (value: string) => {
     throw new Error('올바른 이메일 형식을 입력해 주세요.');
   }
 };
+
+export const checkInstagramUsernameForm = (value: string) => {
+  if (value.length !== 0 && !/^[a-zA-Z0-9_.]+$/.test(value)) {
+    throw new Error('영어, 숫자, _, . 만 입력할 수 있습니다.');
+  }
+};

--- a/frontend/src/validators/form.validators.ts
+++ b/frontend/src/validators/form.validators.ts
@@ -1,3 +1,4 @@
+import { CONSTRAINTS } from '../constants/constraints';
 import { calculateValidLength } from '../utils/grapheme';
 
 export const checkInputEmpty = (value: string) => {
@@ -25,7 +26,7 @@ export const checkEmailForm = (value: string) => {
 };
 
 export const checkInstagramUsernameForm = (value: string) => {
-  if (value.length !== 0 && !/^[a-zA-Z0-9_.]+$/.test(value)) {
+  if (value.length !== 0 && !CONSTRAINTS.INSTAGRAM_USERNAME_REGEX.test(value)) {
     throw new Error('영어, 숫자, _, . 만 입력할 수 있습니다.');
   }
 };


### PR DESCRIPTION
## 연관된 이슈

- close #850

## 작업 내용

1. 인스타그램 입력 형식 제어

<img width="441" height="172" alt="image" src="https://github.com/user-attachments/assets/8e6f1042-ade5-4d0e-a5f9-8a5da6ae5bb3" />


- 인스타그램 형식 추가
숫자, 영어, _, . 만 입력할 수 있도록 설정
- 스페이스 생성 / 스페이스 정보 수정 페이지 모두 적용


2. 스페이스 정보 수정

- 스페이스 설명 선택 사항으로 변경
- 스페이스 정보 중 필수항목 색상 error로 변경 (QA 사항)

<img width="460" height="126" alt="image" src="https://github.com/user-attachments/assets/f6dc99d3-aedd-43e3-9f39-5991e462c4f0" />
