### PR TITLE
refactor: 스페이스 관련 엔티티(Space, SpaceHostMap, SpacePhoto) soft delete 도입

### DIFF
--- a/backend/forgather/src/main/java/com/forgather/back_office/service/AdminHostService.java
+++ b/backend/forgather/src/main/java/com/forgather/back_office/service/AdminHostService.java
@@ -27,7 +27,7 @@ public class AdminHostService {
     public AdminHostResponse getAllHosts(Pageable pageable, AdminUser adminUser) {
         Page<Host> hosts = hostRepository.findAll(pageable);
         return AdminHostResponse.from(hosts.map(host -> {
-            List<Long> spaceIds = spaceHostMapRepository.findAllByHost(host)
+            List<Long> spaceIds = spaceHostMapRepository.findAllByHostAndDeletedAtIsNull(host)
                 .stream()
                 .map(spaceHostMap -> spaceHostMap.getSpace().getId())
                 .toList();

--- a/backend/forgather/src/main/java/com/forgather/back_office/service/AdminHostService.java
+++ b/backend/forgather/src/main/java/com/forgather/back_office/service/AdminHostService.java
@@ -27,7 +27,7 @@ public class AdminHostService {
     public AdminHostResponse getAllHosts(Pageable pageable, AdminUser adminUser) {
         Page<Host> hosts = hostRepository.findAll(pageable);
         return AdminHostResponse.from(hosts.map(host -> {
-            List<Long> spaceIds = spaceHostMapRepository.findAllByHostWithSpaceOrderByCreatedAtDesc(host)
+            List<Long> spaceIds = spaceHostMapRepository.findAllByHostAndDeletedAtIsNullWithSpaceOrderByCreatedAtDesc(host)
                 .stream()
                 .map(spaceHostMap -> spaceHostMap.getSpace().getId())
                 .toList();

--- a/backend/forgather/src/main/java/com/forgather/back_office/service/AdminSpaceService.java
+++ b/backend/forgather/src/main/java/com/forgather/back_office/service/AdminSpaceService.java
@@ -26,13 +26,13 @@ public class AdminSpaceService {
     @Transactional(readOnly = true)
     public AdminSpaceResponse getAllSpaces(Pageable pageable, AdminUser adminUser) {
         // TODO: 관리자 권한에 따른 호출 여부 로직 추가 가능성이 있음
-        Page<Space> spaces = spaceRepository.findAll(pageable);
+        Page<Space> spaces = spaceRepository.findAllByDeletedAtIsNull(pageable);
         return AdminSpaceResponse.from(spaces);
     }
 
     @Transactional(readOnly = true)
     public SpaceDetailResponse getSpaceDetail(String spaceCode, AdminUser adminUser) {
-        Space space = spaceRepository.getByCodeOrThrow(spaceCode);
+        Space space = spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
         boolean hasProduct = !productRepository.findAllBySpace(space)
             .isEmpty();
         Long guestBookCardCount = guestBookCardRepository.countBySpace(space);

--- a/backend/forgather/src/main/java/com/forgather/domain/guestbook/model/Guest.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/guestbook/model/Guest.java
@@ -2,7 +2,7 @@ package com.forgather.domain.guestbook.model;
 
 import org.springframework.http.HttpStatus;
 
-import com.forgather.domain.model.BaseTimeEntity;
+import com.forgather.domain.model.SoftDeleteEntity;
 import com.forgather.global.exception.BaseException;
 import com.forgather.global.exception.BaseNullPointerException;
 import com.forgather.global.util.TextLengthCounter;
@@ -19,7 +19,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Guest extends BaseTimeEntity {
+public class Guest extends SoftDeleteEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/forgather/src/main/java/com/forgather/domain/guestbook/model/GuestBookCard.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/guestbook/model/GuestBookCard.java
@@ -2,7 +2,7 @@ package com.forgather.domain.guestbook.model;
 
 import org.springframework.http.HttpStatus;
 
-import com.forgather.domain.model.BaseTimeEntity;
+import com.forgather.domain.model.SoftDeleteEntity;
 import com.forgather.domain.space.model.Space;
 import com.forgather.global.exception.BaseException;
 import com.forgather.global.exception.BaseNullPointerException;
@@ -23,7 +23,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class GuestBookCard extends BaseTimeEntity {
+public class GuestBookCard extends SoftDeleteEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/forgather/src/main/java/com/forgather/domain/guestbook/service/GuestBookService.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/guestbook/service/GuestBookService.java
@@ -54,7 +54,7 @@ public class GuestBookService {
 
     @Transactional
     public WriteGuestBookCardResponse writeCard(String spaceCode, WriteGuestBookCardRequest request) {
-        Space space = spaceRepository.getByCodeOrThrow(spaceCode);
+        Space space = spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
         Guest guest = guestRepository.save(new Guest(request.nickname()));
         GuestBookCard guestBookCard = guestBookCardRepository.save(request.toEntity(space, guest));
 
@@ -85,7 +85,7 @@ public class GuestBookService {
 
     @Transactional(readOnly = true)
     public GuestBookResponse read(Host host, String spaceCode, Pageable pageable) {
-        Space space = spaceRepository.getByCodeOrThrow(spaceCode);
+        Space space = spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
         validateCanRead(space, host);
         boolean isHost = host != null && isSpaceHost(space, host);
         Page<GuestBookCardListDto> guestBookCardDtos = guestBookCardRepository.findAllDtoBySpace(space, pageable);
@@ -102,7 +102,7 @@ public class GuestBookService {
 
     @Transactional
     public GuestBookCardResponse readCard(Host host, String spaceCode, Long guestBookCardId) {
-        Space space = spaceRepository.getByCodeOrThrow(spaceCode);
+        Space space = spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
         validateCanRead(space, host);
 
         GuestBookCard guestBookCard = getGuestBookCard(guestBookCardId, space);
@@ -134,7 +134,7 @@ public class GuestBookService {
 
     @Transactional
     public void deleteCard(Host host, String spaceCode, Long guestBookCardId) {
-        Space space = spaceRepository.getByCodeOrThrow(spaceCode);
+        Space space = spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
         validateSpaceHost(host, space);
         GuestBookCard guestBookCard = getGuestBookCard(guestBookCardId, space);
         deleteGuestBookCardPhotos(guestBookCard);
@@ -155,7 +155,7 @@ public class GuestBookService {
         Long guestBookCardId,
         DeleteGuestBookCardPhotosRequest request
     ) {
-        Space space = spaceRepository.getByCodeOrThrow(spaceCode);
+        Space space = spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
         validateSpaceHost(host, space);
         GuestBookCardPhotos guestBookCardPhotos = getGuestBookCardPhotos(space, guestBookCardId);
         List<GuestBookCardPhoto> deletedPhotos = guestBookCardPhotos.deleteByIds(request.deletePhotoIds());
@@ -191,7 +191,7 @@ public class GuestBookService {
         if (space == null || host == null) {
             throw new BaseNullPointerException("스페이스와 호스트는 null일 수 없습니다.", INTERNAL_SERVER_ERROR);
         }
-        return spaceHostMapRepository.findBySpaceAndHost(space, host).isPresent();
+        return spaceHostMapRepository.findBySpaceAndHostAndDeletedAtIsNull(space, host).isPresent();
     }
 
     private void deleteGuestBookCardPhotos(List<GuestBookCardPhoto> photos) {

--- a/backend/forgather/src/main/java/com/forgather/domain/model/Photo.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/model/Photo.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @MappedSuperclass
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public abstract class Photo extends BaseTimeEntity {
+public abstract class Photo extends SoftDeleteEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/forgather/src/main/java/com/forgather/domain/model/SoftDeleteEntity.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/model/SoftDeleteEntity.java
@@ -1,0 +1,19 @@
+package com.forgather.domain.model;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+public class SoftDeleteEntity extends BaseTimeEntity {
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    public void softDelete() {
+        deletedAt = LocalDateTime.now();
+    }
+}

--- a/backend/forgather/src/main/java/com/forgather/domain/model/SoftDeleteEntity.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/model/SoftDeleteEntity.java
@@ -13,7 +13,7 @@ public class SoftDeleteEntity extends BaseTimeEntity {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
-    public void softDelete() {
+    public void delete() {
         deletedAt = LocalDateTime.now();
     }
 }

--- a/backend/forgather/src/main/java/com/forgather/domain/model/SoftDeleteEntity.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/model/SoftDeleteEntity.java
@@ -14,6 +14,9 @@ public class SoftDeleteEntity extends BaseTimeEntity {
     private LocalDateTime deletedAt;
 
     public void delete() {
+        if (deletedAt != null) {
+            return;
+        }
         deletedAt = LocalDateTime.now();
     }
 }

--- a/backend/forgather/src/main/java/com/forgather/domain/product/model/Product.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/product/model/Product.java
@@ -2,7 +2,7 @@ package com.forgather.domain.product.model;
 
 import org.springframework.http.HttpStatus;
 
-import com.forgather.domain.model.BaseTimeEntity;
+import com.forgather.domain.model.SoftDeleteEntity;
 import com.forgather.domain.space.model.Space;
 import com.forgather.global.exception.BaseException;
 import com.forgather.global.exception.BaseNullPointerException;
@@ -23,7 +23,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Product extends BaseTimeEntity {
+public class Product extends SoftDeleteEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/forgather/src/main/java/com/forgather/domain/product/service/ProductService.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/product/service/ProductService.java
@@ -50,7 +50,7 @@ public class ProductService {
      */
     @Transactional(readOnly = true)
     public ProductsResponse getAll(String spaceCode) {
-        Space space = spaceRepository.getByCodeOrThrow(spaceCode);
+        Space space = spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
         List<Product> products = productRepository.findAllBySpace(space);
         List<SimpleProductResponse> productResponses = products.stream()
             .map(product -> new SimpleProductResponse(
@@ -62,7 +62,7 @@ public class ProductService {
 
     @Transactional(readOnly = true)
     public ProductResponse get(String spaceCode, Long productId) {
-        Space space = spaceRepository.getByCodeOrThrow(spaceCode);
+        Space space = spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
         Product product = productRepository.getBySpaceAndIdOrThrow(space, productId);
         ProductPhotos productPhotos = new ProductPhotos(productPhotoRepository.findAllByProduct(product));
         return new ProductResponse(product, productPhotos.getAll());
@@ -70,7 +70,7 @@ public class ProductService {
 
     @Transactional
     public ProductResponse registerV3(Host host, String spaceCode, RegisterProductRequest request) {
-        Space space = spaceRepository.getByCodeOrThrow(spaceCode);
+        Space space = spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
         validateSpaceHost(host, space);
         validateExceedProductMaxCount(space);
         Product product = productRepository.save(request.toEntity(space));
@@ -99,7 +99,7 @@ public class ProductService {
     @Transactional
     public ProductResponse updateV3(Host host, String spaceCode, Long productId, UpdateProductRequest request) {
         // Product 정보 수정
-        Space space = spaceRepository.getByCodeOrThrow(spaceCode);
+        Space space = spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
         validateSpaceHost(host, space);
         Product product = productRepository.getBySpaceAndIdOrThrow(space, productId);
         product.update(request.title(), request.category(), request.authorName(), request.description(),
@@ -129,7 +129,7 @@ public class ProductService {
 
     @Transactional
     public void deleteV2(Host host, String spaceCode, Long productId) {
-        Space space = spaceRepository.getByCodeOrThrow(spaceCode);
+        Space space = spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
         validateSpaceHost(host, space);
         Product product = productRepository.getBySpaceAndIdOrThrow(space, productId);
         deleteAllProductPhotos(product);
@@ -179,6 +179,6 @@ public class ProductService {
         if (space == null || host == null) {
             throw new BaseNullPointerException("스페이스와 호스트는 null일 수 없습니다.");
         }
-        return spaceHostMapRepository.findBySpaceAndHost(space, host).isPresent();
+        return spaceHostMapRepository.findBySpaceAndHostAndDeletedAtIsNull(space, host).isPresent();
     }
 }

--- a/backend/forgather/src/main/java/com/forgather/domain/space/model/Space.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/space/model/Space.java
@@ -5,7 +5,7 @@ import java.util.regex.Pattern;
 
 import org.springframework.http.HttpStatus;
 
-import com.forgather.domain.model.BaseTimeEntity;
+import com.forgather.domain.model.SoftDeleteEntity;
 import com.forgather.global.exception.BaseException;
 import com.forgather.global.exception.BaseNullPointerException;
 import com.forgather.global.util.TextLengthCounter;
@@ -22,7 +22,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Space extends BaseTimeEntity {
+public class Space extends SoftDeleteEntity {
 
     private static final int CODE_LENGTH = 10;
     private static final int MAX_NAME_LENGTH = 30;

--- a/backend/forgather/src/main/java/com/forgather/domain/space/repository/SpacePhotoRepository.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/space/repository/SpacePhotoRepository.java
@@ -14,8 +14,6 @@ public interface SpacePhotoRepository {
 
     List<SpacePhoto> findAllBySpaceIdInAndDeletedAtIsNull(List<Long> spaceIds);
 
-    void delete(SpacePhoto spacePhoto);
-
     default SpacePhoto getBySpaceAndDeletedAtIsNullOrEmpty(Space space) {
         return findBySpaceAndDeletedAtIsNull(space)
             .orElse(SpacePhoto.empty(space));

--- a/backend/forgather/src/main/java/com/forgather/domain/space/repository/SpacePhotoRepository.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/space/repository/SpacePhotoRepository.java
@@ -12,7 +12,7 @@ public interface SpacePhotoRepository {
 
     Optional<SpacePhoto> findBySpaceAndDeletedAtIsNull(Space space);
 
-    List<SpacePhoto> findAllBySpaceIdIn(List<Long> spaceIds);
+    List<SpacePhoto> findAllBySpaceIdInAndDeletedAtIsNull(List<Long> spaceIds);
 
     void delete(SpacePhoto spacePhoto);
 

--- a/backend/forgather/src/main/java/com/forgather/domain/space/repository/SpacePhotoRepository.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/space/repository/SpacePhotoRepository.java
@@ -9,12 +9,12 @@ public interface SpacePhotoRepository {
 
     SpacePhoto save(SpacePhoto spacePhoto);
 
-    Optional<SpacePhoto> findBySpace(Space space);
+    Optional<SpacePhoto> findBySpaceAndDeletedAtIsNull(Space space);
 
     void delete(SpacePhoto spacePhoto);
 
-    default SpacePhoto getBySpaceOrEmpty(Space space) {
-        return findBySpace(space)
+    default SpacePhoto getBySpaceAndDeletedAtIsNullOrEmpty(Space space) {
+        return findBySpaceAndDeletedAtIsNull(space)
             .orElse(SpacePhoto.empty(space));
     }
 }

--- a/backend/forgather/src/main/java/com/forgather/domain/space/repository/SpaceRepository.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/space/repository/SpaceRepository.java
@@ -16,19 +16,19 @@ public interface SpaceRepository {
 
     Space save(Space space);
 
-    Optional<Space> findByCode(String spaceCode);
+    Optional<Space> findByCodeAndDeletedAtIsNull(String spaceCode);
 
-    List<Space> findAll();
+    List<Space> findAllByDeletedAtIsNull();
 
-    Page<Space> findAll(Pageable pageable);
+    Page<Space> findAllByDeletedAtIsNull(Pageable pageable);
 
     long count();
 
-    default Space getByCodeOrThrow(String spaceCode) {
+    default Space getByCodeAndDeletedAtIsNullOrThrow(String spaceCode) {
         if (spaceCode == null) {
             throw new BaseException("스페이스 코드는 null일 수 없습니다. code: " + spaceCode);
         }
-        return findByCode(spaceCode)
+        return findByCodeAndDeletedAtIsNull(spaceCode)
             .orElseThrow(() -> new NotFoundException("존재하지 않는 스페이스입니다. spaceCode: " + spaceCode));
     }
 }

--- a/backend/forgather/src/main/java/com/forgather/domain/space/repository/SpaceRepository.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/space/repository/SpaceRepository.java
@@ -12,8 +12,6 @@ import com.forgather.global.exception.NotFoundException;
 
 public interface SpaceRepository {
 
-    void delete(Space space);
-
     Space save(Space space);
 
     Optional<Space> findByCodeAndDeletedAtIsNull(String spaceCode);

--- a/backend/forgather/src/main/java/com/forgather/domain/space/service/SpaceService.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/space/service/SpaceService.java
@@ -3,7 +3,6 @@ package com.forgather.domain.space.service;
 import java.util.Comparator;
 import java.util.List;
 
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -22,7 +21,6 @@ import com.forgather.domain.space.model.Space;
 import com.forgather.domain.space.model.SpacePhoto;
 import com.forgather.domain.space.repository.SpacePhotoRepository;
 import com.forgather.domain.space.repository.SpaceRepository;
-import com.forgather.domain.upload.event.DeletePhotoEvent;
 import com.forgather.domain.upload.service.UploadService;
 import com.forgather.global.auth.model.Host;
 import com.forgather.global.auth.model.SpaceHostMap;
@@ -49,7 +47,6 @@ public class SpaceService {
     private final GuestBookCardRepository guestBookCardRepository;
     private final RandomCodeGenerator codeGenerator;
     private final UploadService uploadService;
-    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public CreateSpaceResponse create(CreateSpaceRequest request, MultipartFile file, Host host) {
@@ -137,12 +134,21 @@ public class SpaceService {
     public void delete(String spaceCode, Host host) {
         Space space = spaceRepository.getByCodeOrThrow(spaceCode);
         validateSpaceHost(space, host);
-
         deleteGuestBookAndProduct(host, space);
-        spaceHostMapRepository.deleteBySpace(space);
-        spacePhotoRepository.findBySpace(space)
-            .ifPresent(this::deleteSpacePhoto);
-        spaceRepository.delete(space);
+        deleteSpaceHostMap(host, space);
+        deleteSpacePhoto(space);
+        space.delete();
+    }
+
+    private void validateSpaceHost(Space space, Host host) {
+        validateHostNull(host);
+        if (space == null) {
+            throw new BaseNullPointerException("스페이스는 null일 수 없습니다.");
+        }
+        if (spaceHostMapRepository.findBySpaceAndHost(space, host).isPresent()) {
+            return;
+        }
+        throw new ForbiddenException("권한이 존재하지 않습니다.");
     }
 
     private void deleteGuestBookAndProduct(Host host, Space space) {
@@ -150,9 +156,18 @@ public class SpaceService {
         productService.deleteIfExists(host, space);
     }
 
+    private void deleteSpaceHostMap(Host host, Space space) {
+        SpaceHostMap spaceHostMap = spaceHostMapRepository.findBySpaceAndHost(space, host).orElseThrow();
+        spaceHostMap.delete();
+    }
+
+    private void deleteSpacePhoto(Space space) {
+        spacePhotoRepository.findBySpace(space)
+            .ifPresent(this::deleteSpacePhoto);
+    }
+
     private void deleteSpacePhoto(SpacePhoto spacePhoto) {
-        spacePhotoRepository.delete(spacePhoto);
-        eventPublisher.publishEvent(new DeletePhotoEvent(this, spacePhoto));
+        spacePhoto.delete();
     }
 
     @Transactional(readOnly = true)
@@ -178,17 +193,6 @@ public class SpaceService {
         Space space = spaceRepository.getByCodeOrThrow(spaceCode);
         validateHostNull(host);
         return new CheckSpaceHostResponse(spaceHostMapRepository.findBySpaceAndHost(space, host).isPresent());
-    }
-
-    private void validateSpaceHost(Space space, Host host) {
-        validateHostNull(host);
-        if (space == null) {
-            throw new BaseNullPointerException("스페이스는 null일 수 없습니다.");
-        }
-        if (spaceHostMapRepository.findBySpaceAndHost(space, host).isPresent()) {
-            return;
-        }
-        throw new ForbiddenException("권한이 존재하지 않습니다.");
     }
 
     private void validateHostNull(Host host) {

--- a/backend/forgather/src/main/java/com/forgather/domain/space/service/SpaceService.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/space/service/SpaceService.java
@@ -155,7 +155,7 @@ public class SpaceService {
     }
 
     private void deleteSpaceHostMap(Host host, Space space) {
-        SpaceHostMap spaceHostMap = spaceHostMapRepository.findBySpaceAndHostAndDeletedAtIsNull(space, host).orElseThrow();
+        SpaceHostMap spaceHostMap = spaceHostMapRepository.getBySpaceAndHostAndDeletedAtIsNullOrThrow(space, host);
         spaceHostMap.delete();
     }
 

--- a/backend/forgather/src/main/java/com/forgather/domain/space/service/SpaceService.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/space/service/SpaceService.java
@@ -64,10 +64,10 @@ public class SpaceService {
 
     @Transactional(readOnly = true)
     public SpaceResponse getSpaceInformation(String spaceCode) {
-        Space space = spaceRepository.getByCodeOrThrow(spaceCode);
+        Space space = spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
         Long guestBookCardCount = guestBookCardRepository.countBySpace(space);
 
-        return spacePhotoRepository.findBySpace(space)
+        return spacePhotoRepository.findBySpaceAndDeletedAtIsNull(space)
             .map(spacePhoto -> SpaceResponse.from(space, SpacePhotoResponse.exists(spacePhoto.getPath()),
                 guestBookCardCount))
             .orElseGet(() -> SpaceResponse.from(space, SpacePhotoResponse.notExists(), guestBookCardCount));
@@ -75,7 +75,7 @@ public class SpaceService {
 
     @Transactional
     public SpaceResponse update(String spaceCode, UpdateSpaceRequest request, MultipartFile file, Host host) {
-        Space space = spaceRepository.getByCodeOrThrow(spaceCode);
+        Space space = spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
         validateSpaceHost(space, host);
 
         space.update(request.name(), request.description(), request.isPublic(), request.instagramUsername(),
@@ -88,7 +88,7 @@ public class SpaceService {
         }
         Long guestBookCardCount = guestBookCardRepository.countBySpace(space);
 
-        return spacePhotoRepository.findBySpace(space)
+        return spacePhotoRepository.findBySpaceAndDeletedAtIsNull(space)
             .map(spacePhoto -> SpaceResponse.from(space, SpacePhotoResponse.exists(spacePhoto.getPath()),
                 guestBookCardCount))
             .orElseGet(() -> SpaceResponse.from(space, SpacePhotoResponse.notExists(), guestBookCardCount));
@@ -114,7 +114,7 @@ public class SpaceService {
     }
 
     private void uploadNewPhoto(Space space, MultipartFile file, String spaceCode) {
-        spacePhotoRepository.findBySpace(space)
+        spacePhotoRepository.findBySpaceAndDeletedAtIsNull(space)
             .ifPresent(photo -> {
                 throw new BaseException("스페이스 사진이 이미 존재합니다. 기존 스페이스 사진을 삭제 해주세요.");
             });
@@ -124,7 +124,7 @@ public class SpaceService {
     }
 
     private void deleteExistingPhoto(Space space) {
-        SpacePhoto existingPhoto = spacePhotoRepository.findBySpace(space)
+        SpacePhoto existingPhoto = spacePhotoRepository.findBySpaceAndDeletedAtIsNull(space)
             .orElseThrow(() -> new BaseException("삭제할 스페이스 사진이 존재하지 않습니다."));
 
         deleteSpacePhoto(existingPhoto);
@@ -132,7 +132,7 @@ public class SpaceService {
 
     @Transactional
     public void delete(String spaceCode, Host host) {
-        Space space = spaceRepository.getByCodeOrThrow(spaceCode);
+        Space space = spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
         validateSpaceHost(space, host);
         deleteGuestBookAndProduct(host, space);
         deleteSpaceHostMap(host, space);
@@ -145,7 +145,7 @@ public class SpaceService {
         if (space == null) {
             throw new BaseNullPointerException("스페이스는 null일 수 없습니다.");
         }
-        if (spaceHostMapRepository.findBySpaceAndHost(space, host).isPresent()) {
+        if (spaceHostMapRepository.findBySpaceAndHostAndDeletedAtIsNull(space, host).isPresent()) {
             return;
         }
         throw new ForbiddenException("권한이 존재하지 않습니다.");
@@ -157,12 +157,12 @@ public class SpaceService {
     }
 
     private void deleteSpaceHostMap(Host host, Space space) {
-        SpaceHostMap spaceHostMap = spaceHostMapRepository.findBySpaceAndHost(space, host).orElseThrow();
+        SpaceHostMap spaceHostMap = spaceHostMapRepository.findBySpaceAndHostAndDeletedAtIsNull(space, host).orElseThrow();
         spaceHostMap.delete();
     }
 
     private void deleteSpacePhoto(Space space) {
-        spacePhotoRepository.findBySpace(space)
+        spacePhotoRepository.findBySpaceAndDeletedAtIsNull(space)
             .ifPresent(this::deleteSpacePhoto);
     }
 
@@ -172,13 +172,13 @@ public class SpaceService {
 
     @Transactional(readOnly = true)
     public HostSpaceResponse getSpacesInformation(Host host) {
-        List<SpaceHostMap> spaceHostMaps = spaceHostMapRepository.findAllByHost(host);
+        List<SpaceHostMap> spaceHostMaps = spaceHostMapRepository.findAllByHostAndDeletedAtIsNull(host);
 
         List<SpaceResponse> spaceResponses = spaceHostMaps.stream()
             .map(spaceHostMap -> {
                 Space space = spaceHostMap.getSpace();
                 Long guestBookCardCount = guestBookCardRepository.countBySpace(space);
-                return spacePhotoRepository.findBySpace(space)
+                return spacePhotoRepository.findBySpaceAndDeletedAtIsNull(space)
                     .map(photo -> SpaceResponse.from(space, SpacePhotoResponse.exists(photo.getPath()),
                         guestBookCardCount))
                     .orElseGet(() -> SpaceResponse.from(space, SpacePhotoResponse.notExists(), guestBookCardCount));
@@ -190,9 +190,9 @@ public class SpaceService {
 
     @Transactional(readOnly = true)
     public CheckSpaceHostResponse checkSpaceHost(String spaceCode, Host host) {
-        Space space = spaceRepository.getByCodeOrThrow(spaceCode);
+        Space space = spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
         validateHostNull(host);
-        return new CheckSpaceHostResponse(spaceHostMapRepository.findBySpaceAndHost(space, host).isPresent());
+        return new CheckSpaceHostResponse(spaceHostMapRepository.findBySpaceAndHostAndDeletedAtIsNull(space, host).isPresent());
     }
 
     private void validateHostNull(Host host) {

--- a/backend/forgather/src/main/java/com/forgather/domain/space/service/SpaceService.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/space/service/SpaceService.java
@@ -170,7 +170,7 @@ public class SpaceService {
 
     @Transactional(readOnly = true)
     public HostSpaceResponse getSpacesInformation(Host host) {
-        List<SpaceHostMap> spaceHostMaps = spaceHostMapRepository.findAllByHostWithSpaceOrderByCreatedAtDesc(host);
+        List<SpaceHostMap> spaceHostMaps = spaceHostMapRepository.findAllByHostAndDeletedAtIsNullWithSpaceOrderByCreatedAtDesc(host);
         if (spaceHostMaps.isEmpty()) {
             return new HostSpaceResponse(Collections.emptyList());
         }

--- a/backend/forgather/src/main/java/com/forgather/domain/space/service/SpaceService.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/space/service/SpaceService.java
@@ -190,7 +190,7 @@ public class SpaceService {
                 SpaceGuestBookCountDto::guestBookCount)
             );
 
-        Map<Long, SpacePhoto> spacePhotos = spacePhotoRepository.findAllBySpaceIdIn(spaceIds)
+        Map<Long, SpacePhoto> spacePhotos = spacePhotoRepository.findAllBySpaceIdInAndDeletedAtIsNull(spaceIds)
             .stream()
             .collect(Collectors.toMap(
                 spacePhoto -> spacePhoto.getSpace().getId(),

--- a/backend/forgather/src/main/java/com/forgather/domain/upload/service/UploadService.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/upload/service/UploadService.java
@@ -46,7 +46,7 @@ public class UploadService {
     }
 
     public IssueSignedUrlResponse issueSignedUrls(String spaceCode, IssueSignedUrlRequest request) {
-        spaceRepository.getByCodeOrThrow(spaceCode);
+        spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
         Map<String, String> signedUrls = signedUrlIssuer.issueSignedUrls(
             request.uploadFileNames(),
             spaceCode,

--- a/backend/forgather/src/main/java/com/forgather/global/auth/model/SpaceHostMap.java
+++ b/backend/forgather/src/main/java/com/forgather/global/auth/model/SpaceHostMap.java
@@ -1,6 +1,6 @@
 package com.forgather.global.auth.model;
 
-import com.forgather.domain.model.BaseTimeEntity;
+import com.forgather.domain.model.SoftDeleteEntity;
 import com.forgather.domain.space.model.Space;
 
 import jakarta.persistence.Entity;
@@ -19,7 +19,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "space_host_map")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class SpaceHostMap extends BaseTimeEntity {
+public class SpaceHostMap extends SoftDeleteEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/forgather/src/main/java/com/forgather/global/auth/repository/SpaceHostMapRepository.java
+++ b/backend/forgather/src/main/java/com/forgather/global/auth/repository/SpaceHostMapRepository.java
@@ -22,9 +22,7 @@ public interface SpaceHostMapRepository {
         AND s.deletedAt IS NULL
         ORDER BY s.createdAt DESC
         """)
-    List<SpaceHostMap> findAllByHostWithSpaceOrderByCreatedAtDesc(@Param("host") Host host);
-
-    void deleteBySpace(Space space);
+    List<SpaceHostMap> findAllByHostAndDeletedAtIsNullWithSpaceOrderByCreatedAtDesc(@Param("host") Host host);
 
     Optional<SpaceHostMap> findBySpaceAndHostAndDeletedAtIsNull(Space space, Host host);
 }

--- a/backend/forgather/src/main/java/com/forgather/global/auth/repository/SpaceHostMapRepository.java
+++ b/backend/forgather/src/main/java/com/forgather/global/auth/repository/SpaceHostMapRepository.java
@@ -11,9 +11,9 @@ public interface SpaceHostMapRepository {
 
     SpaceHostMap save(SpaceHostMap spaceHostMap);
 
-    List<SpaceHostMap> findAllByHost(Host host);
+    List<SpaceHostMap> findAllByHostAndDeletedAtIsNull(Host host);
 
     void deleteBySpace(Space space);
 
-    Optional<SpaceHostMap> findBySpaceAndHost(Space space, Host host);
+    Optional<SpaceHostMap> findBySpaceAndHostAndDeletedAtIsNull(Space space, Host host);
 }

--- a/backend/forgather/src/main/java/com/forgather/global/auth/repository/SpaceHostMapRepository.java
+++ b/backend/forgather/src/main/java/com/forgather/global/auth/repository/SpaceHostMapRepository.java
@@ -5,10 +5,13 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.http.HttpStatus;
 
 import com.forgather.domain.space.model.Space;
 import com.forgather.global.auth.model.Host;
 import com.forgather.global.auth.model.SpaceHostMap;
+import com.forgather.global.exception.BaseNullPointerException;
+import com.forgather.global.exception.NotFoundException;
 
 public interface SpaceHostMapRepository {
 
@@ -25,4 +28,16 @@ public interface SpaceHostMapRepository {
     List<SpaceHostMap> findAllByHostAndDeletedAtIsNullWithSpaceOrderByCreatedAtDesc(@Param("host") Host host);
 
     Optional<SpaceHostMap> findBySpaceAndHostAndDeletedAtIsNull(Space space, Host host);
+
+    default SpaceHostMap getBySpaceAndHostAndDeletedAtIsNullOrThrow(Space space, Host host) {
+        if (space == null) {
+            throw new BaseNullPointerException("스페이스는 null일 수 없습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+        if (host == null) {
+            throw new BaseNullPointerException("호스트는 null일 수 없습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+        return findBySpaceAndHostAndDeletedAtIsNull(space, host)
+            .orElseThrow(() -> new NotFoundException("존재하지 않는 자원입니다. spaceCode: %s, hostId: %d"
+                .formatted(space.getCode(), host.getId())));
+    }
 }

--- a/backend/forgather/src/main/resources/db/migration/V10__add_soft_delete_column.sql
+++ b/backend/forgather/src/main/resources/db/migration/V10__add_soft_delete_column.sql
@@ -1,0 +1,23 @@
+ALTER TABLE `space`
+    ADD COLUMN `deleted_at` TIMESTAMP NULL;
+
+ALTER TABLE `space_host_map`
+    ADD COLUMN `deleted_at` TIMESTAMP NULL;
+
+ALTER TABLE `space_photo`
+    ADD COLUMN `deleted_at` TIMESTAMP NULL;
+
+ALTER TABLE `product`
+    ADD COLUMN `deleted_at` TIMESTAMP NULL;
+
+ALTER TABLE `product_photo`
+    ADD COLUMN `deleted_at` TIMESTAMP NULL;
+
+ALTER TABLE `guest`
+    ADD COLUMN `deleted_at` TIMESTAMP NULL;
+
+ALTER TABLE `guest_book_card`
+    ADD COLUMN `deleted_at` TIMESTAMP NULL;
+
+ALTER TABLE `guest_book_card_photo`
+    ADD COLUMN `deleted_at` TIMESTAMP NULL;

--- a/backend/forgather/src/test/java/com/forgather/acceptance/SpaceAcceptanceTest.java
+++ b/backend/forgather/src/test/java/com/forgather/acceptance/SpaceAcceptanceTest.java
@@ -244,11 +244,8 @@ class SpaceAcceptanceTest extends AcceptanceTest {
         // then
         assertAll(
             () -> assertThat(response.statusCode()).isEqualTo(204),
-            () -> assertThat(spaceRepository.findByCode(space.getCode())).isEmpty(),
-            () -> assertThat(spacePhotoRepository.findBySpace(space)).isEmpty(),
-
-            () -> await().atMost(ofSeconds(6))
-                .untilAsserted(() -> verify(contentsStorage, atLeast(1)).deletePhotos(anyList()))
+            () -> assertThat(spaceRepository.findByCodeAndDeletedAtIsNull(space.getCode())).isEmpty(),
+            () -> assertThat(spacePhotoRepository.findBySpaceAndDeletedAtIsNull(space)).isEmpty()
         );
     }
 
@@ -278,8 +275,8 @@ class SpaceAcceptanceTest extends AcceptanceTest {
         // then
         assertAll(
             () -> assertThat(response.statusCode()).isEqualTo(204),
-            () -> assertThat(spaceRepository.findByCode(space.getCode())).isEmpty(),
-            () -> assertThat(spacePhotoRepository.findBySpace(space)).isEmpty(),
+            () -> assertThat(spaceRepository.findByCodeAndDeletedAtIsNull(space.getCode())).isEmpty(),
+            () -> assertThat(spacePhotoRepository.findBySpaceAndDeletedAtIsNull(space)).isEmpty(),
             () -> assertThat(productRepository.findAllBySpace(space)).isEmpty(),
             () -> assertThat(productPhotoRepository.findAllByProduct(product)).isEmpty(),
             () -> assertThat(guestBookCardRepository.findAllBySpace(space)).isEmpty(),
@@ -369,7 +366,7 @@ class SpaceAcceptanceTest extends AcceptanceTest {
             () -> assertThat(result.isPublic()).isFalse(),
             () -> assertThat(result.instagramUsername()).isEqualTo("forgather_official_new"),
             () -> assertThat(result.email()).isEqualTo("forgather_new@forgather.me"),
-            () -> assertThat(spacePhotoRepository.getBySpaceOrEmpty(space).getOriginalName()).isEqualTo("new.jpg"),
+            () -> assertThat(spacePhotoRepository.getBySpaceAndDeletedAtIsNullOrEmpty(space).getOriginalName()).isEqualTo("new.jpg"),
             () -> assertThat(result.guestBookCardCount()).isZero(),
 
             () -> await().atMost(ofSeconds(6))

--- a/backend/forgather/src/test/java/com/forgather/domain/model/SoftDeleteEntityTest.java
+++ b/backend/forgather/src/test/java/com/forgather/domain/model/SoftDeleteEntityTest.java
@@ -1,0 +1,55 @@
+package com.forgather.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.forgather.fixture.GuestBookCardFixture;
+import com.forgather.fixture.GuestBookCardPhotoFixture;
+import com.forgather.fixture.GuestFixture;
+import com.forgather.fixture.ProductFixture;
+import com.forgather.fixture.ProductPhotoFixture;
+import com.forgather.fixture.SpaceFixture;
+import com.forgather.fixture.SpaceHostMapFixture;
+import com.forgather.fixture.SpacePhotoFixture;
+
+class SoftDeleteEntityTest {
+
+    @DisplayName("논리 삭제되지 않은 엔티티의 deletedAt은 null이다")
+    @MethodSource("softDeleteEntities")
+    @ParameterizedTest
+    void deletedAtIsNullWhenNotSoftDeleted(SoftDeleteEntity entity) {
+        // then
+        assertThat(entity.getDeletedAt()).isNull();
+    }
+
+    @DisplayName("논리 삭제된 엔티티의 deletedAt은 null이 아니다")
+    @MethodSource("softDeleteEntities")
+    @ParameterizedTest
+    void deletedAtIsNotNullWhenSoftDeleted(SoftDeleteEntity entity) {
+        // when
+        entity.delete();
+
+        // then
+        assertThat(entity.getDeletedAt()).isNotNull();
+    }
+
+    static Stream<Arguments> softDeleteEntities() {
+        return Stream.of(
+            arguments(SpaceFixture.createSpace()),
+            arguments(SpacePhotoFixture.createSpacePhoto()),
+            arguments(SpaceHostMapFixture.createSpaceHostMap()),
+            arguments(GuestBookCardFixture.createGuestBookCard()),
+            arguments(GuestBookCardPhotoFixture.createGuestBookCardPhoto()),
+            arguments(GuestFixture.createGuest()),
+            arguments(ProductFixture.createProduct()),
+            arguments(ProductPhotoFixture.createProductPhoto())
+        );
+    }
+}

--- a/backend/forgather/src/test/java/com/forgather/domain/space/service/SpaceServiceTest.java
+++ b/backend/forgather/src/test/java/com/forgather/domain/space/service/SpaceServiceTest.java
@@ -54,6 +54,6 @@ class SpaceServiceTest {
             () -> spaceService.create(request, new MockMultipartFile("temp.png", new byte[] {}), host)
         );
 
-        assertThat(spaceRepository.findAll()).isEmpty();
+        assertThat(spaceRepository.findAllByDeletedAtIsNull()).isEmpty();
     }
 }

--- a/backend/forgather/src/test/java/com/forgather/fixture/SpaceHostMapFixture.java
+++ b/backend/forgather/src/test/java/com/forgather/fixture/SpaceHostMapFixture.java
@@ -1,0 +1,10 @@
+package com.forgather.fixture;
+
+import com.forgather.global.auth.model.SpaceHostMap;
+
+public class SpaceHostMapFixture {
+
+    public static SpaceHostMap createSpaceHostMap() {
+        return new SpaceHostMap(SpaceFixture.createSpace(), HostFixture.createHost());
+    }
+}


### PR DESCRIPTION
## 연관된 이슈

- close #996 

## 작업 내용
### Soft Delete 도입
기존에는 사용자가 스페이스, 작품, 방명록을 삭제하면 관련된 모든 데이터를 데이터베이스 및 저장소에서 물리 삭제했습니다.

하지만 포게더 같이 기념하는 서비스에서 사용자가 실수로 삭제한 데이터를 복구하지 못한다는 점은 매우 큰 문제라고 생각했습니다.
또한 추후 데이터 분석에도 제약이 생길 수 있습니다. ex) 사용 패턴 분석, 스팸, 누적 통계 등
따라서 Soft Delete를 도입합니다.

### 고려할 점
- 법적으로 문제가 없는가?
  - 개인 정보 등 민감 정보가 포함된 데이터는 적절한 목적으로 사전 고지된 기간만큼 보관할 수 있습니다.
  - 그 외 논리 삭제로 인한 법적 문제는 없다고 알고 있습니다.
  - 경우에 따라 논리 삭제 시 민감 정보 마스킹도 고려해 볼 수 있습니다.
- 외래키 제약 조건은 괜찮은가?
  - 상위 도메인은 물리 삭제, 하위 도메인은 논리 삭제를 하는 경우 외래키 제약 조건에 걸릴 수 있습니다.
  - 상위 도메인과 하위 도메인의 물리 삭제 주기가 다르다면 외래키 제약 조건에 걸릴 수 있습니다.
  - 현재는 해당 사항이 없어 괜찮다고 판단했습니다.
- DB 저장 공간은 괜찮은가?
  - 현재 DB 스토리지 사용 가능 용량이 18.5GB / 20GB로, 90% 이상 여유로운 상황입니다.
  - 추후 보관 기간에 따라 물리 삭제를 한다고 하면, 더욱 충분할 것으로 보입니다.
- 파일 저장 비용은 괜찮은가?
  - 파일은 DB 데이터와 동일한 생명주기로 가져가며, 누적될 경우 비용이 많이 나올 수 있습니다. 이 또한 지속적인 모니터링을 통해 추후 물리 삭제, 스토리지 클래스 변경 등을 고려해 볼 수 있습니다.

### 구현 방식

DB에서 논리 삭제와 물리 삭제를 구분하는 대표적인 방법 3가지 중 고려했습니다.
- 논리 삭제 테이블 분리
  - 활성 데이터와 삭제 데이터를 테이블로 분리합니다.
  - 명확한 이해가 가능하고 성능 상 이점 기대해 볼 수 있습니다. 
  - 하지만 논리 삭제 엔티티 당 두개의 테이블(총 2N개)을 관리해야하기 때문에 구조가 복잡해 선택하지 않았습니다.
- is_deleted 컬럼
  - true(1)/false(0)를 기반으로 삭제된 레코드를 구분합니다.
  - 간단하고 명확합니다.
  - 하지만 삭제 시점 별도 보관, 인덱스 활용 시 카디널리티 낮음, 삭제 시점이 추가로 들어가 쿼리가 간단하지는 않다는 점 때문에 선택하지 않았습니다.
- deleted_at 컬럼
  - null / not null(삭제 시점)을 기반으로 삭제된 레코드를 구분합니다.
  - 간단하고 명확합니다.
  - 하나의 컬럼으로 삭제 시점을 보관할 수 있고 관련 쿼리도 작성 가능하며, 카디널리티도 높기 때문에 이 방식을 선택했습니다.

애플리케이션에서 논리 삭제를 구현하는 대표적인 방법 2가지 중 고려했습니다.
- JPA 어노테이션 사용(`@SQLDelete`, `@SQLRestriction`, `@Filter` 등
  - 간편하며 전환 시 발생하는 휴먼 에러가 적습니다.
  - 하지만 하이버네이트 의존성 증가, 벌크 연산 미적용, 사이드 이펙트, 논리 삭제 레코드 조회 시 직접 쿼리를 작성해야한다는 점 때문에 선택하지 않았습니다.
- 애플리케이션 코드로 제어
  - 코드로 직접 구현하기 때문에 사이드 이펙트를 최소화한 면밀한 제어가 가능하며, 특정 기술에 대한 의존성이 적습니다.
  - 코드 양이 증가하기 때문에 복잡하고 관리 포인트가 늘어난다는 단점이 있습니다.
  - 현재 포게더는 빠른 개발 보다 사이드 이펙트를 최소화하고 제어와 안정성을 보장하는게 더 중요하며,
  장기적으로 보았을 때도 규모가 작은 이 시점에 코드로 제어하는 것이 비용적으로 저렴하다고 판단해 이 방식을 선택했습니다.

### 구현
DB 관점으로는 Space, Product, GuestBookCard와 그 하위 도메인 모두에 논리 삭제를 구현해놨습니다.
애플리케이션 관점으로는 PR 범위에 맞게 우선 Space만 구현했으며, 다른 도메인은 별도 PR에서 적용할 예정입니다.

## 테스트 실패
현재 Github Actions 테스트 중 `스페이스를 수정한다` 테스트가 실패하고 있습니다.
Space와 SpacePhoto 간의 `OneToOne` 매핑으로 인해 테스트 환경에서 `space_photo.space_id` 컬럼에 unique 제약 조건이
걸리고, 새로 저장한 space_photo가 논리 삭제된 레코드와 중복된 space_id를 가지고 있어 실패합니다.

로컬에서는 이를 해결했지만,
테스트 환경 때문에 실패하는 것이고 해결 과정에서 변경이 많아 별도의 PR에서 다루겠습니다~