### PR TITLE
feature: 랜딩 세부 요소 추가(스크롤 표시, scrollTop 버튼)

### DIFF
--- a/frontend/src/components/@common/footer/Footer.styles.ts
+++ b/frontend/src/components/@common/footer/Footer.styles.ts
@@ -26,15 +26,13 @@ export const FooterContent = styled.div<{ $mode: FooterMode }>`
 
 export const Copyright = styled.p<{ $mode: FooterMode }>`
   font-size: 12px;
-  color: ${({ theme, $mode }) =>
-    $mode === 'dark' ? theme.colors.gray04 : theme.colors.gray04};
+  color: ${({ theme, $mode }) => ($mode === 'dark' ? theme.colors.gray04 : theme.colors.gray04)};
   margin: 0;
 `;
 
 export const ContactLink = styled.a<{ $mode: FooterMode }>`
   font-size: 14px;
-  color: ${({ theme, $mode }) =>
-    $mode === 'dark' ? theme.colors.gray04 : theme.colors.gray04};
+  color: ${({ theme, $mode }) => ($mode === 'dark' ? theme.colors.gray04 : theme.colors.gray04)};
   text-decoration: none;
   cursor: pointer;
 

--- a/frontend/src/pages/landing/LandingPage.styles.ts
+++ b/frontend/src/pages/landing/LandingPage.styles.ts
@@ -134,12 +134,15 @@ export const Screenshot = styled.img`
 export const ScrollIconContainer = styled.div`
   position: fixed;
   left: 50%;
-  bottom: 16px;
+  bottom: 0px;
   color: ${({ theme }) => theme.colors.white};
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 4px;
+  width: 100%;
+  background: linear-gradient(to top, ${({ theme }) => hexToRgba(theme.colors.gray05, 0.8)}, ${({ theme }) => hexToRgba(theme.colors.gray05, 0.5)}, transparent);
+  width: ${({ theme }) => theme.layout.width};
+  height: 48px;
 `;
 
 export const ScrollTopContainer = styled.div`

--- a/frontend/src/pages/landing/LandingPage.styles.ts
+++ b/frontend/src/pages/landing/LandingPage.styles.ts
@@ -144,6 +144,8 @@ export const ScrollIconContainer = styled.div`
 
 export const ScrollTopContainer = styled.div`
   position: fixed;
-  left: 24px;
-  bottom: 16px;
+  right: calc(
+    (100vw - ${({ theme }) => theme.layout.width}) / 2 + ${({ theme }) => theme.layout.padding.leftRight} * 2);
+  bottom: ${({ theme }) => theme.layout.padding.topBottom};
+  z-index: ${({ theme }) => theme.zIndex.fixedButton};
 `;

--- a/frontend/src/pages/landing/LandingPage.styles.ts
+++ b/frontend/src/pages/landing/LandingPage.styles.ts
@@ -105,7 +105,10 @@ export const Bubble = styled.div<{
   ${({ theme }) => theme.typography.bodyLarge}
   color: ${({ $color, theme }) => ($color === 'light' ? theme.colors.gray06 : theme.colors.white)};
   background-color: ${({ $color, theme }) =>
-    hexToRgba($color === 'light' ? theme.colors.gray01 : theme.colors.gray06, 0.8)};
+    hexToRgba(
+      $color === 'light' ? theme.colors.gray01 : theme.colors.gray06,
+      0.8,
+    )};
   width: 100%;
   padding: 12px 8px;
   line-height: 36px;
@@ -126,4 +129,12 @@ export const Screenshot = styled.img`
   width: 100%;
   filter: drop-shadow(0 0 5px ${({ theme }) => theme.colors.white})
     drop-shadow(0 0 10px ${({ theme }) => hexToRgba(theme.colors.gray02, 0.5)});
