### PR TITLE
feature: 스페이스 이름 길이 제약 변경

### DIFF
--- a/backend/forgather/src/main/java/com/forgather/domain/space/dto/CreateSpaceRequest.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/space/dto/CreateSpaceRequest.java
@@ -8,7 +8,7 @@ import jakarta.validation.constraints.NotBlank;
 
 public record CreateSpaceRequest(
 
-    @Schema(description = "스페이스 이름", example = "졸업 전시", maxLength = 15)
+    @Schema(description = "스페이스 이름", example = "졸업 전시", maxLength = 30)
     @NotBlank
     String name,
 

--- a/backend/forgather/src/main/java/com/forgather/domain/space/dto/SpaceResponse.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/space/dto/SpaceResponse.java
@@ -27,9 +27,6 @@ public record SpaceResponse(
     @Schema(description = "스페이스 호스트 이메일", example = "forgather@forgather.me")
     String email,
 
-    // @Schema(description = "호스트 정보")
-    // HostResponse host,
-
     @Schema(description = "스페이스 프로필 사진", example = """
         {
             "isExists": true,
@@ -51,8 +48,6 @@ public record SpaceResponse(
             space.isPublic(),
             space.getInstagramUsername(),
             space.getEmail(),
-            // TODO: 스페이스 : 호스트 m:n 관계로 변경 후 수정 필요
-            // HostResponse.from(space.getSpaceHostMap().getFirst().getHost()),
             spacePhoto,
             guestBookCardCount
         );

--- a/backend/forgather/src/main/java/com/forgather/domain/space/dto/UpdateSpaceRequest.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/space/dto/UpdateSpaceRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.Email;
 
 public record UpdateSpaceRequest(
 
-    @Schema(description = "새로운 스페이스 이름", example = "나의 졸업전시", maxLength = 15, nullable = true)
+    @Schema(description = "새로운 스페이스 이름", example = "나의 졸업전시", maxLength = 30, nullable = true)
     String name,
 
     @Schema(description = "새로운 스페이스 설명", example = "졸업전시 스페이스입니다.", maxLength = 200, nullable = true)

--- a/backend/forgather/src/main/java/com/forgather/domain/space/model/Space.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/space/model/Space.java
@@ -25,7 +25,7 @@ import lombok.NoArgsConstructor;
 public class Space extends BaseTimeEntity {
 
     private static final int CODE_LENGTH = 10;
-    private static final int MAX_NAME_LENGTH = 15;
+    private static final int MAX_NAME_LENGTH = 30;
     private static final int MAX_DESCRIPTION_LENGTH = 200;
     private static final int MAX_INSTAGRAM_USERNAME_LENGTH = 30;
     private static final int MAX_EMAIL_LENGTH = 50;
@@ -59,7 +59,7 @@ public class Space extends BaseTimeEntity {
      * 스페이스를 생성한다.
      *
      * @param code              스페이스 코드 (필수, 10자)
-     * @param name              스페이스 이름 (필수, 최대 15자)
+     * @param name              스페이스 이름 (필수, 최대 30자)
      * @param description       스페이스 설명 (필수, 최대 200자)
      * @param isPublic          스페이스 공개 여부 (필수)
      * @param instagramUsername 인스타그램 아이디 (필수, 최대 30자)

--- a/backend/forgather/src/main/resources/db/migration/V9__update_space_code_limit.sql
+++ b/backend/forgather/src/main/resources/db/migration/V9__update_space_code_limit.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `space`
+    MODIFY COLUMN `code` VARCHAR(10) NOT NULL;

--- a/backend/forgather/src/test/java/com/forgather/domain/space/model/SpaceTest.java
+++ b/backend/forgather/src/test/java/com/forgather/domain/space/model/SpaceTest.java
@@ -79,8 +79,8 @@ class SpaceTest {
     void createSpaceWithEmoji() {
         // given
         String spaceCode = "1234567890";
-        String emoji = "\uD83D\uDC68\u200D\uD83D\uDC69\u200D\uD83D\uDC67\u200D\uD83D\uDC66"; // // 가족 이모지, length 11
-        String name = "우리의 모임12345678" + emoji; // 스페이스 이름에 이모지 포함
+        // 가족 이모지, length 11
+        String name = "\uD83D\uDC68\u200D\uD83D\uDC69\u200D\uD83D\uDC67\u200D\uD83D\uDC66".repeat(30);
         String description = "스페이스 설명";
         String instagramUsername = "forgather_official";
         String email = "forgather@forgather.me";
@@ -91,10 +91,10 @@ class SpaceTest {
         ).doesNotThrowAnyException();
     }
 
-    @DisplayName("스페이스 이름이 비어있거나, 15자 초과면 예외를 던진다")
+    @DisplayName("스페이스 이름이 비어있거나, 30자 초과면 예외를 던진다")
     @NullAndEmptySource
     @ParameterizedTest
-    @ValueSource(strings = {" ", "abcde12345678901"})
+    @ValueSource(strings = {" ", "a123456789012345678901234567890"})
     void spaceNameValidationTest(String invalidName) {
         // given
         String description = "스페이스 설명";


### PR DESCRIPTION
## 연관된 이슈

- close #977

## 작업 내용

- 사용자 문의를 기반으로 스페이스 이름의 작성 가능한 최대 글자 수를 30으로 증가합니다.

별도로 DB 스키마의 varchar는 변경하지 않았습니다
<img width="830" height="322" alt="image" src="https://github.com/user-attachments/assets/d005b0c3-67e3-4a23-8e8e-56a2afbb5f9f" />

이유는 다음과 같아요
- name이 `VARCHAR(255)`로 선언되어 있어도 실제 사용되는 물리적인 공간은 varchar(31)과 똑같아요. -> VARCHAR(1-255): 1바이트 prefix
- 인덱스가 걸린 컬럼이라면 인덱스 크기를 줄이기 위해 비즈니스 규칙에 맞게 줄이는 것이 좋지만 현재는 인덱스가 존재하지 않아 줄일 필요가 없다 판단했어요

## 여기서 드는 생각 하나
- 현재 code는 unique + not null 제약조건이 존재하는 code 컬럼의 경우 인덱스가 자동으로 생성되어 현재 불필요하게 인덱스 크기가 크게 잡히고 있다는 생각이 들어요
- 비즈니스 규칙 상 10자의 난수로 고정되어 있고 충돌 위험이 낮아 변화하지 않을 규칙이라는 생각이 듭니다. 인덱스 크기를 줄이는 이점도 있는 char(10)이나 varchar(10)을 쓰는게 좋을것 같다는 생각이 들어요. 어떻게 생각하시나요?