### PR TITLE
refactor: 방명록 조회 시 2N+1 문제 해결

### DIFF
--- a/backend/forgather/src/main/java/com/forgather/domain/guestbook/repository/GuestBookCardRepository.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/guestbook/repository/GuestBookCardRepository.java
@@ -5,9 +5,11 @@ import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.http.HttpStatus;
 
 import com.forgather.domain.guestbook.model.GuestBookCard;
+import com.forgather.domain.guestbook.repository.dto.GuestBookCardListDto;
 import com.forgather.domain.space.model.Space;
 import com.forgather.global.exception.BaseNullPointerException;
 import com.forgather.global.exception.NotFoundException;
@@ -23,6 +25,21 @@ public interface GuestBookCardRepository {
     Long countBySpace(Space space);
 
     Page<GuestBookCard> findAllBySpace(Space space, Pageable pageable);
+
+    @Query("""
+        SELECT new com.forgather.domain.guestbook.repository.dto.GuestBookCardListDto(
+            g.id,
+            guest.nickname,
+            g.isRead,
+            CASE WHEN (
+                SELECT COUNT(p) FROM GuestBookCardPhoto p WHERE p.guestBookCard = g
+            ) > 0 THEN true ELSE false END
+        )
+        FROM GuestBookCard g
+        JOIN g.guest guest
+        WHERE g.space = :space
+    """)
+    Page<GuestBookCardListDto> findAllDtoBySpace(Space space, Pageable pageable);
 
     List<GuestBookCard> findAllBySpace(Space space);
 

--- a/backend/forgather/src/main/java/com/forgather/domain/guestbook/repository/GuestBookCardRepository.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/guestbook/repository/GuestBookCardRepository.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.http.HttpStatus;
 
 import com.forgather.domain.guestbook.model.GuestBookCard;
@@ -37,7 +38,7 @@ public interface GuestBookCardRepository {
         JOIN g.guest guest
         WHERE g.space = :space
     """)
-    Page<GuestBookCardListDto> findAllDtoBySpace(Space space, Pageable pageable);
+    Page<GuestBookCardListDto> findAllDtoBySpace(@Param("space") Space space, Pageable pageable);
 
     List<GuestBookCard> findAllBySpace(Space space);
 

--- a/backend/forgather/src/main/java/com/forgather/domain/guestbook/repository/GuestBookCardRepository.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/guestbook/repository/GuestBookCardRepository.java
@@ -24,8 +24,6 @@ public interface GuestBookCardRepository {
 
     Long countBySpace(Space space);
 
-    Page<GuestBookCard> findAllBySpace(Space space, Pageable pageable);
-
     @Query("""
         SELECT new com.forgather.domain.guestbook.repository.dto.GuestBookCardListDto(
             g.id,

--- a/backend/forgather/src/main/java/com/forgather/domain/guestbook/repository/dto/GuestBookCardListDto.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/guestbook/repository/dto/GuestBookCardListDto.java
@@ -1,0 +1,9 @@
+package com.forgather.domain.guestbook.repository.dto;
+
+public record GuestBookCardListDto(
+    Long id,
+    String nickname,
+    boolean isRead,
+    boolean isPhotoExists
+) {
+}

--- a/backend/forgather/src/main/java/com/forgather/domain/guestbook/service/GuestBookService.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/guestbook/service/GuestBookService.java
@@ -27,6 +27,7 @@ import com.forgather.domain.guestbook.model.GuestBookCardPhotos;
 import com.forgather.domain.guestbook.repository.GuestBookCardPhotoRepository;
 import com.forgather.domain.guestbook.repository.GuestBookCardRepository;
 import com.forgather.domain.guestbook.repository.GuestRepository;
+import com.forgather.domain.guestbook.repository.dto.GuestBookCardListDto;
 import com.forgather.domain.space.model.Space;
 import com.forgather.domain.space.repository.SpaceRepository;
 import com.forgather.domain.upload.domain.ContentsStorage;
@@ -82,17 +83,35 @@ public class GuestBookService {
         return new GuestBookCardPhotos(photos);
     }
 
+    // @Transactional(readOnly = true)
+    // public GuestBookResponse read(Host host, String spaceCode, Pageable pageable) {
+    //     Space space = spaceRepository.getByCodeOrThrow(spaceCode);
+    //     validateCanRead(space, host);
+    //     Page<GuestBookCard> guestBookCards = guestBookCardRepository.findAllBySpace(space, pageable);
+    //     boolean isHost = host != null && isSpaceHost(space, host);
+    //     Page<GuestBookCardSimpleResponse> simpleResponses = guestBookCards.map(
+    //         guestBookCard -> new GuestBookCardSimpleResponse(
+    //             guestBookCard.getId(),
+    //             guestBookCard.getNickname(),
+    //             guestBookCardPhotoRepository.existsByGuestBookCard(guestBookCard),
+    //             isHost ? guestBookCard.isRead() : null
+    //         )
+    //     );
+    //     return new GuestBookResponse(simpleResponses);
+    // }
+
+    @Transactional(readOnly = true)
     public GuestBookResponse read(Host host, String spaceCode, Pageable pageable) {
         Space space = spaceRepository.getByCodeOrThrow(spaceCode);
         validateCanRead(space, host);
-        Page<GuestBookCard> guestBookCards = guestBookCardRepository.findAllBySpace(space, pageable);
         boolean isHost = host != null && isSpaceHost(space, host);
-        Page<GuestBookCardSimpleResponse> simpleResponses = guestBookCards.map(
-            guestBookCard -> new GuestBookCardSimpleResponse(
-                guestBookCard.getId(),
-                guestBookCard.getNickname(),
-                guestBookCardPhotoRepository.existsByGuestBookCard(guestBookCard),
-                isHost ? guestBookCard.isRead() : null
+        Page<GuestBookCardListDto> guestBookCardDtos = guestBookCardRepository.findAllDtoBySpace(space, pageable);
+        Page<GuestBookCardSimpleResponse> simpleResponses = guestBookCardDtos.map(
+            guestBookCardDto -> new GuestBookCardSimpleResponse(
+                guestBookCardDto.id(),
+                guestBookCardDto.nickname(),
+                guestBookCardDto.isPhotoExists(),
+                isHost ? guestBookCardDto.isRead() : null
             )
         );
         return new GuestBookResponse(simpleResponses);

--- a/backend/forgather/src/main/java/com/forgather/domain/guestbook/service/GuestBookService.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/guestbook/service/GuestBookService.java
@@ -83,23 +83,6 @@ public class GuestBookService {
         return new GuestBookCardPhotos(photos);
     }
 
-    // @Transactional(readOnly = true)
-    // public GuestBookResponse read(Host host, String spaceCode, Pageable pageable) {
-    //     Space space = spaceRepository.getByCodeOrThrow(spaceCode);
-    //     validateCanRead(space, host);
-    //     Page<GuestBookCard> guestBookCards = guestBookCardRepository.findAllBySpace(space, pageable);
-    //     boolean isHost = host != null && isSpaceHost(space, host);
-    //     Page<GuestBookCardSimpleResponse> simpleResponses = guestBookCards.map(
-    //         guestBookCard -> new GuestBookCardSimpleResponse(
-    //             guestBookCard.getId(),
-    //             guestBookCard.getNickname(),
-    //             guestBookCardPhotoRepository.existsByGuestBookCard(guestBookCard),
-    //             isHost ? guestBookCard.isRead() : null
-    //         )
-    //     );
-    //     return new GuestBookResponse(simpleResponses);
-    // }
-
     @Transactional(readOnly = true)
     public GuestBookResponse read(Host host, String spaceCode, Pageable pageable) {
         Space space = spaceRepository.getByCodeOrThrow(spaceCode);


### PR DESCRIPTION
## 연관된 이슈

- close #922 

## 작업 내용
### 기존
방명록 목록 조회 시 게스트 닉네임과 사진 존재 여부를 조회하기 위해 방명록 한 개당 2번의 쿼리가 추가로 발생하고 있습니다.

### 이후
Repository에서 `@Query`로 게스트를 조인하고, 사진 존재 여부를 서브 쿼리로 조회해 dto를 반환합니다.
따라서 한 번의 쿼리로 방명록 목록과, 각 방명록의 게스트 닉네임, 사진 존재 여부를 조회합니다.

asdf

### 로컬 기준
페이지 크기 15
이전: 약 70ms
이후: 약 30ms

페이지 크기 30
이전: 약 80ms
이후: 약 30ms

페이지 크기 50
이전: 약 80ms
이후: 약 30ms

### 개발 서버 기준
페이지 크기 15
이전 : 약 100ms
이후 : 약 60ms 