+`;
+
+export const ScrollIconContainer = styled.div`
+  position: fixed;
+  left: 50%;
+  bottom: 16px;
+  transform: translateX(-50%);
+  color: ${({ theme }) => theme.colors.white};
 `;

--- a/frontend/src/pages/landing/LandingPage.styles.ts
+++ b/frontend/src/pages/landing/LandingPage.styles.ts
@@ -138,3 +138,9 @@ export const ScrollIconContainer = styled.div`
   transform: translateX(-50%);
   color: ${({ theme }) => theme.colors.white};
 `;
+
+export const ScrollTopContainer = styled.div`
+  position: fixed;
+  left: 24px;
+  bottom: 16px;
+`;

--- a/frontend/src/pages/landing/LandingPage.styles.ts
+++ b/frontend/src/pages/landing/LandingPage.styles.ts
@@ -105,10 +105,7 @@ export const Bubble = styled.div<{
   ${({ theme }) => theme.typography.bodyLarge}
   color: ${({ $color, theme }) => ($color === 'light' ? theme.colors.gray06 : theme.colors.white)};
   background-color: ${({ $color, theme }) =>
-    hexToRgba(
-      $color === 'light' ? theme.colors.gray01 : theme.colors.gray06,
-      0.8,
-    )};
+    hexToRgba($color === 'light' ? theme.colors.gray01 : theme.colors.gray06, 0.8)};
   width: 100%;
   padding: 12px 8px;
   line-height: 36px;
@@ -147,7 +144,9 @@ export const ScrollIconContainer = styled.div`
 export const ScrollTopContainer = styled.div`
   position: fixed;
   right: calc(
-    (100vw - ${({ theme }) => theme.layout.width}) / 2 + ${({ theme }) => theme.layout.padding.leftRight} * 2);
+    (100vw - ${({ theme }) => theme.layout.width}) / 2 +
+      ${({ theme }) => theme.layout.padding.leftRight} * 2
+  );
   bottom: ${({ theme }) => theme.layout.padding.topBottom};
   z-index: ${({ theme }) => theme.zIndex.fixedButton};
 `;

--- a/frontend/src/pages/landing/LandingPage.styles.ts
+++ b/frontend/src/pages/landing/LandingPage.styles.ts
@@ -135,8 +135,11 @@ export const ScrollIconContainer = styled.div`
   position: fixed;
   left: 50%;
   bottom: 16px;
-  transform: translateX(-50%);
   color: ${({ theme }) => theme.colors.white};
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
 `;
 
 export const ScrollTopContainer = styled.div`

--- a/frontend/src/pages/landing/LandingPage.styles.ts
+++ b/frontend/src/pages/landing/LandingPage.styles.ts
@@ -139,8 +139,7 @@ export const ScrollIconContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  width: 100%;
-  background: linear-gradient(to top, ${({ theme }) => hexToRgba(theme.colors.gray05, 0.8)}, ${({ theme }) => hexToRgba(theme.colors.gray05, 0.5)}, transparent);
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.8), rgba(0, 0, 0, 0.5), transparent);
   width: ${({ theme }) => theme.layout.width};
   height: 48px;
 `;

--- a/frontend/src/pages/landing/LandingPage.tsx
+++ b/frontend/src/pages/landing/LandingPage.tsx
@@ -1,4 +1,12 @@
-import { type MotionProps, motion, type Variants } from 'framer-motion';
+import {
+  type MotionProps,
+  motion,
+  useMotionValueEvent,
+  useScroll,
+  type Variants,
+} from 'framer-motion';
+import { useState } from 'react';
+import { MdArrowDownward } from 'react-icons/md';
 import { useNavigate } from 'react-router-dom';
 import completeImage from '../../@assets/images/screenshots/complete.png';
 import guestbookImage from '../../@assets/images/screenshots/guestbook.png';
@@ -18,6 +26,16 @@ const MotionSection = motion(S.Section);
 const MotionTitleContainer = motion(S.TitleContainer);
 const MotionScreenshotBox = motion(S.ScreenshotBox);
 const MotionSubTitle = motion(S.SubTitle);
