### PR TITLE
refactor: 랜덤 코드 생성 로직 개선

### DIFF
--- a/backend/forgather/src/main/java/com/forgather/global/util/RandomCodeGenerator.java
+++ b/backend/forgather/src/main/java/com/forgather/global/util/RandomCodeGenerator.java
@@ -1,6 +1,6 @@
 package com.forgather.global.util;
 
-import java.util.concurrent.ThreadLocalRandom;
+import java.security.SecureRandom;
 
 import org.springframework.stereotype.Component;
 
@@ -8,17 +8,16 @@ import org.springframework.stereotype.Component;
 public class RandomCodeGenerator {
 
     private static final String NUMBER_AND_ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyz";
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     public String generate(int length) {
         if (length <= 0) {
             return "";
         }
         StringBuilder randomString = new StringBuilder();
-        ThreadLocalRandom random = ThreadLocalRandom.current();
         for (int i = 0; i < length; i++) {
-            randomString.append(NUMBER_AND_ALPHABET.charAt(
-                random.nextInt(NUMBER_AND_ALPHABET.length())
-            ));
+            int randomPosition = SECURE_RANDOM.nextInt(NUMBER_AND_ALPHABET.length());
+            randomString.append(NUMBER_AND_ALPHABET.charAt(randomPosition));
         }
         return randomString.toString();
     }

--- a/backend/forgather/src/main/java/com/forgather/global/util/RandomCodeGenerator.java
+++ b/backend/forgather/src/main/java/com/forgather/global/util/RandomCodeGenerator.java
@@ -1,22 +1,25 @@
 package com.forgather.global.util;
 
-import java.util.UUID;
+import java.security.SecureRandom;
 
 import org.springframework.stereotype.Component;
 
 @Component
 public class RandomCodeGenerator {
 
+    private static final String NUMBER_AND_ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyz";
+    private static final SecureRandom RANDOM = new SecureRandom();
+
     public String generate(int length) {
         if (length <= 0) {
             return "";
         }
-
         StringBuilder randomString = new StringBuilder();
-        while (randomString.length() < length) {
-            randomString.append(UUID.randomUUID().toString().replace("-", ""));
+        for (int i = 0; i < length; i++) {
+            randomString.append(NUMBER_AND_ALPHABET.charAt(
+                RANDOM.nextInt(NUMBER_AND_ALPHABET.length())
+            ));
         }
-
-        return randomString.substring(0, length);
+        return randomString.toString();
     }
 }

--- a/backend/forgather/src/main/java/com/forgather/global/util/RandomCodeGenerator.java
+++ b/backend/forgather/src/main/java/com/forgather/global/util/RandomCodeGenerator.java
@@ -1,6 +1,6 @@
 package com.forgather.global.util;
 
-import java.security.SecureRandom;
+import java.util.concurrent.ThreadLocalRandom;
 
 import org.springframework.stereotype.Component;
 
@@ -8,16 +8,16 @@ import org.springframework.stereotype.Component;
 public class RandomCodeGenerator {
 
     private static final String NUMBER_AND_ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyz";
-    private static final SecureRandom RANDOM = new SecureRandom();
 
     public String generate(int length) {
         if (length <= 0) {
             return "";
         }
         StringBuilder randomString = new StringBuilder();
+        ThreadLocalRandom random = ThreadLocalRandom.current();
         for (int i = 0; i < length; i++) {
             randomString.append(NUMBER_AND_ALPHABET.charAt(
-                RANDOM.nextInt(NUMBER_AND_ALPHABET.length())
+                random.nextInt(NUMBER_AND_ALPHABET.length())
             ));
         }
         return randomString.toString();

--- a/backend/forgather/src/main/java/com/forgather/global/util/RandomCodeGenerator.java
+++ b/backend/forgather/src/main/java/com/forgather/global/util/RandomCodeGenerator.java
@@ -4,6 +4,9 @@ import java.security.SecureRandom;
 
 import org.springframework.stereotype.Component;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @Component
 public class RandomCodeGenerator {
 
@@ -11,6 +14,7 @@ public class RandomCodeGenerator {
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     public String generate(int length) {
+        long startMillis = System.currentTimeMillis();
         if (length <= 0) {
             return "";
         }
@@ -19,6 +23,10 @@ public class RandomCodeGenerator {
             int randomPosition = SECURE_RANDOM.nextInt(NUMBER_AND_ALPHABET.length());
             randomString.append(NUMBER_AND_ALPHABET.charAt(randomPosition));
         }
+
+        long durationMillis = System.currentTimeMillis() - startMillis;
+        log.debug("랜덤 코드 생성 완료 생성 시간: {}ms", durationMillis);
+
         return randomString.toString();
     }
 }


### PR DESCRIPTION
## 연관된 이슈

- close #981 

## 작업 내용

- SecureRandom 보안성 강화
- 기존 경우의 수(16^length) -> 바뀐 경우의 수(36^length)

기존 랜덤코드 생성 방식은 16개(0~9, a-f)로 16^length의 경우의 수를 가지고 있었습니다.
현재 스페이스 코드의 길이인 10을 기준으로 16^10의 경우 1,000,000 스페이스가 생성되면 충돌 위험이 유의미하게 높아져 문제가 있다고 판단해서 작업을 진행했습니다

총 36(0~9, a-z) 개의 문자로 늘려 충돌 위험을 낮췄습니다.

## ThreadLocalRandom
해당 문자열 중 임의로 1개를 뽑는 난수를 생성하는 방법은 세가지가 존재했습니다
- `Random`
  - Thread-safe함 (경합 발생 가능성이 높음)
  -  시드값을 알면 다음 값을 예측 가능
  - 멀티스레드 환경에서 경합(contention) 발생 가능
  - 여러 스레드가 동시 접근 시 경합(contention) 발생 -> 대기 시간 증가

- `SecureRandom`
  - Thread-safe함
  - 내부적으로 동기화되어 있어 멀티스레드에서 안전
  - Random보다 경합 처리가 더 효율적
  - 초대 코드 생성처럼 빈번하지 않은 작업에는 성능 문제 없음

- `ThreadLocalRandom`
  - Thread-safe함
  - 각 스레드가 독립적인 Random 인스턴스 보유
  - 경합 없음 -> 위 두가지 방법 대비 성능이 제일 좋음
  - 암호학적으로 안전하지 않음 -> 큰 문제가 되지 않음
  
| 구분                | 스레드 안전 | 경합  | 성능    | 보안  |
|-------------------|--------|-----|-------|-----|
| Random            | ✅ 좋음( 경합 발생)   | 심함  | 느림    | ❌   |
| SecureRandom      | ✅ 좋음   | 약간  | 느림 | ✅   |
| ThreadLocalRandom | ✅ 최고   | 없음  | 빠름    | ❌   |

암호학적으로 안전성을 고려해야 하나? 생각해보면 스페이스 코드의 경우 방문객들이 접근할 수 있는 경로라고 생각합니다. 코드가 유추될 수 있다면 작가님이 원하지 않는 방문객이 접근할 수 있다는 생각이 들어 유추가 불가능한 `SecureRandom`도 좋은 선택이라는 생각이 들었어요

하지만 현재 로깅의 트레이스 아이디 생성에서도 사용하고 있어 `SecureRandom`은 성능적으로 문제가 생길거라 생각합니다.

더 좋은 선택은 하나의 메서드를 사용하지 않고 보안이 필요한 랜덤 난수 생성, 보안이 필요 없는 랜덤 난수 생성 두 가지 책임으로 분리하는 것도 좋다고 생각해요
- 현재는 `ThreadLocalRandom`을 공용으로 사용하도록 선택했습니다