### PR TITLE
feature: 랜딩 페이지 내 수치 현황 표시

### DIFF
--- a/frontend/src/apis/services/space/space.service.ts
+++ b/frontend/src/apis/services/space/space.service.ts
@@ -1,7 +1,13 @@
-import type { MySpace, SpaceInfo } from '../../../types/domain/space.type';
+import type {
+  MySpace,
+  SpaceInfo,
+  SpaceStats,
+} from '../../../types/domain/space.type';
 import { http } from '../../http';
 
 export const spaceService = {
+  getSpaceStats: () => http.get<SpaceStats>('/stats/landing'),
+
   create: (data: FormData) => http.post<{ spaceCode: string }>('/spaces', data),
 
   getSpaceInfo: (spaceCode: string) =>

--- a/frontend/src/components/@common/countUpNumber/CountUpNumber.tsx
+++ b/frontend/src/components/@common/countUpNumber/CountUpNumber.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+
+interface CountUpNumberProps {
+  initialNumber?: number;
+  targetNumber: number;
+  time?: number;
+}
+
+const CountUpNumber = ({
+  initialNumber = 0,
+  targetNumber,
+  time = 1000,
+}: CountUpNumberProps) => {
+  const [number, setNumber] = useState(initialNumber);
+
+  useEffect(() => {
+    let startTime: number | null = null;
+    let animationFrameId: number;
+
+    const totalValue = targetNumber - initialNumber;
+
+    const animate = (timestamp: number) => {
+      if (startTime === null) startTime = timestamp;
+      const elapsed = timestamp - startTime;
+      const progress = Math.min(elapsed / time, 1);
+      const currentValue = initialNumber + totalValue * progress;
+
+      setNumber(currentValue);
+
+      if (progress < 1) {
+        animationFrameId = requestAnimationFrame(animate);
+      }
+    };
+
+    animationFrameId = requestAnimationFrame(animate);
+
+    return () => cancelAnimationFrame(animationFrameId);
+  }, [initialNumber, targetNumber, time]);
+
+  return <p>{Math.round(number)}</p>;
+};
+
+export default CountUpNumber;

--- a/frontend/src/hooks/@common/useCountUp.ts
+++ b/frontend/src/hooks/@common/useCountUp.ts
@@ -4,16 +4,23 @@ interface CountUpProps {
   initialNumber?: number;
   targetNumber: number;
   time?: number;
+  isActive?: boolean;
 }
 
 const useCountUp = ({
   initialNumber = 0,
   targetNumber,
   time = 1000,
+  isActive = true,
 }: CountUpProps) => {
   const [number, setNumber] = useState(initialNumber);
 
   useEffect(() => {
+    if (!isActive) {
+      setNumber(initialNumber);
+      return;
+    }
+
     let startTime: number | null = null;
     let animationFrameId: number;
 
@@ -35,7 +42,7 @@ const useCountUp = ({
     animationFrameId = requestAnimationFrame(animate);
 
     return () => cancelAnimationFrame(animationFrameId);
-  }, [initialNumber, targetNumber, time]);
+  }, [initialNumber, targetNumber, time, isActive]);
 
   return { number };
 };

--- a/frontend/src/hooks/@common/useCountUp.ts
+++ b/frontend/src/hooks/@common/useCountUp.ts
@@ -10,7 +10,7 @@ interface CountUpProps {
 const useCountUp = ({
   initialNumber = 0,
   targetNumber,
-  time = 1000,
+  time = 1500,
   isActive = true,
 }: CountUpProps) => {
   const [number, setNumber] = useState(initialNumber);

--- a/frontend/src/hooks/@common/useCountUp.ts
+++ b/frontend/src/hooks/@common/useCountUp.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+
+interface CountUpProps {
+  initialNumber?: number;
+  targetNumber: number;
+  time?: number;
+}
+
+const useCountUp = ({
+  initialNumber = 0,
+  targetNumber,
+  time = 1000,
+}: CountUpProps) => {
+  const [number, setNumber] = useState(initialNumber);
+
+  useEffect(() => {
+    let startTime: number | null = null;
+    let animationFrameId: number;
+
+    const totalValue = targetNumber - initialNumber;
+
+    const animate = (timestamp: number) => {
+      if (startTime === null) startTime = timestamp;
+      const elapsed = timestamp - startTime;
+      const progress = Math.min(elapsed / time, 1);
+      const currentValue = initialNumber + totalValue * progress;
+
+      setNumber(Math.floor(currentValue));
+
+      if (progress < 1) {
+        animationFrameId = requestAnimationFrame(animate);
+      }
+    };
+
+    animationFrameId = requestAnimationFrame(animate);
+
+    return () => cancelAnimationFrame(animationFrameId);
+  }, [initialNumber, targetNumber, time]);
+
+  return { number };
+};
+
+export default useCountUp;

--- a/frontend/src/hooks/domain/landing/useSpaceStats.ts
+++ b/frontend/src/hooks/domain/landing/useSpaceStats.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+import { spaceService } from '../../../apis/services/space/space.service';
+
+export const useSpaceStats = () => {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['spaceStats'],
+    queryFn: async () => {
+      const res = await spaceService.getSpaceStats();
+      if (res.success && res.data) {
+        return res.data;
+      }
+      throw new Error('스페이스 통계 조회에 실패했습니다');
+    },
+    staleTime: 0,
+  });
+
+  return { stats: data, isLoading, isError };
+};

--- a/frontend/src/hooks/domain/landing/useSpaceStats.ts
+++ b/frontend/src/hooks/domain/landing/useSpaceStats.ts
@@ -11,7 +11,7 @@ export const useSpaceStats = () => {
       }
       throw new Error('스페이스 통계 조회에 실패했습니다');
     },
