### PR TITLE
refactor: 작품 등록 로딩 ui 및 업로드 장수 제한 로직 수정

### DIFF
--- a/frontend/src/hooks/domain/useWorkForm.ts
+++ b/frontend/src/hooks/domain/useWorkForm.ts
@@ -32,6 +32,7 @@ export const useWorkForm = ({ spaceCode, reset }: UseWorkFormParams) => {
   const [initialWorkData, setInitialWorkData] = useState<WorkFormData | null>(
     null,
   );
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: showToast is stable
   useEffect(() => {
@@ -148,6 +149,7 @@ export const useWorkForm = ({ spaceCode, reset }: UseWorkFormParams) => {
     }
 
     try {
+      setIsSubmitting(true);
       const newPhotos = await uploadNewPhotos(files);
 
       if (isEditMode) {
@@ -158,6 +160,8 @@ export const useWorkForm = ({ spaceCode, reset }: UseWorkFormParams) => {
     } catch (error) {
       console.error(error);
       showToast({ text: '작품 저장에 실패했습니다.' });
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -166,5 +170,6 @@ export const useWorkForm = ({ spaceCode, reset }: UseWorkFormParams) => {
     existingPhotos,
     deleteExistingPhoto,
     submitWork,
+    isSubmitting,
   };
 };

--- a/frontend/src/pages/host/spaceHomePage/HostSpaceHomePage.tsx
+++ b/frontend/src/pages/host/spaceHomePage/HostSpaceHomePage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { IoLogoInstagram, IoShareOutline } from 'react-icons/io5';
 import { MdEmail, MdSettings } from 'react-icons/md';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -25,8 +25,12 @@ const HostSpaceHomePage = () => {
   const navigate = useNavigate();
   const { spaceCode = '' } = useParams();
   const { spaceInfo } = useSpaceInfoContext();
-  const [isEventModalOpen, setIsEventModalOpen] = useState(canOpenEventModal);
+  const [isEventModalOpen, setIsEventModalOpen] = useState(false);
   const [isShareModalOpen, setIsShareModalOpen] = useState(false);
+
+  useEffect(() => {
+    setIsEventModalOpen(canOpenEventModal());
+  }, []);
 
   const { trackClick } = useButtonTracking({
     userType: 'host',

--- a/frontend/src/pages/host/workForm/WorkForm.tsx
+++ b/frontend/src/pages/host/workForm/WorkForm.tsx
@@ -7,6 +7,7 @@ import Button from '../../../components/@common/buttons/button/Button';
 import TextareaInput from '../../../components/@common/inputs/textareaInput/TextareaInput';
 import TextInput from '../../../components/@common/inputs/textInput/TextInput';
 import DeleteModal from '../../../components/@common/modal/deleteModal/DeleteModal';
+import LoadingModal from '../../../components/specific/modal/loadingModal/LoadingModal';
 import PhotoUploadButton from '../../../components/specific/photoUploadButton/PhotoUploadButton';
 import { CONSTRAINTS } from '../../../constants/constraints';
 import useButtonTracking from '../../../hooks/@common/useButtonTracking';
@@ -49,15 +50,23 @@ const WorkForm = () => {
   });
 
   const {
+    isEditMode,
+    existingPhotos,
+    deleteExistingPhoto,
+    submitWork,
+    isSubmitting,
+  } = useWorkForm({ spaceCode, reset });
+
+  const {
     localFiles,
     previewFiles,
     deleteFile,
     handleFilesUploadClick,
     handleFilesDrop,
-  } = useLocalFile({ fileType: 'image', maxFileCount: 10 });
-
-  const { isEditMode, existingPhotos, deleteExistingPhoto, submitWork } =
-    useWorkForm({ spaceCode, reset });
+  } = useLocalFile({
+    fileType: 'image',
+    maxFileCount: 10 - existingPhotos.length,
+  });
 
   const onValid = async (data: WorkFormData) => {
     trackClick(
@@ -147,6 +156,10 @@ const WorkForm = () => {
 
   return (
     <>
+      <LoadingModal
+        isOpen={isSubmitting}
+        text={isEditMode ? '수정중 ...' : '등록중...'}
+      />
       <DeleteModal
         isOpen={isDeleteModalOpen}
         onCloseModal={() => {
@@ -279,7 +292,7 @@ const WorkForm = () => {
               type="submit"
               text={isEditMode ? '수정하기' : '등록하기'}
               variant="fixed"
-              disabled={!isAllValid}
+              disabled={!isAllValid || isSubmitting}
             />
           </S.ButtonContainer>
         </S.FormContainer>

--- a/frontend/src/pages/host/workForm/WorkForm.tsx
+++ b/frontend/src/pages/host/workForm/WorkForm.tsx
@@ -65,7 +65,7 @@ const WorkForm = () => {
     handleFilesDrop,
   } = useLocalFile({
     fileType: 'image',
-    maxFileCount: 10 - existingPhotos.length,
+    maxFileCount: Math.max(0, 10 - existingPhotos.length),
   });
 
   const onValid = async (data: WorkFormData) => {
@@ -158,7 +158,7 @@ const WorkForm = () => {
     <>
       <LoadingModal
         isOpen={isSubmitting}
-        text={isEditMode ? '수정중 ...' : '등록중...'}
+        text={isEditMode ? '수정중 ...' : '등록중 ...'}
       />
       <DeleteModal
         isOpen={isDeleteModalOpen}

--- a/frontend/src/utils/canOpenEventModal.ts
+++ b/frontend/src/utils/canOpenEventModal.ts
@@ -5,7 +5,15 @@ export const canOpenEventModal = () => {
   if (Date.now() >= eventEndDate.getTime()) {
     return false;
   }
-  const hideUntil = localStorage.getItem(EVENT_MODAL_HIDE_KEY);
-  if (!hideUntil) return true;
-  return Number(hideUntil) < Date.now();
+
+  if (typeof window === 'undefined') return true;
+
+  try {
+    const hideUntil = window.localStorage.getItem(EVENT_MODAL_HIDE_KEY);
+    if (!hideUntil) return true;
+    return Number(hideUntil) < Date.now();
+  } catch (error) {
+    console.warn('localStorage 접근 실패:', error);
+    return true;
+  }
 };


### PR DESCRIPTION
## 연관된 이슈

- close #902 

## 작업 내용

- [x] 작품 등록 시 로딩 ui 추가
- [x] 업로드 된 사진 + 추가 첨부시에도 10장 제한 로직 리팩토링