### PR TITLE
fix: 스페이스 프로필 미등록시 모달 이미지 깨짐 문제 해결

### DIFF
--- a/frontend/src/components/specific/modal/singlePhotoModal/SinglePhotoModal.tsx
+++ b/frontend/src/components/specific/modal/singlePhotoModal/SinglePhotoModal.tsx
@@ -15,7 +15,6 @@ const SinglePhotoModal = ({
   isOpen,
   imgSrc,
 }: SinglePhotoModalProps) => {
-  console.log('imgSrc', imgSrc);
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
       <Modal.Backdrop />

--- a/frontend/src/components/specific/modal/singlePhotoModal/SinglePhotoModal.tsx
+++ b/frontend/src/components/specific/modal/singlePhotoModal/SinglePhotoModal.tsx
@@ -1,3 +1,6 @@
+import defaultImage from '../../../../@assets/images/default-forgather-image.png';
+import { createImageErrorHandler } from '../../../../utils/createImageErrorHandler';
+
 import Modal from '../../../@common/modal/Modal';
 import * as S from './SinglePhotoModal.style';
 
@@ -12,12 +15,17 @@ const SinglePhotoModal = ({
   isOpen,
   imgSrc,
 }: SinglePhotoModalProps) => {
+  console.log('imgSrc', imgSrc);
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
       <Modal.Backdrop />
       <S.Wrapper>
         <S.ImageWrapper>
-          <S.Image src={imgSrc} alt="사진" />
+          <S.Image
+            src={imgSrc}
+            alt="사진"
+            onError={createImageErrorHandler(defaultImage)}
+          />
         </S.ImageWrapper>
       </S.Wrapper>
     </Modal>


### PR DESCRIPTION
## 연관된 이슈

- close #955 

## 작업 내용

- 스페이스 프로필 모달의 image에 onError를 추가하여 defaultImage가 나타나도록 수정하였습니다.
<img width="200" alt="image" src="https://github.com/user-attachments/assets/dae4e473-5001-4350-a03d-120f463eeb74" />
