### PR TITLE
fix: 수정 후 재 fetch 가 안되는 문제 해결

### DIFF
--- a/frontend/src/hooks/domain/guestbook/useGuestbookCard.ts
+++ b/frontend/src/hooks/domain/guestbook/useGuestbookCard.ts
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { guestbookService } from '../../../apis/services/guestbook/guestbook.service';
 import { createGuestbookRoute } from '../../../constants/routes';
+import { queryClient } from '../../../main';
 import type { GuestbookCard } from '../../../types/domain/guestbook.type';
 import { useToast } from '../../@common/useToast';
 
@@ -36,6 +37,9 @@ const useGuestbookCard = ({
     queryFn: async () => {
       const res = await guestbookService.getDetail(spaceCode, guestbookCardId);
       if (res.success) {
+        queryClient.invalidateQueries({
+          queryKey: ['guestbookList', spaceCode],
+        });
         return res.data;
       }
       throw new Error('방명록 상세 조회에 실패했습니다');

--- a/frontend/src/hooks/domain/space/usePatchSpaceInfo.ts
+++ b/frontend/src/hooks/domain/space/usePatchSpaceInfo.ts
@@ -1,3 +1,4 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { spaceService } from '../../../apis/services/space/space.service';
 import { createSpaceInfoRoute } from '../../../constants/routes';
@@ -19,6 +20,7 @@ const usePatchSpaceInfo = ({
 }: UsePatchSpaceInfoProps) => {
   const { showToast } = useToast();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   const findUpdatedData = (
     data: Partial<SpaceInfoFormData>,
@@ -67,6 +69,7 @@ const usePatchSpaceInfo = ({
         type: 'info',
       });
       afterPatch?.();
+      queryClient.invalidateQueries({ queryKey: ['spaceInfo', spaceCode] });
       navigate(createSpaceInfoRoute(spaceCode));
       return;
     }


### PR DESCRIPTION
## 연관된 이슈

- close #873

## 작업 내용
수정 후 재 fetch 가 안되는 문제 해결
- queryclient key 무효화
- guestbook 상세 조회 이후에 조회 여부 업데이트