### PR TITLE
fix: 사진이 없는 작품의 경우 guest 환경에서 가운데 정렬이 되는 현상 수정

### DIFF
--- a/frontend/src/pages/WorkDetail.common.styles.ts
+++ b/frontend/src/pages/WorkDetail.common.styles.ts
@@ -12,6 +12,7 @@ const glow = keyframes`
 `;
 
 export const WorkContainer = styled.div`
+  width: 100%;
   display: flex;
   flex-direction: column;
   gap: 16px;


### PR DESCRIPTION
## 연관된 이슈

- close #895 

## 작업 내용

- guest는 수정버튼이 없기 때문에 width가 넓어지지 않아 가운데로 모임
- Work 내 Container 자체 width를 100%로 지정

### 근데 왜 host는 괜찮고, guest에서만 문제가 발생했는가?
- host는 오른쪽 위에 수정 버튼을 놓기 위해 제목과 수정 버튼을 space-between으로 넓혀주고 있었음, 따라서 width가 없어도 layout 전체를 사용함
- 반면 guest는 수정버튼이 없으므로 width가 쪼그라들었고, 기본적으로 가운데 정렬되어있는 레이아웃 특성상 가운데로 몰렸음
### 근데 왜 사진이 없을때만 문제가 발생했는가?
- 사진을 올리면 layout에 맞도록 width: 100%가 지정됨
- 따라서 위의 설명란은 width가 주어지지 않아도 아래 사진덕분에 넓은 width 상에서 표시될 수 있었음

## 논의 사항
- 수정 내용이 별로 없고 prod에 바로 반영해야 되니 빠르게 머지하겠습니다!