+const MotionScrollIconContainer = motion(S.ScrollIconContainer);
+
+const scrollIconVariants: Variants = {
+  visible: { opacity: 1, scale: 1 },
+  hidden: {
+    opacity: 0,
+    scale: 0.9,
+    transition: { duration: 0.25, ease: 'easeOut' },
+  },
+};
 
 const fadeVariants: Variants = {
   hidden: { opacity: 0, y: 40 },
@@ -54,6 +72,13 @@ const LandingPage = () => {
   const { trackClick } = useButtonTracking({
     userType: isLoggedIn ? 'host' : 'guest',
   });
+  const { scrollYProgress } = useScroll();
+  const [hideScrollIcon, setHideScrollIcon] = useState(false);
+
+  useMotionValueEvent(scrollYProgress, 'change', (latest) => {
+    if (latest > 0 && !hideScrollIcon) setHideScrollIcon(true);
+    if (latest <= 0) setHideScrollIcon(false);
+  });
 
   const handleStartButton = () => {
     if (isLoggedIn) {
@@ -75,6 +100,14 @@ const LandingPage = () => {
 
   return (
     <S.Wrapper>
+      <MotionScrollIconContainer
+        initial="visible"
+        animate={hideScrollIcon ? 'hidden' : 'visible'}
+        variants={scrollIconVariants}
+        style={{ pointerEvents: hideScrollIcon ? 'none' : 'auto' }}
+      >
+        <MdArrowDownward size={24} />
+      </MotionScrollIconContainer>
       <S.ContentContainer>
         <MotionSection
           style={{ gap: '156px' }}

--- a/frontend/src/pages/landing/LandingPage.tsx
+++ b/frontend/src/pages/landing/LandingPage.tsx
@@ -5,8 +5,8 @@ import {
   useScroll,
   type Variants,
 } from 'framer-motion';
-import { useEffect, useState } from 'react';
-import { MdArrowDownward, MdArrowUpward, MdOutlineMouse } from 'react-icons/md';
+import { useState } from 'react';
+import { MdArrowUpward, MdKeyboardDoubleArrowDown } from 'react-icons/md';
 import { useNavigate } from 'react-router-dom';
 import completeImage from '../../@assets/images/screenshots/complete.png';
 import guestbookImage from '../../@assets/images/screenshots/guestbook.png';
@@ -34,12 +34,10 @@ const MotionScrollTopContainer = motion.create(S.ScrollTopContainer);
 const scrollIconVariants: Variants = {
   visible: {
     opacity: 1,
-    scale: 1,
     transition: { duration: 1, ease: 'easeOut' },
   },
   hidden: {
     opacity: 0,
-    scale: 0.9,
     transition: { duration: 0.25, ease: 'easeOut' },
   },
 };
@@ -90,15 +88,6 @@ const LandingPage = () => {
   const { scrollYProgress } = useScroll();
   const [hideScrollIcon, setHideScrollIcon] = useState(false);
   const [hideScrollTop, setHideScrollTop] = useState(true);
-  const [canShowScrollIcon, setCanShowScrollIcon] = useState(false);
-
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setCanShowScrollIcon(true);
-    }, 2000);
-
-    return () => clearTimeout(timer);
-  }, []);
 
   useMotionValueEvent(scrollYProgress, 'change', (latest) => {
     if (latest > 0 && !hideScrollIcon) setHideScrollIcon(true);
@@ -131,12 +120,11 @@ const LandingPage = () => {
     <S.Wrapper>
       <MotionScrollIconContainer
         initial="hidden"
-        animate={canShowScrollIcon && !hideScrollIcon ? 'visible' : 'hidden'}
+        animate={!hideScrollIcon ? 'visible' : 'hidden'}
         variants={scrollIconVariants}
         style={{ pointerEvents: hideScrollIcon ? 'none' : 'auto', x: '-50%' }}
       >
-        <MdOutlineMouse size={24} />
-        <MdArrowDownward size={24} />
+        <MdKeyboardDoubleArrowDown size={32} />
       </MotionScrollIconContainer>
       <MotionScrollTopContainer
         initial="hidden"

--- a/frontend/src/pages/landing/LandingPage.tsx
+++ b/frontend/src/pages/landing/LandingPage.tsx
@@ -5,7 +5,7 @@ import {
   useScroll,
   type Variants,
 } from 'framer-motion';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { MdArrowDownward, MdArrowUpward, MdOutlineMouse } from 'react-icons/md';
 import { useNavigate } from 'react-router-dom';
 import completeImage from '../../@assets/images/screenshots/complete.png';
@@ -32,7 +32,11 @@ const MotionScrollIconContainer = motion.create(S.ScrollIconContainer);
 const MotionScrollTopContainer = motion.create(S.ScrollTopContainer);
 
 const scrollIconVariants: Variants = {
-  visible: { opacity: 1, scale: 1 },
+  visible: {
+    opacity: 1,
+    scale: 1,
+    transition: { duration: 1, ease: 'easeOut' },
+  },
   hidden: {
     opacity: 0,
     scale: 0.9,
@@ -86,6 +90,15 @@ const LandingPage = () => {
   const { scrollYProgress } = useScroll();
   const [hideScrollIcon, setHideScrollIcon] = useState(false);
   const [hideScrollTop, setHideScrollTop] = useState(true);
+  const [canShowScrollIcon, setCanShowScrollIcon] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setCanShowScrollIcon(true);
+    }, 2000);
+
+    return () => clearTimeout(timer);
+  }, []);
 
   useMotionValueEvent(scrollYProgress, 'change', (latest) => {
     if (latest > 0 && !hideScrollIcon) setHideScrollIcon(true);
@@ -117,8 +130,8 @@ const LandingPage = () => {
   return (
     <S.Wrapper>
       <MotionScrollIconContainer
-        initial="visible"
-        animate={hideScrollIcon ? 'hidden' : 'visible'}
+        initial="hidden"
+        animate={canShowScrollIcon && !hideScrollIcon ? 'visible' : 'hidden'}
         variants={scrollIconVariants}
         style={{ pointerEvents: hideScrollIcon ? 'none' : 'auto', x: '-50%' }}
       >

--- a/frontend/src/pages/landing/LandingPage.tsx
+++ b/frontend/src/pages/landing/LandingPage.tsx
@@ -6,7 +6,7 @@ import {
   type Variants,
 } from 'framer-motion';
 import { useState } from 'react';
-import { MdArrowDownward } from 'react-icons/md';
+import { MdArrowDownward, MdArrowUpward } from 'react-icons/md';
 import { useNavigate } from 'react-router-dom';
 import completeImage from '../../@assets/images/screenshots/complete.png';
 import guestbookImage from '../../@assets/images/screenshots/guestbook.png';
@@ -16,19 +16,30 @@ import spaceImage from '../../@assets/images/screenshots/space.png';
 import visibilityImage from '../../@assets/images/screenshots/visibility.png';
 import titleImage from '../../@assets/logo/main-logo.png';
 import Button from '../../components/@common/buttons/button/Button';
+import IconButton from '../../components/@common/buttons/iconButton/IconButton';
 import { AUTH_COOKIES } from '../../constants/cookie';
 import { ROUTES } from '../../constants/routes';
 import useButtonTracking from '../../hooks/@common/useButtonTracking';
 import { CookieUtils } from '../../utils/cookie';
+import { goToTop } from '../../utils/goToTop';
 import * as S from './LandingPage.styles';
 
-const MotionSection = motion(S.Section);
-const MotionTitleContainer = motion(S.TitleContainer);
-const MotionScreenshotBox = motion(S.ScreenshotBox);
-const MotionSubTitle = motion(S.SubTitle);
-const MotionScrollIconContainer = motion(S.ScrollIconContainer);
+const MotionSection = motion.create(S.Section);
+const MotionTitleContainer = motion.create(S.TitleContainer);
+const MotionScreenshotBox = motion.create(S.ScreenshotBox);
+const MotionSubTitle = motion.create(S.SubTitle);
+const MotionScrollIconContainer = motion.create(S.ScrollIconContainer);
+const MotionScrollTopContainer = motion.create(S.ScrollTopContainer);
 
 const scrollIconVariants: Variants = {
+  visible: { opacity: 1, scale: 1 },
+  hidden: {
+    opacity: 0,
+    scale: 0.9,
+    transition: { duration: 0.25, ease: 'easeOut' },
+  },
+};
+const scrollTopVariants: Variants = {
   visible: { opacity: 1, scale: 1 },
   hidden: {
     opacity: 0,
@@ -74,10 +85,15 @@ const LandingPage = () => {
   });
   const { scrollYProgress } = useScroll();
   const [hideScrollIcon, setHideScrollIcon] = useState(false);
+  const [hideScrollTop, setHideScrollTop] = useState(true);
 
   useMotionValueEvent(scrollYProgress, 'change', (latest) => {
     if (latest > 0 && !hideScrollIcon) setHideScrollIcon(true);
     if (latest <= 0) setHideScrollIcon(false);
+  });
+  useMotionValueEvent(scrollYProgress, 'change', (latest) => {
+    if (latest <= 0.1 && !hideScrollTop) setHideScrollTop(true);
+    if (latest > 0.1) setHideScrollTop(false);
   });
 
   const handleStartButton = () => {
@@ -108,6 +124,17 @@ const LandingPage = () => {
       >
         <MdArrowDownward size={24} />
       </MotionScrollIconContainer>
+      <MotionScrollTopContainer
+        initial="hidden"
+        animate={hideScrollTop ? 'hidden' : 'visible'}
+        variants={scrollTopVariants}
+      >
+        <IconButton
+          icon={<MdArrowUpward />}
+          variant="dark"
+          onClick={() => goToTop()}
+        />
+      </MotionScrollTopContainer>
       <S.ContentContainer>
         <MotionSection
           style={{ gap: '156px' }}

--- a/frontend/src/pages/landing/LandingPage.tsx
+++ b/frontend/src/pages/landing/LandingPage.tsx
@@ -6,7 +6,7 @@ import {
   type Variants,
 } from 'framer-motion';
 import { useState } from 'react';
-import { MdArrowDownward, MdArrowUpward } from 'react-icons/md';
+import { MdArrowDownward, MdArrowUpward, MdOutlineMouse } from 'react-icons/md';
 import { useNavigate } from 'react-router-dom';
 import completeImage from '../../@assets/images/screenshots/complete.png';
 import guestbookImage from '../../@assets/images/screenshots/guestbook.png';
@@ -120,8 +120,9 @@ const LandingPage = () => {
         initial="visible"
         animate={hideScrollIcon ? 'hidden' : 'visible'}
         variants={scrollIconVariants}
-        style={{ pointerEvents: hideScrollIcon ? 'none' : 'auto' }}
+        style={{ pointerEvents: hideScrollIcon ? 'none' : 'auto', x: '-50%' }}
       >
+        <MdOutlineMouse size={24} />
         <MdArrowDownward size={24} />
       </MotionScrollIconContainer>
       <MotionScrollTopContainer


### PR DESCRIPTION
## 연관된 이슈

- close #876 

## 작업 내용

### 스크롤 표시 추가
- useEffect를 이용해 2초 뒤 애니메이션이 출력되도록 변경
- framerMotion의 staggerChildren을 이용해 구현하면 처음 요소가 모두 보이고 출력하도록 할 수 있지만, 스크롤 표시는 fixed로 되어있는 것이 모든 viewport에 대응할 수 있다고 판단
  - 만약 staggerChildren을 이용하기 위해 MotionSection 내에 넣을 경우 처음엔 요소가 없어 viewport의 height가 낮아 아이콘이 위로 올라가는 현상 발생
  - 따라서 Wrapper 바로 밑에 fixed로 선언하고 useEffect로 딜레이
### scrollTop 버튼 추가
- 일정 스크롤을 내릴 시 표시

https://github.com/user-attachments/assets/f7cd0cae-5e36-4c8e-b172-3a97cadb0895
