### PR TITLE
fix: CDN 응답 헤더 설정을 통한 CORS 오류 해결

### DIFF
--- a/frontend/src/apis/http.ts
+++ b/frontend/src/apis/http.ts
@@ -215,7 +215,6 @@ const createHttpClient = ({
       fullUrl: url,
       headersOverride: {
         'Content-Type': file.type || 'application/octet-stream',
-        'Cache-Control': 'no-store',
         'Content-Disposition': `attachment; filename*=UTF-8''${encodeURIComponent(file.name)}`,
         'x-amz-tagging':
           'Service=techcourse&Role=techcourse-etc&ProjectTeam=PhotoGather',


### PR DESCRIPTION
## 연관된 이슈

- close #891

## 작업 내용
기존 방식의 문제점
- S3 객체 메타데이터에 Cache-control: no-store을 사용하면서 브라우저 캐싱을 전혀 활용하지 못함
- CDN 응답 헤더 정책에 대한 설정으로 이미지 배포에 대해서 no-cors / cors 요청 모두 CORS 헤더를 추가할 수 있도록 설정 

⬇️ 구체적인 CDN 응답 헤더 정책 설정 및 해결 방안에 대한 문서 ⬇️
[CDN_응답헤더정책으로_CORS_해결하기](https://www.notion.so/CDN-CORS-29afad1516c280f58b2efe9025d0dffb?pvs=74)