### PR TITLE
feature: 이전 단계로 가는 버튼 추가

### DIFF
--- a/frontend/src/components/@common/header/Header.styles.ts
+++ b/frontend/src/components/@common/header/Header.styles.ts
@@ -21,7 +21,7 @@ export const Logo = styled.div<{ $mode: HeaderMode }>`
 
   svg {
     path {
-      fill: ${({ theme, $mode }) => ($mode === 'dark' ? theme.colors.white : theme.colors.black)};
+      color: ${({ theme, $mode }) => ($mode === 'dark' ? theme.colors.white : theme.colors.black)};
     }
   }
 `;

--- a/frontend/src/components/layout/global/layout/Layout.tsx
+++ b/frontend/src/components/layout/global/layout/Layout.tsx
@@ -89,7 +89,7 @@ const Layout = () => {
     },
     back: {
       icon: <MdChevronLeft size={32} />,
-      onClick: () => history.back(),
+      onClick: () => navigate(-1),
     },
   };
 

--- a/frontend/src/components/layout/global/layout/Layout.tsx
+++ b/frontend/src/components/layout/global/layout/Layout.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
-import { IoMdHome } from 'react-icons/io';
-import { MdMenu } from 'react-icons/md';
+import { MdChevronLeft, MdHome, MdMenu } from 'react-icons/md';
 import {
   Outlet,
   useLocation,
@@ -72,7 +71,7 @@ const Layout = () => {
       },
     },
     profile: {
-      icon: <IoMdHome size={24} />,
+      icon: <MdHome size={24} />,
       onClick: () => {
         trackClick('header_home_icon_click', {
           page: path,
@@ -87,6 +86,10 @@ const Layout = () => {
         }
         navigate(ROUTES.LANDING);
       },
+    },
+    back: {
+      icon: <MdChevronLeft size={28} />,
+      onClick: () => history.back(),
     },
   };
 

--- a/frontend/src/components/layout/global/layout/Layout.tsx
+++ b/frontend/src/components/layout/global/layout/Layout.tsx
@@ -88,7 +88,7 @@ const Layout = () => {
       },
     },
     back: {
-      icon: <MdChevronLeft size={28} />,
+      icon: <MdChevronLeft size={32} />,
       onClick: () => history.back(),
     },
   };

--- a/frontend/src/pages/host/spaceCreate/funnel/SpaceCreateFunnel.styles.ts
+++ b/frontend/src/pages/host/spaceCreate/funnel/SpaceCreateFunnel.styles.ts
@@ -19,3 +19,8 @@ export const ContentContainer = styled.div`
   display: flex;
   flex-direction: column;
 `;
+
+export const ProgressBarContainer = styled.div`
+  position: relative;
+  top: -16px;
+`;

