### PR TITLE
fix: 잘못된 경로를 전달하던 현상 수정

### DIFF
--- a/frontend/src/constants/routes.ts
+++ b/frontend/src/constants/routes.ts
@@ -12,7 +12,6 @@ export const ROUTES = {
     SHARE: '/host/share',
   },
   GUEST: {
-    MAIN: '/guest/main',
     CREATE_GUESTBOOK_COMPLETE: '/guest/create-guestbook-complete',
   },
 };

--- a/frontend/src/pages/host/share/SharePage.tsx
+++ b/frontend/src/pages/host/share/SharePage.tsx
@@ -5,7 +5,11 @@ import CompleteImage from '../../../@assets/images/space-create.png';
 import Button from '../../../components/@common/buttons/button/Button';
 import IconButton from '../../../components/@common/buttons/iconButton/IconButton';
 import QRCode from '../../../components/@common/qrCode/QRCode';
-import { createSpaceMainRoute, ROUTES } from '../../../constants/routes';
+import {
+  createGuestHomeRoute,
+  createSpaceMainRoute,
+  ROUTES,
+} from '../../../constants/routes';
 import useButtonTracking from '../../../hooks/@common/useButtonTracking';
 import useConfetti from '../../../hooks/@common/useConfetti';
 import { useToast } from '../../../hooks/@common/useToast';
@@ -28,7 +32,7 @@ const SharePage = () => {
     }
   }, [location, navigate]);
 
-  const copyAddress = `${import.meta.env.VITE_DOMAIN}/guest/${spaceCode}/main`;
+  const copyAddress = `${import.meta.env.VITE_DOMAIN}${createGuestHomeRoute(spaceCode)}`;
 
   const handleSpaceMainButton = () => {
     trackClick('space_create_share_move_to_space_main', {


### PR DESCRIPTION
## 연관된 이슈

- close #862

## 작업 내용

- sharePage에서 잘못된 경로를 참조하고 있었음
- 리터럴이 아니라 분리해둔 함수를 활용해야 이러한 오류를 피할 수 있겠네요..