### PR TITLE
refactor: 스페이스 홈에서의 스페이스명 줄바꿈 허용

### DIFF
--- a/frontend/src/components/specific/editForm/EditForm.tsx
+++ b/frontend/src/components/specific/editForm/EditForm.tsx
@@ -144,12 +144,13 @@ const EditForm = () => {
         }}
         deleteImage={handleDeleteImage}
       />
-      <TextInput
+      <TextareaInput
         {...register('name', {
           validate: editFormValidators.name,
         })}
         isRequired
         validLength={calculateValidLength(watch('name'))}
+        style={{ minHeight: '50px' }}
         label="스페이스 이름"
         placeholder="전시명"
         errorMessage={errors.name?.message}

--- a/frontend/src/pages/MainPage.common.styles.ts
+++ b/frontend/src/pages/MainPage.common.styles.ts
@@ -30,6 +30,7 @@ export const InfoContainer = styled.div`
 
 export const Name = styled.h1`
   ${({ theme }) => theme.typography.header02}
+  white-space: pre-line;
 `;
 
 export const Introduction = styled.p`


### PR DESCRIPTION
## 연관된 이슈

- close #985 

## 작업 내용

- 작품명과 스페이스명이 동일한 경우, 작품명 줄바꿈 허용하였듯이 스페이스명도 줄바꿈을 허용하도록 수정하였습니다.

<img width="357" height="485" alt="image" src="https://github.com/user-attachments/assets/93eacf76-cf19-4a38-9bb4-7a894b267a5e" />