-    staleTime: 0,
+    staleTime: 30 * 60 * 1000,
   });
 
   return { stats: data, isLoading, isError };

--- a/frontend/src/pages/landing/LandingPage.styles.ts
+++ b/frontend/src/pages/landing/LandingPage.styles.ts
@@ -15,8 +15,8 @@ export const Wrapper = styled.div`
 export const ContentContainer = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 300px;
-  padding: 120px 0px;
+  gap: 250px;
+  padding: 20px 0px;
 `;
 
 export const Section = styled.section`
@@ -105,7 +105,10 @@ export const Bubble = styled.div<{
   ${({ theme }) => theme.typography.bodyLarge}
   color: ${({ $color, theme }) => ($color === 'light' ? theme.colors.gray06 : theme.colors.white)};
   background-color: ${({ $color, theme }) =>
-    hexToRgba($color === 'light' ? theme.colors.gray01 : theme.colors.gray06, 0.8)};
+    hexToRgba(
+      $color === 'light' ? theme.colors.gray01 : theme.colors.gray06,
+      0.8,
+    )};
   width: 100%;
   padding: 12px 8px;
   line-height: 36px;
@@ -145,7 +148,7 @@ export const ScrollTopContainer = styled.div`
   position: fixed;
   right: calc(
     (100vw - ${({ theme }) => theme.layout.width}) / 2 +
-      ${({ theme }) => theme.layout.padding.leftRight} * 2
+    (${({ theme }) => theme.layout.padding.leftRight} * 2)
   );
   bottom: ${({ theme }) => theme.layout.padding.topBottom};
   z-index: ${({ theme }) => theme.zIndex.fixedButton};

