### PR TITLE
hotfix: 스페이스 사진 수정이 안되는 문제 해결

### DIFF
--- a/frontend/src/hooks/domain/space/usePatchSpaceInfo.ts
+++ b/frontend/src/hooks/domain/space/usePatchSpaceInfo.ts
@@ -29,12 +29,10 @@ const usePatchSpaceInfo = ({
   const createFormData = (data: Partial<SpaceInfoFormData>, image?: File) => {
     const updatedData = findUpdatedData(data);
     const formData = new FormData();
-    formData.append(
-      'request',
-      new Blob([JSON.stringify(updatedData)], {
-        type: 'application/json',
-      }),
-    );
+    if (image) {
+      updatedData.isDeletePhoto = true;
+    }
+    formData.append('request', JSON.stringify(updatedData));
 
     if (image) {
       formData.append('file', image);


### PR DESCRIPTION
## 연관된 이슈

- close #869

## 작업 내용

- 스페이스 사진 수정시 isDeletePhoto를 true로 바꿔 전송하는 로직이 누락됨
- 해당 로직 추가 후 정상 동작 확인함