### PR TITLE
refactor: 라우터 타입 보강 및 Theme 선언 병합 변경

### DIFF
--- a/frontend/src/components/layout/global/layout/Layout.tsx
+++ b/frontend/src/components/layout/global/layout/Layout.tsx
@@ -16,7 +16,11 @@ import {
 import useButtonTracking from '../../../../hooks/@common/useButtonTracking';
 import useInAppRedirect from '../../../../hooks/@common/useInAppRedirect';
 import usePageTracking from '../../../../hooks/@common/usePageTracking';
-import type { AppRouteObject, IconAction } from '../../../../types/route.type';
+import type {
+  AppRouteObject,
+  IconAction,
+  LeftIcons,
+} from '../../../../types/route.type';
 import Footer from '../../../@common/footer/Footer';
 import Hamburger from '../../../@common/hamburger/Hamburger';
 import Header from '../../../@common/header/Header';
@@ -60,7 +64,7 @@ const Layout = () => {
   const isNoFooter = current?.handle?.noFooter;
   const isNoHamburger = current?.handle?.noHamburger;
 
-  const leftHeaderIcons: Record<string, IconAction> = {
+  const leftHeaderIcons: Record<LeftIcons, IconAction> = {
     logo: {
       icon: <LogoSvg />,
       onClick: () => {
@@ -93,7 +97,8 @@ const Layout = () => {
     },
   };
 
-  const leftIcon = leftHeaderIcons[current?.handle?.headerIcon?.leftIcon];
+  const leftIconIndex = current?.handle?.headerIcon?.leftIcon;
+  const leftIcon = leftIconIndex && leftHeaderIcons[leftIconIndex];
 
   //biome-ignore lint/correctness/useExhaustiveDependencies: 페이지 접속 시 처음 한 번만 실행
   useEffect(() => {
@@ -123,7 +128,7 @@ const Layout = () => {
           }}
         />
       )}
-      <S.Container $isDarkPage={isDarkPage}>
+      <S.Container $isDarkPage={!!isDarkPage}>
         <Outlet />
       </S.Container>
       {!isNoFooter && <Footer mode={isDarkPage ? 'dark' : 'light'} />}

--- a/frontend/src/types/globals/emotion.d.ts
+++ b/frontend/src/types/globals/emotion.d.ts
@@ -5,5 +5,5 @@ import type { theme } from '../../styles/theme';
 type ExtendedTheme = typeof theme;
 
 declare module '@emotion/react' {
-  type Theme = ExtendedTheme;
+  interface Theme extends ExtendedTheme {}
 }

--- a/frontend/src/types/route.type.ts
+++ b/frontend/src/types/route.type.ts
@@ -1,9 +1,16 @@
-import type { RouteObject } from 'react-router-dom';
+import type { NonIndexRouteObject } from 'react-router-dom';
+
+export type LeftIcons = 'logo' | 'profile' | 'back';
 
 export type RouteHandle = {
-  header?: boolean;
   starField?: boolean;
   highlight?: boolean;
+  noHamburger?: boolean;
+  headerIcon?: {
+    leftIcon?: LeftIcons;
+  };
+  noHeader?: boolean;
+  noFooter?: boolean;
 };
 
 export interface IconAction {
@@ -16,6 +23,7 @@ export interface NavigateInfo {
   name: string;
 }
 
-export type AppRouteObject = RouteObject & {
+export interface AppRouteObject extends NonIndexRouteObject {
   handle?: RouteHandle;
-};
+  children?: AppRouteObject[];
+}

--- a/frontend/src/types/route.type.ts
+++ b/frontend/src/types/route.type.ts
@@ -1,4 +1,8 @@
-import type { NonIndexRouteObject } from 'react-router-dom';
+import type {
+  IndexRouteObject,
+  IndexRouteProps,
+  NonIndexRouteObject,
+} from 'react-router-dom';
 
 export type LeftIcons = 'logo' | 'profile' | 'back';
 
@@ -23,7 +27,12 @@ export interface NavigateInfo {
   name: string;
 }
 
-export interface AppRouteObject extends NonIndexRouteObject {
+export type AppRouteObject = AppIndexRouteObject | AppNonIndexRouteObject;
+
+export interface AppIndexRouteObject extends IndexRouteObject {
+  handle?: RouteHandle;
+}
+export interface AppNonIndexRouteObject extends NonIndexRouteObject {
   handle?: RouteHandle;
   children?: AppRouteObject[];
 }

--- a/frontend/src/types/route.type.ts
+++ b/frontend/src/types/route.type.ts
@@ -1,8 +1,4 @@
-import type {
-  IndexRouteObject,
-  IndexRouteProps,
-  NonIndexRouteObject,
-} from 'react-router-dom';
+import type { IndexRouteObject, NonIndexRouteObject } from 'react-router-dom';
 
 export type LeftIcons = 'logo' | 'profile' | 'back';
 


### PR DESCRIPTION
## 연관된 이슈

- close #947

## 작업 내용

### 라우터 타입 보강을 통해 깊은 라우터에서도 타입이 추론되도록 변경

- **🚧 관련해서 블로그 글 작성중입니다! 🚧**
<img width="1128" height="340" alt="image" src="https://github.com/user-attachments/assets/69b6bcec-cfff-4438-afba-5eb137863de5" />
<img width="944" height="514" alt="image" src="https://github.com/user-attachments/assets/3f3fbc89-5022-4b43-ad71-635a88117c33" />

### Theme의 타입을 대체하는 것이 아닌 선언 병합 형태로 변경
- 선언 병합으로 변경해야 되는 이유는 [이슈](https://github.com/woowacourse-teams/2025-PhotoGather/issues/947#issuecomment-3566825778)에 정리해두었습니다.