--- a/frontend/src/pages/landing/LandingPage.styles.ts
+++ b/frontend/src/pages/landing/LandingPage.styles.ts
@@ -44,6 +44,7 @@ export const SmallTitle = styled.p`
   ${({ theme }) => theme.typography.header03}
   color: ${({ theme }) => theme.colors.white};
   white-space: pre-wrap;
+  text-align: center;
 `;
 
 export const SubTitle = styled.h2`

--- a/frontend/src/pages/landing/LandingPage.tsx
+++ b/frontend/src/pages/landing/LandingPage.tsx
@@ -166,7 +166,7 @@ const LandingPage = () => {
       </MotionScrollTopContainer>
       <S.ContentContainer>
         <MotionSection
-          style={{ gap: '120px' }}
+          style={{ gap: '90px' }}
           {...sectionMotionProps}
           variants={delaySectionVariants}
         >

--- a/frontend/src/pages/landing/LandingPage.tsx
+++ b/frontend/src/pages/landing/LandingPage.tsx
@@ -1,11 +1,12 @@
 import {
   type MotionProps,
   motion,
+  useInView,
   useMotionValueEvent,
   useScroll,
   type Variants,
 } from 'framer-motion';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { MdArrowUpward, MdKeyboardDoubleArrowDown } from 'react-icons/md';
 import { useNavigate } from 'react-router-dom';
 import completeImage from '../../@assets/images/screenshots/complete.png';
@@ -20,6 +21,7 @@ import IconButton from '../../components/@common/buttons/iconButton/IconButton';
 import { AUTH_COOKIES } from '../../constants/cookie';
 import { ROUTES } from '../../constants/routes';
 import useButtonTracking from '../../hooks/@common/useButtonTracking';
+import useCountUp from '../../hooks/@common/useCountUp';
 import { CookieUtils } from '../../utils/cookie';
 import { goToTop } from '../../utils/goToTop';
 import * as S from './LandingPage.styles';
@@ -88,6 +90,19 @@ const LandingPage = () => {
   const { scrollYProgress } = useScroll();
   const [hideScrollIcon, setHideScrollIcon] = useState(false);
   const [hideScrollTop, setHideScrollTop] = useState(true);
+  const countUpHeadingRef = useRef<HTMLHeadingElement | null>(null);
+  const isCountUpInView = useInView(countUpHeadingRef, {
+    once: true,
+    amount: 0.3,
+  });
+  const { number: spaceCount } = useCountUp({
+    targetNumber: 60,
+    isActive: isCountUpInView,
+  });
+  const { number: guestbookCount } = useCountUp({
+    targetNumber: 100,
+    isActive: isCountUpInView,
+  });
 
   useMotionValueEvent(scrollYProgress, 'change', (latest) => {
     if (latest > 0 && !hideScrollIcon) setHideScrollIcon(true);
@@ -161,6 +176,11 @@ const LandingPage = () => {
             {
               '스페이스를 통해 작품을 소개하고,\n방문객의 진심 어린 축하를 간직하세요.'
             }
+          </S.SubTitle>
+          <S.SubTitle ref={countUpHeadingRef}>
+            {isCountUpInView
+              ? `현재 ${spaceCount}개의 스페이스에\n${guestbookCount}개의 방명록이 모였어요.`
+              : null}
           </S.SubTitle>
         </MotionSection>
         <MotionSection {...sectionMotionProps}>

--- a/frontend/src/pages/landing/LandingPage.tsx
+++ b/frontend/src/pages/landing/LandingPage.tsx
@@ -166,12 +166,12 @@ const LandingPage = () => {
       </MotionScrollTopContainer>
       <S.ContentContainer>
         <MotionSection
-          style={{ gap: '90px' }}
+          style={{ gap: '95px' }}
           {...sectionMotionProps}
           variants={delaySectionVariants}
         >
           <MotionTitleContainer variants={fadeVariants}>
-            <S.Title>당신을 위한 순간, 흩어지지 않게</S.Title>
+            <S.SmallTitle>당신을 위한 순간, 흩어지지 않게</S.SmallTitle>
             <S.TitleImage src={titleImage} alt="포게더 로고 이미지" />
           </MotionTitleContainer>
           <MotionTitleContainer variants={fadeVariants}>

--- a/frontend/src/pages/landing/LandingPage.tsx
+++ b/frontend/src/pages/landing/LandingPage.tsx
@@ -22,6 +22,7 @@ import { AUTH_COOKIES } from '../../constants/cookie';
 import { ROUTES } from '../../constants/routes';
 import useButtonTracking from '../../hooks/@common/useButtonTracking';
 import useCountUp from '../../hooks/@common/useCountUp';
+import { useSpaceStats } from '../../hooks/domain/landing/useSpaceStats';
 import { CookieUtils } from '../../utils/cookie';
 import { goToTop } from '../../utils/goToTop';
 import * as S from './LandingPage.styles';
@@ -95,13 +96,24 @@ const LandingPage = () => {
     once: true,
     amount: 0.3,
   });
+  const { stats, isLoading } = useSpaceStats();
+
+  const spaceTargetNumber =
+    isCountUpInView && !isLoading
+      ? (stats?.spaceStats.spaceCount ?? 60) - 10
+      : 0;
+  const guestbookTargetNumber =
+    isCountUpInView && !isLoading
+      ? (stats?.guestBookStats.cardCount ?? 100)
+      : 0;
+
   const { number: spaceCount } = useCountUp({
-    targetNumber: 60,
-    isActive: isCountUpInView,
+    targetNumber: spaceTargetNumber,
+    isActive: isCountUpInView && !isLoading,
   });
   const { number: guestbookCount } = useCountUp({
-    targetNumber: 100,
-    isActive: isCountUpInView,
+    targetNumber: guestbookTargetNumber,
+    isActive: isCountUpInView && !isLoading,
   });
 
   useMotionValueEvent(scrollYProgress, 'change', (latest) => {
@@ -154,13 +166,20 @@ const LandingPage = () => {
       </MotionScrollTopContainer>
       <S.ContentContainer>
         <MotionSection
-          style={{ gap: '156px' }}
+          style={{ gap: '120px' }}
           {...sectionMotionProps}
           variants={delaySectionVariants}
         >
           <MotionTitleContainer variants={fadeVariants}>
             <S.Title>당신을 위한 순간, 흩어지지 않게</S.Title>
             <S.TitleImage src={titleImage} alt="포게더 로고 이미지" />
+          </MotionTitleContainer>
+          <MotionTitleContainer variants={fadeVariants}>
+            <S.SubTitle ref={countUpHeadingRef}>
+              {isCountUpInView
+                ? `현재 ${spaceCount}개의 스페이스에\n${guestbookCount}개의 방명록이 모였어요.`
+                : null}
+            </S.SubTitle>
           </MotionTitleContainer>
           <MotionTitleContainer variants={fadeVariants}>
             <S.SmallTitle>작가와 방문객이 연결되는 공간</S.SmallTitle>
@@ -176,11 +195,6 @@ const LandingPage = () => {
             {
               '스페이스를 통해 작품을 소개하고,\n방문객의 진심 어린 축하를 간직하세요.'
             }
-          </S.SubTitle>
-          <S.SubTitle ref={countUpHeadingRef}>
-            {isCountUpInView
-              ? `현재 ${spaceCount}개의 스페이스에\n${guestbookCount}개의 방명록이 모였어요.`
-              : null}
           </S.SubTitle>
         </MotionSection>
         <MotionSection {...sectionMotionProps}>

--- a/frontend/src/stories/@common/CountUpNumber.stories.tsx
+++ b/frontend/src/stories/@common/CountUpNumber.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import CountUpNumber from '../../components/@common/countUpNumber/CountUpNumber';
+
+const meta: Meta<typeof CountUpNumber> = {
+  title: 'Components/CountUpNumber',
+  component: CountUpNumber,
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {},
+};

--- a/frontend/src/types/domain/space.type.ts
+++ b/frontend/src/types/domain/space.type.ts
@@ -29,3 +29,12 @@ export interface SpaceInfoFormData {
   instagramUsername: string;
   isDeletePhoto?: boolean;
 }
+
+export interface SpaceStats {
+  spaceStats: {
+    spaceCount: number;
+  };
+  guestBookStats: {
+    cardCount: number;
+  };
+}


### PR DESCRIPTION
## 연관된 이슈

- close #881

## 작업 내용

- [만든 이력 정리글](https://velog.io/@minsungje/useCountUp-%EB%A7%8C%EB%93%A4%EA%B8%B0)
- useCountUp 훅 제작
- CountUpNumber는 스토리북 통해 훅이 잘 동작하는지 확인하기 위한 임시 컴포넌트여서, 삭제해주셔도 됩니다!
```tsx
interface CountUpProps {
  initialNumber?: number;  // 시작 숫자
  targetNumber: number;  // 목표 숫자
  time?: number;  // 시간
  isActive?: boolean;  // 올라가도 될지 여부
}
```
```tsx
// 사용처(LandingPage.tsx에 추가해둠)

const { number: spaceCount } = useCountUp({
  targetNumber: 60,  // 아직 API 연동이 안된 상태
  isActive: isCountUpInView,
});
const { number: guestbookCount } = useCountUp({
  targetNumber: 100,
  isActive: isCountUpInView,
});
```
<img width="584" height="311" alt="image" src="https://github.com/user-attachments/assets/cec78726-2950-4fa0-9895-aeef2d48d810" />