### PR TITLE
feature: 작가명의 글자수 제한 20 -> 35자로 증가

### DIFF
--- a/backend/forgather/src/main/java/com/forgather/domain/product/dto/RegisterProductRequest.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/product/dto/RegisterProductRequest.java
@@ -14,7 +14,7 @@ public record RegisterProductRequest(
     @Schema(description = "작품 카테고리", example = "Chair", maxLength = 20)
     String category,
 
-    @Schema(description = "작가명", example = "검은수염", maxLength = 20)
+    @Schema(description = "작가명", example = "검은수염", maxLength = 35)
     String authorName,
 
     @Schema(description = "작품 설명", example = "150 x 200 x 200\n\n매우 고귀한 의자입니다.\n조심해서 다뤄주세요.", maxLength = 2000)

--- a/backend/forgather/src/main/java/com/forgather/domain/product/dto/UpdateProductRequest.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/product/dto/UpdateProductRequest.java
@@ -12,7 +12,7 @@ public record UpdateProductRequest(
     @Schema(description = "작품 카테고리", example = "Chair", maxLength = 20)
     String category,
 
-    @Schema(description = "작가명", example = "히비노카프카", maxLength = 20)
+    @Schema(description = "작가명", example = "히비노카프카", maxLength = 35)
     String authorName,
 
     @Schema(description = "작품 설명", example = "150 x 200 x 200\n\n고귀하지 않은 의자입니다.\n막 다뤄주세요.", maxLength = 2000)

--- a/backend/forgather/src/main/java/com/forgather/domain/product/model/Product.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/product/model/Product.java
@@ -57,7 +57,7 @@ public class Product extends BaseTimeEntity {
      * @param space       작품이 속한 스페이스 (필수)
      * @param title       작품명 (필수, 최대 50자)
      * @param category    카테고리 (선택, 최대 20자)
-     * @param authorName  작가명 (선택, 최대 20자)
+     * @param authorName  작가명 (선택, 최대 35자)
      * @param description 작품 설명 (필수, 최대 2000자)
      * @param videoUrl 임베드 영상 링크 (선택, 최대 255자)
      * @param isVideoAfterPhoto 영상이 사진 뒤에 오는지 여부 (선택)
@@ -171,8 +171,8 @@ public class Product extends BaseTimeEntity {
     }
 
     private void validateAuthorName(String authorName) {
-        if (TextLengthCounter.count(authorName) > 20) {
-            throw new BaseException("작가명은 최대 20자까지 입력 가능합니다.");
+        if (TextLengthCounter.count(authorName) > 35) {
+            throw new BaseException("작가명은 최대 35자까지 입력 가능합니다.");
         }
     }
 

--- a/backend/forgather/src/test/java/com/forgather/domain/product/model/ProductTest.java
+++ b/backend/forgather/src/test/java/com/forgather/domain/product/model/ProductTest.java
@@ -144,11 +144,11 @@ class ProductTest {
         assertThat(result.getAuthorName()).isEqualTo("");
     }
 
-    @DisplayName("작가명의 길이가 20자를 초과하면 예외를 던진다")
+    @DisplayName("작가명의 길이가 35자를 초과하면 예외를 던진다")
     @Test
     void throwExceptionWhenExceedAuthorNameLength() {
         // given
-        String authorName = "0123456789".repeat(2) + 1;
+        String authorName = "0123456789".repeat(3) + "123456";
 
         // when, then
         assertThatThrownBy(() -> createProductWithAuthorName(authorName))
@@ -156,12 +156,12 @@ class ProductTest {
             .hasMessageContaining("작가명은 최대");
     }
 
-    @DisplayName("작가명은 이모지를 한 글자로 간주해 20자까지 입력 가능하다")
+    @DisplayName("작가명은 이모지를 한 글자로 간주해 35자까지 입력 가능하다")
     @ValueSource(strings = {"😀", "👦", "👨", "‍👩‍", "‍👦", "‍👩‍👧‍", "👨‍👩‍👧", "👨‍👩‍👧‍👦"})
     @ParameterizedTest
     void countEmojiAsOneCharAtAuthorName(String emoji) {
         // given
-        String authorName = emoji.repeat(19) + "c";
+        String authorName = emoji.repeat(34) + "c";
 
         // when, then
         assertThatCode(() -> createProductWithAuthorName(authorName)).doesNotThrowAnyException();


### PR DESCRIPTION
## 연관된 이슈

- close #982 

## 작업 내용
사용자 문의를 기반으로 작품 설명의 작성 가능한 글자 수를 증가시킵니다.

#### db 스키마 변경
기존 author_name 컬럼의 타입은 varchar(255)로,
35자로의 변경에도 호환이 되기에 스키마 변경은 없습니다.

#### Product.authorName 검증 로직 및 api 명세 수정
<img width="543" height="118" alt="image" src="https://github.com/user-attachments/assets/e5fef0ea-b1b4-403d-be5a-bfbc20a28259" />