--- a/frontend/src/pages/host/spaceCreate/funnel/SpaceCreateFunnel.tsx
+++ b/frontend/src/pages/host/spaceCreate/funnel/SpaceCreateFunnel.tsx
@@ -58,10 +58,12 @@ const SpaceCreateFunnel = () => {
 
   return (
     <S.Wrapper>
-      <StepProgressBar
-        currentStep={currentStepIndex}
-        maxStep={PROGRESS_STEP_LIST.length}
-      />
+      <S.ProgressBarContainer>
+        <StepProgressBar
+          currentStep={currentStepIndex}
+          maxStep={PROGRESS_STEP_LIST.length}
+        />
+      </S.ProgressBarContainer>
       <S.TopContainer />
       <S.ContentContainer>
         <Funnel.Step name="name">

--- a/frontend/src/pages/host/spaceCreate/funnel/SpaceCreateFunnel.tsx
+++ b/frontend/src/pages/host/spaceCreate/funnel/SpaceCreateFunnel.tsx
@@ -63,12 +63,7 @@ const SpaceCreateFunnel = () => {
       <Button
         type="button"
         variant="fit"
-        text={
-          <>
-            <MdArrowBack />
-            <p>이전 단계</p>
-          </>
-        }
+        text={<MdArrowBack size={28} />}
         onClick={() => history.back()}
       />
       <StepProgressBar

--- a/frontend/src/pages/host/spaceCreate/funnel/SpaceCreateFunnel.tsx
+++ b/frontend/src/pages/host/spaceCreate/funnel/SpaceCreateFunnel.tsx
@@ -1,3 +1,5 @@
+import { MdArrowBack } from 'react-icons/md';
+import Button from '../../../../components/@common/buttons/button/Button';
 import StepProgressBar from '../../../../components/@common/progressBar/step/StepProgressBar';
 import useButtonTracking from '../../../../hooks/@common/useButtonTracking';
 import useConfirmBeforeRefresh from '../../../../hooks/@common/useConfirmBeforeRefresh';
@@ -58,6 +60,17 @@ const SpaceCreateFunnel = () => {
 
   return (
     <S.Wrapper>
+      <Button
+        type="button"
+        variant="fit"
+        text={
+          <>
+            <MdArrowBack />
+            <p>이전 단계</p>
+          </>
+        }
+        onClick={() => history.back()}
+      />
       <StepProgressBar
         currentStep={currentStepIndex}
         maxStep={PROGRESS_STEP_LIST.length}

--- a/frontend/src/pages/host/spaceCreate/funnel/SpaceCreateFunnel.tsx
+++ b/frontend/src/pages/host/spaceCreate/funnel/SpaceCreateFunnel.tsx
@@ -1,5 +1,3 @@
-import { MdChevronLeft } from 'react-icons/md';
-import Button from '../../../../components/@common/buttons/button/Button';
 import StepProgressBar from '../../../../components/@common/progressBar/step/StepProgressBar';
 import useButtonTracking from '../../../../hooks/@common/useButtonTracking';
 import useConfirmBeforeRefresh from '../../../../hooks/@common/useConfirmBeforeRefresh';
@@ -60,12 +58,6 @@ const SpaceCreateFunnel = () => {
 
   return (
     <S.Wrapper>
-      <Button
-        type="button"
-        variant="fit"
-        text={<MdChevronLeft size={28} />}
-        onClick={() => history.back()}
-      />
       <StepProgressBar
         currentStep={currentStepIndex}
         maxStep={PROGRESS_STEP_LIST.length}

--- a/frontend/src/pages/host/spaceCreate/funnel/SpaceCreateFunnel.tsx
+++ b/frontend/src/pages/host/spaceCreate/funnel/SpaceCreateFunnel.tsx
@@ -1,4 +1,4 @@
-import { MdArrowBack } from 'react-icons/md';
+import { MdChevronLeft } from 'react-icons/md';
 import Button from '../../../../components/@common/buttons/button/Button';
 import StepProgressBar from '../../../../components/@common/progressBar/step/StepProgressBar';
 import useButtonTracking from '../../../../hooks/@common/useButtonTracking';
@@ -63,7 +63,7 @@ const SpaceCreateFunnel = () => {
       <Button
         type="button"
         variant="fit"
-        text={<MdArrowBack size={28} />}
+        text={<MdChevronLeft size={28} />}
         onClick={() => history.back()}
       />
       <StepProgressBar

--- a/frontend/src/router/router.tsx
+++ b/frontend/src/router/router.tsx
@@ -182,7 +182,7 @@ const routes: AppRouteObject[] = [
                 handle: {
                   noFooter: true,
                   headerIcon: {
-                    leftIcon: 'logo',
+                    leftIcon: 'back',
                   },
                 },
               },


### PR DESCRIPTION
## 연관된 이슈

- close #879 

## 작업 내용

- 스페이스 생성 퍼널에서 이전으로 가는 버튼 추가

<img width="585" height="1266" alt="localhost_5173_host_create-space(iPhone 12 Pro)" src="https://github.com/user-attachments/assets/a53b777f-2622-40ad-baec-e58222024521" />

## 논의 사항

- ProgressBar를 없앨 지 고민이 됐습니다. 이전 단계 버튼을 추가하니 현재 위치가 애매하다고 생각했고, 방명록을 작성하는 다른 퍼널엔 표시되지 않으니 두 퍼널 간 통일성을 챙길 수 있어 보입니다. 어떻게 생각하시나요?