### PR TITLE
feature: 백오피스 스페이스 목록/상세 조회 기능 추가

### DIFF
--- a/backend/forgather/src/main/java/com/forgather/back_office/controller/AdminHostController.java
+++ b/backend/forgather/src/main/java/com/forgather/back_office/controller/AdminHostController.java
@@ -28,7 +28,7 @@ public class AdminHostController {
         Pageable pageable,
         @Admin AdminUser adminUser
     ) {
-        var response = adminHostService.getAllHosts(pageable, adminUser);
+        var response = adminHostService.getAllHosts(pageable);
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/forgather/src/main/java/com/forgather/back_office/controller/AdminSpaceController.java
+++ b/backend/forgather/src/main/java/com/forgather/back_office/controller/AdminSpaceController.java
@@ -30,7 +30,7 @@ public class AdminSpaceController {
         Pageable pageable,
         @Admin AdminUser adminUser
     ) {
-        var response = adminSpaceService.getAllSpaces(pageable, adminUser);
+        var response = adminSpaceService.getAllSpaces(pageable);
         return ResponseEntity.ok(response);
     }
 
@@ -39,7 +39,7 @@ public class AdminSpaceController {
         @PathVariable(name = "spaceCode") String spaceCode,
         @Admin AdminUser adminUser
     ) {
-        var response = adminSpaceService.getSpaceDetail(spaceCode, adminUser);
+        var response = adminSpaceService.getSpaceDetail(spaceCode);
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/forgather/src/main/java/com/forgather/back_office/controller/AdminSpaceController.java
+++ b/backend/forgather/src/main/java/com/forgather/back_office/controller/AdminSpaceController.java
@@ -28,7 +28,7 @@ public class AdminSpaceController {
 
     @GetMapping
     public ResponseEntity<AdminSpaceResponse> getAllSpaces(
-        @PageableDefault(size = 15, sort = {"id"}, direction = Sort.Direction.DESC)
+        @PageableDefault(size = 15, sort = {"createdAt"}, direction = Sort.Direction.DESC)
         Pageable pageable,
         @Admin AdminUser adminUser
     ) {

--- a/backend/forgather/src/main/java/com/forgather/back_office/controller/AdminSpaceController.java
+++ b/backend/forgather/src/main/java/com/forgather/back_office/controller/AdminSpaceController.java
@@ -5,11 +5,13 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.forgather.back_office.annotation.Admin;
+import com.forgather.back_office.dto.AdminSpaceFilterRequest;
 import com.forgather.back_office.dto.AdminSpaceResponse;
 import com.forgather.back_office.dto.SpaceDetailResponse;
 import com.forgather.back_office.model.AdminUser;
@@ -31,6 +33,17 @@ public class AdminSpaceController {
         @Admin AdminUser adminUser
     ) {
         var response = adminSpaceService.getAllSpaces(pageable);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<AdminSpaceResponse> getSpacesByFilters(
+        @PageableDefault(size = 15, sort = {"createdAt"}, direction = Sort.Direction.DESC)
+        Pageable pageable,
+        @ModelAttribute AdminSpaceFilterRequest request,
+        @Admin AdminUser adminUser
+    ) {
+        var response = adminSpaceService.getSpacesByFilters(request, pageable);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/forgather/src/main/java/com/forgather/back_office/dto/AdminSpaceFilterRequest.java
+++ b/backend/forgather/src/main/java/com/forgather/back_office/dto/AdminSpaceFilterRequest.java
@@ -1,0 +1,6 @@
+package com.forgather.back_office.dto;
+
+public record AdminSpaceFilterRequest(
+    Boolean hasProduct
+) {
+}

--- a/backend/forgather/src/main/java/com/forgather/back_office/dto/SpaceDetailResponse.java
+++ b/backend/forgather/src/main/java/com/forgather/back_office/dto/SpaceDetailResponse.java
@@ -4,11 +4,11 @@ import com.forgather.domain.space.model.Space;
 
 public record SpaceDetailResponse(
     SimpleSpaceResponse space,
-    Boolean hasProduct,
+    Long productCount,
     Long guestBookCount
 ) {
 
-    public static SpaceDetailResponse of(Space space, Boolean hasProduct, Long guestBookCount) {
-        return new SpaceDetailResponse(SimpleSpaceResponse.from(space), hasProduct, guestBookCount);
+    public static SpaceDetailResponse of(Space space, Long productCount, Long guestBookCount) {
+        return new SpaceDetailResponse(SimpleSpaceResponse.from(space), productCount, guestBookCount);
     }
 }

--- a/backend/forgather/src/main/java/com/forgather/back_office/service/AdminHostService.java
+++ b/backend/forgather/src/main/java/com/forgather/back_office/service/AdminHostService.java
@@ -9,7 +9,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.forgather.back_office.dto.AdminHostResponse;
 import com.forgather.back_office.dto.HostDetailResponse;
-import com.forgather.back_office.model.AdminUser;
 import com.forgather.domain.space.repository.HostRepository;
 import com.forgather.global.auth.model.Host;
 import com.forgather.global.auth.repository.SpaceHostMapRepository;
@@ -24,7 +23,7 @@ public class AdminHostService {
     private final SpaceHostMapRepository spaceHostMapRepository;
 
     @Transactional(readOnly = true)
-    public AdminHostResponse getAllHosts(Pageable pageable, AdminUser adminUser) {
+    public AdminHostResponse getAllHosts(Pageable pageable) {
         Page<Host> hosts = hostRepository.findAll(pageable);
         return AdminHostResponse.from(hosts.map(host -> {
             List<Long> spaceIds = spaceHostMapRepository.findAllByHostAndDeletedAtIsNullWithSpaceOrderByCreatedAtDesc(host)

--- a/backend/forgather/src/main/java/com/forgather/back_office/service/AdminSpaceService.java
+++ b/backend/forgather/src/main/java/com/forgather/back_office/service/AdminSpaceService.java
@@ -38,13 +38,14 @@ public class AdminSpaceService {
     }
 
     public AdminSpaceResponse getSpacesByFilters(AdminSpaceFilterRequest request, Pageable pageable) {
-        Page<Space> spaces;
         if (request.hasProduct() == null) {
-            spaces = spaceRepository.findAllByDeletedAtIsNull(pageable);
-            return AdminSpaceResponse.from(spaces);
+            Page<Space> allSpaces = spaceRepository.findAllByDeletedAtIsNull(pageable);
+            return AdminSpaceResponse.from(allSpaces);
         }
 
-        spaces = spaceRepository.findAllByDeletedAtIsNullAndProductFilter(request.hasProduct(), pageable);
-        return AdminSpaceResponse.from(spaces);
+        Page<Space> filteredSpaces = spaceRepository.findAllByDeletedAtIsNullAndProductFilter(
+            request.hasProduct(), pageable
+        );
+        return AdminSpaceResponse.from(filteredSpaces);
     }
 }

--- a/backend/forgather/src/main/java/com/forgather/back_office/service/AdminSpaceService.java
+++ b/backend/forgather/src/main/java/com/forgather/back_office/service/AdminSpaceService.java
@@ -32,13 +32,12 @@ public class AdminSpaceService {
     @Transactional(readOnly = true)
     public SpaceDetailResponse getSpaceDetail(String spaceCode) {
         Space space = spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
-        boolean hasProduct = !productRepository.findAllBySpace(space)
-            .isEmpty();
+        Long productCount = productRepository.countBySpace(space);
         Long guestBookCardCount = guestBookCardRepository.countBySpace(space);
 
-        return SpaceDetailResponse.of(space, hasProduct, guestBookCardCount);
+        return SpaceDetailResponse.of(space, productCount, guestBookCardCount);
     }
-    
+
     @Transactional(readOnly = true)
     public AdminSpaceResponse getSpacesByFilters(AdminSpaceFilterRequest request, Pageable pageable) {
         Page<Space> spaces;

--- a/backend/forgather/src/main/java/com/forgather/back_office/service/AdminSpaceService.java
+++ b/backend/forgather/src/main/java/com/forgather/back_office/service/AdminSpaceService.java
@@ -17,19 +17,18 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class AdminSpaceService {
 
     private final SpaceRepository spaceRepository;
     private final ProductRepository productRepository;
     private final GuestBookCardRepository guestBookCardRepository;
 
-    @Transactional(readOnly = true)
     public AdminSpaceResponse getAllSpaces(Pageable pageable) {
         Page<Space> spaces = spaceRepository.findAllByDeletedAtIsNull(pageable);
         return AdminSpaceResponse.from(spaces);
     }
 
-    @Transactional(readOnly = true)
     public SpaceDetailResponse getSpaceDetail(String spaceCode) {
         Space space = spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
         Long productCount = productRepository.countBySpace(space);
@@ -38,7 +37,6 @@ public class AdminSpaceService {
         return SpaceDetailResponse.of(space, productCount, guestBookCardCount);
     }
 
-    @Transactional(readOnly = true)
     public AdminSpaceResponse getSpacesByFilters(AdminSpaceFilterRequest request, Pageable pageable) {
         Page<Space> spaces;
         if (request.hasProduct() == null) {

--- a/backend/forgather/src/main/java/com/forgather/back_office/service/AdminSpaceService.java
+++ b/backend/forgather/src/main/java/com/forgather/back_office/service/AdminSpaceService.java
@@ -7,7 +7,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.forgather.back_office.dto.AdminSpaceResponse;
 import com.forgather.back_office.dto.SpaceDetailResponse;
-import com.forgather.back_office.model.AdminUser;
 import com.forgather.domain.guestbook.repository.GuestBookCardRepository;
 import com.forgather.domain.product.repository.ProductRepository;
 import com.forgather.domain.space.model.Space;
@@ -24,14 +23,13 @@ public class AdminSpaceService {
     private final GuestBookCardRepository guestBookCardRepository;
 
     @Transactional(readOnly = true)
-    public AdminSpaceResponse getAllSpaces(Pageable pageable, AdminUser adminUser) {
-        // TODO: 관리자 권한에 따른 호출 여부 로직 추가 가능성이 있음
+    public AdminSpaceResponse getAllSpaces(Pageable pageable) {
         Page<Space> spaces = spaceRepository.findAllByDeletedAtIsNull(pageable);
         return AdminSpaceResponse.from(spaces);
     }
 
     @Transactional(readOnly = true)
-    public SpaceDetailResponse getSpaceDetail(String spaceCode, AdminUser adminUser) {
+    public SpaceDetailResponse getSpaceDetail(String spaceCode) {
         Space space = spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
         boolean hasProduct = !productRepository.findAllBySpace(space)
             .isEmpty();

--- a/backend/forgather/src/main/java/com/forgather/back_office/service/AdminSpaceService.java
+++ b/backend/forgather/src/main/java/com/forgather/back_office/service/AdminSpaceService.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.forgather.back_office.dto.AdminSpaceFilterRequest;
 import com.forgather.back_office.dto.AdminSpaceResponse;
 import com.forgather.back_office.dto.SpaceDetailResponse;
 import com.forgather.domain.guestbook.repository.GuestBookCardRepository;
@@ -36,5 +37,17 @@ public class AdminSpaceService {
         Long guestBookCardCount = guestBookCardRepository.countBySpace(space);
 
         return SpaceDetailResponse.of(space, hasProduct, guestBookCardCount);
+    }
+    
+    @Transactional(readOnly = true)
+    public AdminSpaceResponse getSpacesByFilters(AdminSpaceFilterRequest request, Pageable pageable) {
+        Page<Space> spaces;
+        if (request.hasProduct() == null) {
+            spaces = spaceRepository.findAllByDeletedAtIsNull(pageable);
+            return AdminSpaceResponse.from(spaces);
+        }
+
+        spaces = spaceRepository.findAllByDeletedAtIsNullAndProductFilter(request.hasProduct(), pageable);
+        return AdminSpaceResponse.from(spaces);
     }
 }

--- a/backend/forgather/src/main/java/com/forgather/domain/space/repository/SpaceRepository.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/space/repository/SpaceRepository.java
@@ -5,6 +5,8 @@ import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.forgather.domain.space.model.Space;
 import com.forgather.global.exception.BaseException;
@@ -19,6 +21,21 @@ public interface SpaceRepository {
     List<Space> findAllByDeletedAtIsNull();
 
     Page<Space> findAllByDeletedAtIsNull(Pageable pageable);
+
+    @Query("""
+        SELECT DISTINCT s
+        FROM Space s
+                LEFT JOIN Product p ON p.space = s AND p.deletedAt IS NULL
+        WHERE s.deletedAt IS NULL AND (
+                (:hasProduct = true AND p.id IS NOT NULL) OR
+                        (:hasProduct = false AND p.id IS NULL)
+        )
+        ORDER BY s.createdAt DESC
+        """)
+    Page<Space> findAllByDeletedAtIsNullAndProductFilter(
+        @Param("hasProduct") boolean hasProduct,
+        Pageable pageable
+    );
 
     long count();
 

--- a/backend/forgather/src/main/java/com/forgather/domain/space/repository/SpaceRepository.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/space/repository/SpaceRepository.java
@@ -30,7 +30,6 @@ public interface SpaceRepository {
                 (:hasProduct = true AND p.id IS NOT NULL) OR
                         (:hasProduct = false AND p.id IS NULL)
         )
-        ORDER BY s.createdAt DESC
         """)
     Page<Space> findAllByDeletedAtIsNullAndProductFilter(
         @Param("hasProduct") boolean hasProduct,

--- a/backend/forgather/src/main/resources/static/css/admin/common.css
+++ b/backend/forgather/src/main/resources/static/css/admin/common.css
@@ -339,9 +339,10 @@ body {
 
 .pagination {
     display: flex;
+    flex-direction: column;
     justify-content: center;
     align-items: center;
-    gap: var(--spacing-lg);
+    gap: var(--spacing-md);
     margin-top: var(--spacing-xl);
     padding: var(--spacing-lg);
     background-color: var(--surface-color);
@@ -349,35 +350,64 @@ body {
     box-shadow: var(--shadow-sm);
 }
 
+/* 페이지 버튼 컨테이너 */
+.pagination-buttons {
+    display: flex;
+    gap: 0.375rem;
+    align-items: center;
+}
+
+/* 개별 페이지 버튼 */
 .pagination-btn {
-    padding: var(--spacing-sm) var(--spacing-lg);
-    background-color: var(--primary-color);
-    color: white;
-    border: none;
+    min-width: 2.25rem;
+    height: 2.25rem;
+    padding: 0 0.5rem;
+    background-color: var(--surface-color);
+    color: var(--text-primary);
+    border: 1px solid var(--border-color);
     border-radius: var(--radius-md);
     cursor: pointer;
     font-weight: 500;
     font-size: 0.875rem;
     transition: all 0.2s;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
 }
 
-.pagination-btn:hover:not(:disabled) {
-    background-color: var(--primary-hover);
+/* 버튼 호버 상태 */
+.pagination-btn:hover:not(:disabled):not(.active) {
+    background-color: var(--bg-color);
+    border-color: var(--primary-color);
+    color: var(--primary-color);
 }
 
+/* 현재 페이지 (활성 상태) */
+.pagination-btn.active {
+    background-color: var(--primary-color);
+    color: white;
+    border-color: var(--primary-color);
+    cursor: default;
+}
+
+/* 비활성화된 버튼 */
 .pagination-btn:disabled {
-    background-color: var(--secondary-color);
+    background-color: var(--bg-color);
+    color: var(--text-muted);
+    border-color: var(--border-color);
     cursor: not-allowed;
     opacity: 0.5;
 }
 
+/* 페이지 정보 텍스트 */
 .pagination-info {
     color: var(--text-secondary);
     font-size: 0.875rem;
-    font-weight: 500;
+    font-weight: 400;
+    text-align: center;
 }
 
-.pagination-info span {
+.pagination-info strong {
     color: var(--text-primary);
     font-weight: 600;
 }
@@ -518,9 +548,16 @@ body {
         min-width: 600px;
     }
 
-    .pagination {
-        flex-direction: column;
-        gap: var(--spacing-md);
+    /* 페이지네이션은 이미 column 방향이므로 추가 조정 불필요 */
+    .pagination-buttons {
+        flex-wrap: wrap;
+        justify-content: center;
+    }
+
+    /* 모바일에서 버튼 크기 약간 증가 (터치하기 쉽게) */
+    .pagination-btn {
+        min-width: 2.5rem;
+        height: 2.5rem;
     }
 
     .container {

--- a/backend/forgather/src/main/resources/static/css/admin/spaces.css
+++ b/backend/forgather/src/main/resources/static/css/admin/spaces.css
@@ -33,6 +33,7 @@
     background-color: var(--surface-color);
     border-radius: var(--radius-lg);
     box-shadow: var(--shadow-sm);
+    gap: var(--spacing-lg);
 }
 
 .page-size-selector {
@@ -51,6 +52,114 @@
 .page-size-selector .form-select {
     width: auto;
     min-width: 80px;
+}
+
+/* ==========================================================================
+   Filter Section
+   - 스페이스 필터링 UI 영역
+   - 향후 필터 조건 추가 시 이 영역에 filter-group을 추가하면 됨
+   ========================================================================== */
+
+/**
+ * 필터 섹션 컨테이너
+ * - controls 영역의 왼쪽에 배치
+ * - 여러 필터 그룹과 검색 버튼을 포함
+ */
+.filter-section {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-lg);
+    flex: 1;
+}
+
+/**
+ * 개별 필터 그룹 (라벨 + 입력 요소)
+ * - 하나의 필터 조건을 담는 컨테이너
+ * - 예: 작품 소개 등록 여부 필터
+ * - 향후 확장: 공개 여부 필터, 날짜 필터 등을 추가할 때 이 클래스 재사용
+ */
+.filter-group {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-md);
+    flex-wrap: wrap;
+}
+
+/**
+ * 필터 라벨
+ * - 필터 조건의 제목을 표시
+ * - 진하게 표시하여 입력 요소와 구분
+ */
+.filter-label {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    white-space: nowrap;
+}
+
+/**
+ * Radio 버튼 라벨
+ * - radio input과 텍스트를 감싸는 라벨
+ * - cursor: pointer로 클릭 가능함을 표시
+ * - hover 시 배경색 변경으로 인터랙티브함 강조
+ */
+.filter-radio-label {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--spacing-xs);
+    cursor: pointer;
+    padding: var(--spacing-xs) var(--spacing-sm);
+    border-radius: var(--radius-md);
+    transition: background-color 0.2s;
+    font-size: 0.875rem;
+    color: var(--text-primary);
+    font-weight: 400;
+}
+
+.filter-radio-label:hover {
+    background-color: var(--bg-color);
+}
+
+/**
+ * Radio 버튼 스타일
+ * - 브라우저 기본 스타일 사용 (간결함 유지)
+ * - cursor: pointer로 클릭 가능함 명시
+ */
+.filter-radio-label input[type="radio"] {
+    cursor: pointer;
+    width: 16px;
+    height: 16px;
+    margin: 0;
+}
+
+/**
+ * 검색 버튼
+ * - 필터 선택 후 이 버튼을 클릭해야 필터가 적용됨
+ * - 기존 프로젝트의 primary 버튼 스타일 재사용
+ */
+.btn-filter {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.625rem 1.5rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    line-height: 1.5;
+    border-radius: var(--radius-md);
+    border: none;
+    cursor: pointer;
+    transition: all 0.2s;
+    background-color: var(--primary-color);
+    color: white;
+    white-space: nowrap;
+}
+
+.btn-filter:hover {
+    background-color: var(--primary-hover);
+}
+
+.btn-filter:active {
+    transform: scale(0.98);
 }
 
 /* ==========================================================================
@@ -414,10 +523,43 @@ body.modal-open {
         font-size: 1.5rem;
     }
 
+    /**
+     * 모바일에서 controls 영역 세로 배치
+     * - 필터 섹션이 위, 페이지 크기 선택이 아래
+     */
     .controls {
         flex-direction: column;
-        align-items: flex-start;
+        align-items: stretch;
         gap: var(--spacing-md);
+    }
+
+    /**
+     * 모바일에서 필터 섹션 세로 배치
+     * - 필터 그룹과 검색 버튼을 세로로 배치하여 가독성 향상
+     */
+    .filter-section {
+        flex-direction: column;
+        align-items: stretch;
+        gap: var(--spacing-md);
+    }
+
+    /**
+     * 모바일에서 필터 그룹도 세로 배치
+     * - 라벨과 radio 버튼들을 세로로 배치
+     */
+    .filter-group {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: var(--spacing-sm);
+    }
+
+    /**
+     * 모바일에서 검색 버튼 전체 너비
+     * - 터치하기 쉽도록 버튼 크기 확대
+     */
+    .btn-filter {
+        width: 100%;
+        padding: 0.75rem 1.5rem;
     }
 
     .page-size-selector {

--- a/backend/forgather/src/main/resources/static/js/admin/api.js
+++ b/backend/forgather/src/main/resources/static/js/admin/api.js
@@ -316,9 +316,9 @@ const API = {
      * Space 상세 정보 조회 API
      *
      * @param {string} spaceCode - 조회할 스페이스 코드 (예: "e3f6b97f19")
-     * @returns {Promise<object>} 스페이스 상세 정보 응답
+     * @returns {Promise<object>} 스페이스 상세 정보 응답 (SpaceDetailResponse)
      * @returns {object} response.space - 스페이스 기본 정보 (id, code, name, isPublic)
-     * @returns {boolean} response.hasProduct - 작품 소개 등록 여부
+     * @returns {number} response.productCount - 등록한 작품 소개 개수 (0 이상의 정수)
      * @returns {number} response.guestBookCount - 방명록 개수
      * @throws {Error} API 호출 실패 시 에러 (404: 존재하지 않는 스페이스, 401: 인증 실패 등)
      *
@@ -327,6 +327,7 @@ const API = {
      * try {
      *     const detail = await API.getSpaceDetail('e3f6b97f19');
      *     console.log(detail.space.name); // "졸업 전시"
+     *     console.log(detail.productCount); // 5 (등록한 작품 소개 개수)
      *     console.log(detail.guestBookCount); // 42
      * } catch (error) {
      *     console.error('Failed to load space detail:', error);

--- a/backend/forgather/src/main/resources/static/js/admin/api.js
+++ b/backend/forgather/src/main/resources/static/js/admin/api.js
@@ -104,8 +104,6 @@ const API = {
 
                 // Token Refresh 시도
                 try {
-                    console.log('[API] Access Token 갱신 시도...');
-
                     // 동시 다중 401 에러 처리: tokenRefreshPromise 캐싱
                     // 이미 갱신 중이면 기존 Promise 재사용, 아니면 새로 시작
                     if (!tokenRefreshPromise) {
@@ -117,8 +115,6 @@ const API = {
 
                     // 갱신 완료 후 캐시 리셋 (다음 401 에러를 위해)
                     tokenRefreshPromise = null;
-
-                    console.log('[API] Access Token 갱신 완료. 원래 요청 재시도:', url);
 
                     // 새 Access Token으로 Authorization 헤더 업데이트
                     if (options.headers && options.headers['Authorization']) {
@@ -251,7 +247,7 @@ const API = {
      * @returns {Promise<object>} 로그인 응답 (accessToken, refreshToken)
      */
     async login(username, password) {
-        return this.post('/login', { username, password }, false);
+        return this.post('/login', {username, password}, false);
     },
 
     /**
@@ -261,7 +257,7 @@ const API = {
      * @returns {Promise<object>} Space 목록 응답
      */
     async getSpaces(page = 1, size = 15) {
-        return this.get('/spaces', { page, size }, true);
+        return this.get('/spaces', {page, size}, true);
     },
 
     /**
@@ -302,7 +298,7 @@ const API = {
      * - 향후 다른 필터 추가 시 filters 객체에 프로퍼티 추가
      */
     async getSpacesByFilters(page = 1, size = 15, filters = {}) {
-        const params = { page, size };
+        const params = {page, size};
 
         // hasProduct 필터가 명시적으로 true 또는 false인 경우에만 파라미터에 추가
         if (filters.hasProduct !== null && filters.hasProduct !== undefined) {
@@ -379,7 +375,7 @@ const API = {
      * - 페이지 번호는 1부터 시작 (서버에서 0-based를 1-based로 변환하여 반환)
      */
     async getHosts(page = 1, size = 15) {
-        return this.get('/hosts', { page, size }, true);
+        return this.get('/hosts', {page, size}, true);
     }
 };
 

--- a/backend/forgather/src/main/resources/static/js/admin/api.js
+++ b/backend/forgather/src/main/resources/static/js/admin/api.js
@@ -255,13 +255,61 @@ const API = {
     },
 
     /**
-     * Space 목록 조회 API
+     * Space 목록 조회 API (전체 - 필터 없음)
      * @param {number} page - 페이지 번호 (1부터 시작)
      * @param {number} size - 페이지 크기
      * @returns {Promise<object>} Space 목록 응답
      */
     async getSpaces(page = 1, size = 15) {
         return this.get('/spaces', { page, size }, true);
+    },
+
+    /**
+     * Space 목록 조회 API (필터링)
+     *
+     * @param {number} page - 페이지 번호 (1부터 시작)
+     * @param {number} size - 페이지 크기
+     * @param {object} filters - 필터 조건 객체
+     * @param {boolean|null} filters.hasProduct - 작품 소개 등록 여부 (true: 등록함, false: 미등록, null: 전체)
+     * @returns {Promise<object>} Space 목록 응답
+     *
+     * 엔드포인트: GET /admin/spaces/search
+     *
+     * 쿼리 파라미터:
+     * - page: 페이지 번호 (필수)
+     * - size: 페이지 크기 (필수)
+     * - hasProduct: 작품 소개 등록 여부 (선택)
+     *
+     * 응답 구조:
+     * - spaces: Space 목록 배열
+     * - currentPage: 현재 페이지 번호 (1부터 시작)
+     * - pageSize: 페이지 크기
+     * - totalCount: 전체 Space 개수
+     * - totalPages: 전체 페이지 수
+     *
+     * 사용 예시:
+     * ```javascript
+     * // 작품 소개 등록한 스페이스만 조회
+     * const response = await API.getSpacesByFilters(1, 15, { hasProduct: true });
+     *
+     * // 작품 소개 미등록 스페이스만 조회
+     * const response = await API.getSpacesByFilters(1, 15, { hasProduct: false });
+     * ```
+     *
+     * 주의:
+     * - filters.hasProduct가 null이면 해당 파라미터는 쿼리에 포함되지 않음
+     * - 필터 조건이 없으면 getSpaces() 함수를 사용하는 것이 더 적합
+     * - 향후 다른 필터 추가 시 filters 객체에 프로퍼티 추가
+     */
+    async getSpacesByFilters(page = 1, size = 15, filters = {}) {
+        const params = { page, size };
+
+        // hasProduct 필터가 명시적으로 true 또는 false인 경우에만 파라미터에 추가
+        if (filters.hasProduct !== null && filters.hasProduct !== undefined) {
+            params.hasProduct = filters.hasProduct;
+        }
+
+        return this.get('/spaces/search', params, true);
     },
 
     /**

--- a/backend/forgather/src/main/resources/static/js/admin/auth.js
+++ b/backend/forgather/src/main/resources/static/js/admin/auth.js
@@ -175,8 +175,6 @@ const Auth = {
         }
 
         try {
-            console.log('[Auth] Access Token 갱신 시도 중...');
-
             // 주의: 여기서는 API.request()를 사용하면 안 됨 (무한 루프)
             // 직접 fetch를 사용하여 Refresh Token API 호출
             const response = await fetch('/admin/refresh', {
@@ -184,7 +182,7 @@ const Auth = {
                 headers: {
                     'Content-Type': 'application/json'
                 },
-                body: JSON.stringify({ refreshToken })
+                body: JSON.stringify({refreshToken})
             });
 
             // 401/404: Refresh Token 만료 또는 유효하지 않음
@@ -210,7 +208,6 @@ const Auth = {
                 this.setRefreshToken(data.refreshToken);
             }
 
-            console.log('[Auth] Access Token이 성공적으로 갱신되었습니다.');
             return data.accessToken;
 
         } catch (error) {

--- a/backend/forgather/src/main/resources/static/js/admin/hosts.js
+++ b/backend/forgather/src/main/resources/static/js/admin/hosts.js
@@ -73,11 +73,6 @@ document.addEventListener('DOMContentLoaded', function() {
     const errorMessage = document.getElementById('errorMessage');
     const pageSizeSelect = document.getElementById('pageSize');
     const paginationContainer = document.getElementById('pagination');
-    const currentPageSpan = document.getElementById('currentPage');
-    const totalPagesSpan = document.getElementById('totalPages');
-    const totalCountSpan = document.getElementById('totalCount');
-    const prevBtn = document.getElementById('prevBtn');
-    const nextBtn = document.getElementById('nextBtn');
     const logoutBtn = document.getElementById('logoutBtn');
 
     // ======================================================================
@@ -268,29 +263,19 @@ document.addEventListener('DOMContentLoaded', function() {
     /**
      * 페이지네이션 UI 업데이트
      *
-     * 동작:
-     * 1. 현재 페이지, 전체 페이지, 전체 아이템 개수 표시
-     * 2. 이전 버튼 활성화/비활성화 (currentPage <= 1이면 비활성화)
-     * 3. 다음 버튼 활성화/비활성화 (currentPage >= totalPages이면 비활성화)
-     * 4. 페이지네이션 컨테이너 표시
-     *
-     * 버튼 비활성화 시:
-     * - disabled 속성 추가
-     * - CSS에서 투명도 낮추고 cursor: not-allowed 적용
+     * PaginationUtil을 사용하여 숫자 페이지 네비게이션을 렌더링합니다.
+     * - 현재 페이지, 전체 페이지, 전체 아이템 개수를 표시
+     * - 페이지 클릭 시 goToPage 함수 호출
+     * - « ‹ 1 2 3 4 5 › » 형태의 버튼 렌더링
      */
     function updatePagination() {
-        currentPageSpan.textContent = currentPage;
-        totalPagesSpan.textContent = totalPages;
-        totalCountSpan.textContent = totalCount;
-
-        // 이전 버튼 활성화/비활성화
-        prevBtn.disabled = currentPage <= 1;
-
-        // 다음 버튼 활성화/비활성화
-        nextBtn.disabled = currentPage >= totalPages;
-
-        // 페이지네이션 표시
-        paginationContainer.style.display = 'flex';
+        PaginationUtil.render(
+            paginationContainer,
+            currentPage,
+            totalPages,
+            totalCount,
+            goToPage
+        );
     }
 
     // ======================================================================
@@ -348,11 +333,14 @@ document.addEventListener('DOMContentLoaded', function() {
 
     /**
      * 페이지 이동
+     *
      * @param {number} page - 이동할 페이지 번호
      *
+     * 동작:
      * - 유효성 검사: page가 1 ~ totalPages 범위 내인지 확인
      * - 범위를 벗어나면 무시 (아무 동작도 하지 않음)
      * - 유효한 경우 currentPage를 업데이트하고 데이터 재로드
+     * - PaginationUtil에서 페이지 버튼 클릭 시 이 함수가 호출됨
      */
     function goToPage(page) {
         if (page < 1 || page > totalPages) {
@@ -361,24 +349,6 @@ document.addEventListener('DOMContentLoaded', function() {
         currentPage = page;
         loadHosts();
     }
-
-    /**
-     * 이전 페이지로 이동
-     * - window 객체에 할당하여 HTML의 onclick에서 호출 가능하게 함
-     * - 현재 페이지 - 1로 이동
-     */
-    window.goToPreviousPage = function() {
-        goToPage(currentPage - 1);
-    };
-
-    /**
-     * 다음 페이지로 이동
-     * - window 객체에 할당하여 HTML의 onclick에서 호출 가능하게 함
-     * - 현재 페이지 + 1로 이동
-     */
-    window.goToNextPage = function() {
-        goToPage(currentPage + 1);
-    };
 
     // ======================================================================
     // 유틸리티 함수
@@ -453,12 +423,12 @@ document.addEventListener('DOMContentLoaded', function() {
         // 좌측 화살표: 이전 페이지
         if (event.key === 'ArrowLeft' && currentPage > 1) {
             event.preventDefault();
-            goToPreviousPage();
+            goToPage(currentPage - 1);
         }
         // 우측 화살표: 다음 페이지
         else if (event.key === 'ArrowRight' && currentPage < totalPages) {
             event.preventDefault();
-            goToNextPage();
+            goToPage(currentPage + 1);
         }
     });
 

--- a/backend/forgather/src/main/resources/static/js/admin/login.js
+++ b/backend/forgather/src/main/resources/static/js/admin/login.js
@@ -3,7 +3,7 @@
  * 로그인 폼 처리 및 인증 로직
  */
 
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('DOMContentLoaded', function () {
     // 이미 로그인된 경우 spaces 페이지로 리다이렉트
     if (Auth.isAuthenticated() && !Auth.isAccessTokenExpired()) {
         window.location.href = '/view/admin/spaces';
@@ -116,8 +116,6 @@ document.addEventListener('DOMContentLoaded', function() {
             Auth.setAccessToken(response.accessToken);
             Auth.setRefreshToken(response.refreshToken);
 
-            console.log('Login successful');
-
             // Spaces 페이지로 리다이렉트
             window.location.href = '/view/admin/spaces';
 
@@ -140,7 +138,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // Enter 키 처리
     [usernameInput, passwordInput].forEach(input => {
-        input.addEventListener('keypress', function(event) {
+        input.addEventListener('keypress', function (event) {
             if (event.key === 'Enter') {
                 event.preventDefault();
                 loginForm.dispatchEvent(new Event('submit'));

--- a/backend/forgather/src/main/resources/static/js/admin/pagination.js
+++ b/backend/forgather/src/main/resources/static/js/admin/pagination.js
@@ -1,0 +1,185 @@
+/**
+ * Pagination Utility Module
+ * 숫자 페이지 네비게이션을 렌더링하는 공통 유틸리티
+ *
+ * 주요 기능:
+ * - 숫자 페이지 버튼 렌더링 (1 2 3 4 5)
+ * - 이전/다음 페이지 버튼
+ * - 첫 페이지/마지막 페이지 이동 버튼
+ * - 현재 페이지 강조 표시
+ * - 페이지가 많을 경우 표시 범위 제한
+ */
+
+const PaginationUtil = {
+    /**
+     * 페이지네이션 UI를 렌더링한다
+     *
+     * @param {HTMLElement} container - 페이지네이션을 렌더링할 DOM 요소
+     * @param {number} currentPage - 현재 페이지 번호 (1-based)
+     * @param {number} totalPages - 전체 페이지 수
+     * @param {number} totalCount - 전체 아이템 개수
+     * @param {function} onPageClick - 페이지 클릭 시 호출될 콜백 함수 (pageNumber를 인자로 받음)
+     * @param {object} options - 추가 옵션
+     * @param {number} options.maxPageButtons - 표시할 최대 페이지 버튼 개수 (기본값: 5)
+     *
+     * 페이지 번호 표시 로직:
+     * - 전체 페이지가 5개 이하면 모두 표시: [1] [2] [3] [4] [5]
+     * - 현재 페이지 기준 앞뒤 2개씩 표시
+     *   - 현재 페이지가 1~3: [1] [2] [3] [4] [5]
+     *   - 현재 페이지가 중간: [3] [4] [5] [6] [7]
+     *   - 현재 페이지가 끝부분: [6] [7] [8] [9] [10]
+     *
+     * 버튼 구성:
+     * - « (첫 페이지로)
+     * - ‹ (이전 페이지)
+     * - 숫자 버튼들 (1 2 3 4 5)
+     * - › (다음 페이지)
+     * - » (마지막 페이지로)
+     *
+     * 주의사항:
+     * - API는 1-based 페이지를 사용 (서버에서 0-based를 1-based로 변환하여 응답)
+     * - UI도 1-based로 표시
+     */
+    render(container, currentPage, totalPages, totalCount, onPageClick, options = {}) {
+        // 옵션 기본값 설정
+        const maxPageButtons = options.maxPageButtons || 5;
+
+        // 컨테이너 초기화
+        container.innerHTML = '';
+
+        // 데이터가 없으면 페이지네이션 숨김
+        if (totalPages === 0) {
+            container.style.display = 'none';
+            return;
+        }
+
+        // 페이지네이션 표시
+        container.style.display = 'flex';
+
+        // 페이지 번호 범위 계산
+        const pageRange = this._calculatePageRange(currentPage, totalPages, maxPageButtons);
+
+        // 버튼 컨테이너 생성
+        const buttonsContainer = document.createElement('div');
+        buttonsContainer.className = 'pagination-buttons';
+
+        // 첫 페이지로 이동 버튼 (currentPage > 1일 때만 활성화)
+        const firstBtn = this._createButton('«', currentPage === 1, () => onPageClick(1));
+        firstBtn.setAttribute('aria-label', '첫 페이지로 이동');
+        buttonsContainer.appendChild(firstBtn);
+
+        // 이전 페이지 버튼
+        const prevBtn = this._createButton('‹', currentPage === 1, () => onPageClick(currentPage - 1));
+        prevBtn.setAttribute('aria-label', '이전 페이지');
+        buttonsContainer.appendChild(prevBtn);
+
+        // 숫자 페이지 버튼들
+        for (let page = pageRange.start; page <= pageRange.end; page++) {
+            const isActive = page === currentPage;
+            const pageBtn = this._createButton(
+                page.toString(),
+                false,
+                () => onPageClick(page),
+                isActive
+            );
+            pageBtn.setAttribute('aria-label', `${page}페이지로 이동`);
+            if (isActive) {
+                pageBtn.setAttribute('aria-current', 'page');
+            }
+            buttonsContainer.appendChild(pageBtn);
+        }
+
+        // 다음 페이지 버튼
+        const nextBtn = this._createButton('›', currentPage === totalPages, () => onPageClick(currentPage + 1));
+        nextBtn.setAttribute('aria-label', '다음 페이지');
+        buttonsContainer.appendChild(nextBtn);
+
+        // 마지막 페이지로 이동 버튼
+        const lastBtn = this._createButton('»', currentPage === totalPages, () => onPageClick(totalPages));
+        lastBtn.setAttribute('aria-label', '마지막 페이지로 이동');
+        buttonsContainer.appendChild(lastBtn);
+
+        // 페이지 정보 표시 (Page 1 of 10 (Total: 150 items))
+        const infoContainer = document.createElement('div');
+        infoContainer.className = 'pagination-info';
+        infoContainer.innerHTML = `
+            Page <strong>${currentPage}</strong> of <strong>${totalPages}</strong>
+            (Total: <strong>${totalCount.toLocaleString()}</strong> items)
+        `;
+
+        // DOM에 추가
+        container.appendChild(buttonsContainer);
+        container.appendChild(infoContainer);
+    },
+
+    /**
+     * 표시할 페이지 번호 범위를 계산한다
+     *
+     * @param {number} currentPage - 현재 페이지
+     * @param {number} totalPages - 전체 페이지 수
+     * @param {number} maxButtons - 표시할 최대 버튼 개수
+     * @returns {object} { start: 시작 페이지, end: 끝 페이지 }
+     *
+     * 계산 로직:
+     * 1. 전체 페이지가 maxButtons 이하면 모두 표시
+     * 2. 현재 페이지가 시작 부분이면 1부터 maxButtons까지
+     * 3. 현재 페이지가 끝 부분이면 (totalPages - maxButtons + 1)부터 totalPages까지
+     * 4. 현재 페이지가 중간이면 현재 페이지 기준 앞뒤로 배치
+     */
+    _calculatePageRange(currentPage, totalPages, maxButtons) {
+        // 전체 페이지가 최대 버튼 개수 이하면 모두 표시
+        if (totalPages <= maxButtons) {
+            return { start: 1, end: totalPages };
+        }
+
+        // 현재 페이지 기준으로 앞뒤로 몇 개씩 표시할지 계산
+        const half = Math.floor(maxButtons / 2);
+        let start = currentPage - half;
+        let end = currentPage + half;
+
+        // 시작이 1보다 작으면 조정
+        if (start < 1) {
+            start = 1;
+            end = maxButtons;
+        }
+
+        // 끝이 totalPages보다 크면 조정
+        if (end > totalPages) {
+            end = totalPages;
+            start = totalPages - maxButtons + 1;
+        }
+
+        return { start, end };
+    },
+
+    /**
+     * 페이지네이션 버튼을 생성한다
+     *
+     * @param {string} text - 버튼에 표시할 텍스트
+     * @param {boolean} disabled - 비활성화 여부
+     * @param {function} onClick - 클릭 이벤트 핸들러
+     * @param {boolean} active - 활성 상태 여부 (현재 페이지)
+     * @returns {HTMLButtonElement} 생성된 버튼 요소
+     */
+    _createButton(text, disabled, onClick, active = false) {
+        const button = document.createElement('button');
+        button.className = 'pagination-btn';
+        button.textContent = text;
+        button.disabled = disabled;
+
+        // 현재 페이지는 active 클래스 추가
+        if (active) {
+            button.classList.add('active');
+        }
+
+        // 비활성화되지 않은 버튼에만 이벤트 리스너 추가
+        if (!disabled) {
+            button.addEventListener('click', onClick);
+        }
+
+        return button;
+    }
+};
+
+// 전역 객체로 노출
+window.PaginationUtil = PaginationUtil;

--- a/backend/forgather/src/main/resources/static/js/admin/spaces.js
+++ b/backend/forgather/src/main/resources/static/js/admin/spaces.js
@@ -9,6 +9,23 @@ let currentPageSize = 15;
 let totalPages = 1;
 let totalCount = 0;
 
+/**
+ * 현재 선택된 필터 상태를 관리하는 객체
+ *
+ * 필터 조건 확장 가이드:
+ * - 새로운 필터를 추가할 때는 이 객체에 프로퍼티를 추가한다.
+ * - 예: { hasProduct: true, isPublic: true, hostName: '홍길동' }
+ * - 각 프로퍼티의 초기값은 null 또는 적절한 기본값으로 설정
+ *
+ * hasProduct 필터 값:
+ * - null: 전체 (필터 없음)
+ * - true: 작품 소개 등록함
+ * - false: 작품 소개 등록하지 않음
+ */
+const filterState = {
+    hasProduct: null
+};
+
 document.addEventListener('DOMContentLoaded', function() {
     // 인증 확인
     if (!Auth.requireAuth()) {
@@ -197,14 +214,59 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     /**
+     * 필터 조건 유무를 확인한다
+     *
+     * @returns {boolean} 필터 조건이 하나라도 있으면 true, 모두 없으면 false
+     *
+     * 동작:
+     * - filterState 객체의 모든 프로퍼티를 확인
+     * - null이 아닌 값이 하나라도 있으면 필터가 설정된 것으로 판단
+     * - 모든 값이 null이면 필터 없음 (전체 조회)
+     *
+     * 확장 포인트:
+     * - 새로운 필터를 추가해도 이 함수는 수정할 필요 없음
+     * - filterState 객체만 업데이트하면 자동으로 처리됨
+     */
+    function hasActiveFilters() {
+        return Object.values(filterState).some(value => value !== null);
+    }
+
+    /**
      * Space 목록 로드
+     *
+     * 호출 시점:
+     * - 페이지 최초 로드 (DOMContentLoaded)
+     * - 필터 검색 버튼 클릭 (applyFilter)
+     * - 페이지 크기 변경 (handlePageSizeChange)
+     * - 페이지네이션 버튼 클릭 (goToPage)
+     *
+     * API 엔드포인트 분기 규칙:
+     * - 필터 조건이 하나라도 있으면 → /admin/spaces/search
+     * - 필터 조건이 없으면 (전체) → /admin/spaces
+     *
+     * 동작 흐름:
+     * 1. 필터 조건 유무 확인 (hasActiveFilters)
+     * 2. 조건에 따라 적절한 API 호출
+     * 3. 응답 데이터로 테이블 렌더링
+     * 4. 페이지네이션 UI 업데이트
      */
     async function loadSpaces() {
         hideError();
         showLoading();
 
         try {
-            const response = await API.getSpaces(currentPage, currentPageSize);
+            let response;
+
+            // 필터 조건이 있는지 확인
+            if (hasActiveFilters()) {
+                // 필터링 API 호출 (/admin/spaces/search)
+                console.log('[Filter] 필터 조건 적용:', filterState);
+                response = await API.getSpacesByFilters(currentPage, currentPageSize, filterState);
+            } else {
+                // 전체 조회 API 호출 (/admin/spaces)
+                console.log('[Filter] 필터 없음 - 전체 조회');
+                response = await API.getSpaces(currentPage, currentPageSize);
+            }
 
             // 상태 업데이트
             currentPage = response.currentPage;
@@ -278,9 +340,60 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
+    /**
+     * 필터 적용 함수
+     *
+     * 호출 시점:
+     * - 사용자가 필터를 선택하고 [검색] 버튼을 클릭했을 때
+     *
+     * 동작 흐름:
+     * 1. HTML에서 선택된 radio 버튼의 value를 읽어온다
+     * 2. value를 적절한 타입으로 변환 ('all' → null, 'true' → true, 'false' → false)
+     * 3. filterState 객체에 저장
+     * 4. 페이지를 1페이지로 초기화 (필터 변경 시 항상 첫 페이지부터 시작)
+     * 5. loadSpaces() 호출하여 목록 갱신
+     *
+     * 확장 포인트:
+     * - 새로운 필터를 추가할 때 이 함수에서 해당 필터 값을 읽어서 filterState에 추가
+     * - 예시:
+     *   ```javascript
+     *   const isPublic = document.querySelector('input[name="isPublic"]:checked').value;
+     *   filterState.isPublic = isPublic === 'all' ? null : isPublic === 'true';
+     *   ```
+     */
+    function applyFilter() {
+        // hasProduct 필터 값 읽기
+        const hasProductValue = document.querySelector('input[name="hasProduct"]:checked').value;
+
+        // 값 변환 및 filterState 업데이트
+        if (hasProductValue === 'all') {
+            filterState.hasProduct = null; // 전체
+        } else if (hasProductValue === 'true') {
+            filterState.hasProduct = true; // 등록함
+        } else if (hasProductValue === 'false') {
+            filterState.hasProduct = false; // 등록하지 않음
+        }
+
+        // 필터 변경 시 페이지를 1페이지로 초기화
+        currentPage = 1;
+
+        // 목록 갱신
+        loadSpaces();
+
+        // 디버깅 로그
+        console.log('[Filter] 필터 적용됨:', filterState);
+    }
+
     // 이벤트 리스너 등록
     pageSizeSelect.addEventListener('change', handlePageSizeChange);
     logoutBtn.addEventListener('click', handleLogout);
+
+    /**
+     * 필터 검색 버튼 클릭 이벤트 리스너
+     * - [검색] 버튼 클릭 시 필터 적용 함수 호출
+     */
+    const applyFilterBtn = document.getElementById('applyFilterBtn');
+    applyFilterBtn.addEventListener('click', applyFilter);
 
     /**
      * 키보드 네비게이션

--- a/backend/forgather/src/main/resources/static/js/admin/spaces.js
+++ b/backend/forgather/src/main/resources/static/js/admin/spaces.js
@@ -21,11 +21,6 @@ document.addEventListener('DOMContentLoaded', function() {
     const errorMessage = document.getElementById('errorMessage');
     const pageSizeSelect = document.getElementById('pageSize');
     const paginationContainer = document.getElementById('pagination');
-    const currentPageSpan = document.getElementById('currentPage');
-    const totalPagesSpan = document.getElementById('totalPages');
-    const totalCountSpan = document.getElementById('totalCount');
-    const prevBtn = document.getElementById('prevBtn');
-    const nextBtn = document.getElementById('nextBtn');
     const logoutBtn = document.getElementById('logoutBtn');
 
     /**
@@ -186,20 +181,19 @@ document.addEventListener('DOMContentLoaded', function() {
 
     /**
      * 페이지네이션 UI 업데이트
+     *
+     * PaginationUtil을 사용하여 숫자 페이지 네비게이션을 렌더링합니다.
+     * - 현재 페이지, 전체 페이지, 전체 아이템 개수를 표시
+     * - 페이지 클릭 시 goToPage 함수 호출
      */
     function updatePagination() {
-        currentPageSpan.textContent = currentPage;
-        totalPagesSpan.textContent = totalPages;
-        totalCountSpan.textContent = totalCount;
-
-        // 이전 버튼 활성화/비활성화
-        prevBtn.disabled = currentPage <= 1;
-
-        // 다음 버튼 활성화/비활성화
-        nextBtn.disabled = currentPage >= totalPages;
-
-        // 페이지네이션 표시
-        paginationContainer.style.display = 'flex';
+        PaginationUtil.render(
+            paginationContainer,
+            currentPage,
+            totalPages,
+            totalCount,
+            goToPage
+        );
     }
 
     /**
@@ -234,7 +228,13 @@ document.addEventListener('DOMContentLoaded', function() {
 
     /**
      * 페이지 이동
+     *
      * @param {number} page - 이동할 페이지 번호
+     *
+     * 동작:
+     * - 유효한 페이지 범위인지 확인 (1 ~ totalPages)
+     * - 유효하면 currentPage를 업데이트하고 데이터 재로드
+     * - PaginationUtil에서 페이지 버튼 클릭 시 이 함수가 호출됨
      */
     function goToPage(page) {
         if (page < 1 || page > totalPages) {
@@ -243,20 +243,6 @@ document.addEventListener('DOMContentLoaded', function() {
         currentPage = page;
         loadSpaces();
     }
-
-    /**
-     * 이전 페이지로 이동
-     */
-    window.goToPreviousPage = function() {
-        goToPage(currentPage - 1);
-    };
-
-    /**
-     * 다음 페이지로 이동
-     */
-    window.goToNextPage = function() {
-        goToPage(currentPage + 1);
-    };
 
     /**
      * HTML 이스케이프 (XSS 방지)
@@ -296,17 +282,23 @@ document.addEventListener('DOMContentLoaded', function() {
     pageSizeSelect.addEventListener('change', handlePageSizeChange);
     logoutBtn.addEventListener('click', handleLogout);
 
-    // 키보드 네비게이션
+    /**
+     * 키보드 네비게이션
+     * - 좌측 화살표: 이전 페이지
+     * - 우측 화살표: 다음 페이지
+     *
+     * 접근성 향상을 위한 기능
+     */
     document.addEventListener('keydown', function(event) {
         // 좌측 화살표: 이전 페이지
         if (event.key === 'ArrowLeft' && currentPage > 1) {
             event.preventDefault();
-            goToPreviousPage();
+            goToPage(currentPage - 1);
         }
         // 우측 화살표: 다음 페이지
         else if (event.key === 'ArrowRight' && currentPage < totalPages) {
             event.preventDefault();
-            goToNextPage();
+            goToPage(currentPage + 1);
         }
     });
 

--- a/backend/forgather/src/main/resources/static/js/admin/spaces.js
+++ b/backend/forgather/src/main/resources/static/js/admin/spaces.js
@@ -387,7 +387,9 @@ document.addEventListener('DOMContentLoaded', function () {
      * - [검색] 버튼 클릭 시 필터 적용 함수 호출
      */
     const applyFilterBtn = document.getElementById('applyFilterBtn');
-    applyFilterBtn.addEventListener('click', applyFilter);
+    if (applyFilterBtn) {
+        applyFilterBtn.addEventListener('click', applyFilter);
+    }
 
     /**
      * 키보드 네비게이션

--- a/backend/forgather/src/main/resources/static/js/admin/spaces.js
+++ b/backend/forgather/src/main/resources/static/js/admin/spaces.js
@@ -360,17 +360,16 @@ document.addEventListener('DOMContentLoaded', function () {
      *   ```
      */
     function applyFilter() {
-        // hasProduct 필터 값 읽기
-        const hasProductValue = document.querySelector('input[name="hasProduct"]:checked').value;
+        // Optional Chaining (?.)으로 안전하게 접근 후, Nullish Coalescing (??)으로 기본값 설정
+        const hasProductValue = document.querySelector('input[name="hasProduct"]:checked')?.value ?? 'all';
 
-        // 값 변환 및 filterState 업데이트
-        if (hasProductValue === 'all') {
-            filterState.hasProduct = null; // 전체
-        } else if (hasProductValue === 'true') {
-            filterState.hasProduct = true; // 등록함
-        } else if (hasProductValue === 'false') {
-            filterState.hasProduct = false; // 등록하지 않음
-        }
+        // 매핑 로직 개선 (객체 리터럴 활용으로 if-else 제거)
+        const filterMap = {
+            'all': null,
+            'true': true,
+            'false': false
+        };
+        filterState.hasProduct = filterMap[hasProductValue];
 
         // 필터 변경 시 페이지를 1페이지로 초기화
         currentPage = 1;

--- a/backend/forgather/src/main/resources/static/js/admin/spaces.js
+++ b/backend/forgather/src/main/resources/static/js/admin/spaces.js
@@ -509,7 +509,12 @@ document.addEventListener('DOMContentLoaded', function() {
 
     /**
      * 모달에 스페이스 상세 정보 표시
-     * @param {object} data - API 응답 데이터 (space, hasProduct, guestBookCount)
+     *
+     * API: GET /admin/spaces/{spaceCode}
+     * @param {object} data - API 응답 데이터 (SpaceDetailResponse)
+     * @param {object} data.space - 스페이스 기본 정보 (SimpleSpaceResponse)
+     * @param {number} data.productCount - 등록한 작품 소개 개수
+     * @param {number} data.guestBookCount - 방명록 개수
      */
     function showModalContent(data) {
         resetModalContent();
@@ -525,11 +530,15 @@ document.addEventListener('DOMContentLoaded', function() {
             : '<span class="badge badge-danger">Private</span>';
         modalSpacePublic.innerHTML = publicBadge;
 
-        // 작품 소개 등록 여부 표시
-        const hasProductText = data.hasProduct
-            ? '<span style="color: var(--success-color); font-weight: 600;">Registered</span>'
-            : '<span style="color: var(--text-muted);">Not Registered</span>';
-        modalHasProduct.innerHTML = hasProductText;
+        /**
+         * 작품 소개 등록 상태 표시
+         * - productCount가 0: "작품 소개를 등록하지 않음" (회색 텍스트)
+         * - productCount가 1 이상: "등록한 작품 소개 N개" (녹색 텍스트, 숫자 포맷팅 적용)
+         */
+        const productStatusText = data.productCount === 0
+            ? '<span style="color: var(--text-muted);">작품 소개를 등록하지 않음</span>'
+            : `<span style="color: var(--success-color); font-weight: 600;">${data.productCount.toLocaleString()}개</span>`;
+        modalHasProduct.innerHTML = productStatusText;
 
         // 방명록 개수 표시 (숫자 포맷팅)
         modalGuestBookCount.textContent = data.guestBookCount.toLocaleString();

--- a/backend/forgather/src/main/resources/static/js/admin/spaces.js
+++ b/backend/forgather/src/main/resources/static/js/admin/spaces.js
@@ -26,7 +26,7 @@ const filterState = {
     hasProduct: null
 };
 
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('DOMContentLoaded', function () {
     // 인증 확인
     if (!Auth.requireAuth()) {
         return;
@@ -260,11 +260,9 @@ document.addEventListener('DOMContentLoaded', function() {
             // 필터 조건이 있는지 확인
             if (hasActiveFilters()) {
                 // 필터링 API 호출 (/admin/spaces/search)
-                console.log('[Filter] 필터 조건 적용:', filterState);
                 response = await API.getSpacesByFilters(currentPage, currentPageSize, filterState);
             } else {
                 // 전체 조회 API 호출 (/admin/spaces)
-                console.log('[Filter] 필터 없음 - 전체 조회');
                 response = await API.getSpaces(currentPage, currentPageSize);
             }
 
@@ -379,9 +377,6 @@ document.addEventListener('DOMContentLoaded', function() {
 
         // 목록 갱신
         loadSpaces();
-
-        // 디버깅 로그
-        console.log('[Filter] 필터 적용됨:', filterState);
     }
 
     // 이벤트 리스너 등록
@@ -402,7 +397,7 @@ document.addEventListener('DOMContentLoaded', function() {
      *
      * 접근성 향상을 위한 기능
      */
-    document.addEventListener('keydown', function(event) {
+    document.addEventListener('keydown', function (event) {
         // 좌측 화살표: 이전 페이지
         if (event.key === 'ArrowLeft' && currentPage > 1) {
             event.preventDefault();
@@ -634,7 +629,7 @@ document.addEventListener('DOMContentLoaded', function() {
      * 3. Code 컬럼이면 data-space-code 속성에서 spaceCode를 읽어옴
      * 4. loadSpaceDetail 함수를 호출하여 모달 표시
      */
-    spacesTableBody.addEventListener('click', function(event) {
+    spacesTableBody.addEventListener('click', function (event) {
         // 클릭된 요소가 td인지, 그리고 두 번째 컬럼(Code)인지 확인
         const target = event.target;
 
@@ -662,7 +657,7 @@ document.addEventListener('DOMContentLoaded', function() {
      * - currentOpenSpaceCode는 모달을 열 때 설정됨 (loadSpaceDetail 함수)
      * - URL 생성은 getSpacePageUrl 함수가 담당 (환경별 도메인 처리)
      */
-    visitSpaceBtn.addEventListener('click', function() {
+    visitSpaceBtn.addEventListener('click', function () {
         if (currentOpenSpaceCode) {
             const url = getSpacePageUrl(currentOpenSpaceCode);
             window.open(url, '_blank', 'noopener,noreferrer');
@@ -672,7 +667,7 @@ document.addEventListener('DOMContentLoaded', function() {
     /**
      * 모달 닫기 버튼 클릭 핸들러
      */
-    closeModalBtn.addEventListener('click', function() {
+    closeModalBtn.addEventListener('click', function () {
         closeModal();
     });
 
@@ -686,7 +681,7 @@ document.addEventListener('DOMContentLoaded', function() {
      * - event.currentTarget: 이벤트 리스너가 등록된 요소 (항상 modal)
      * - 둘이 같다는 것은 오버레이를 직접 클릭했다는 의미
      */
-    modal.addEventListener('click', function(event) {
+    modal.addEventListener('click', function (event) {
         if (event.target === modal) {
             closeModal();
         }
@@ -697,7 +692,7 @@ document.addEventListener('DOMContentLoaded', function() {
      * - 키보드 접근성 향상
      * - 모달이 열려있을 때만 동작 (modal.classList.contains('show'))
      */
-    document.addEventListener('keydown', function(event) {
+    document.addEventListener('keydown', function (event) {
         if (event.key === 'Escape' && modal.classList.contains('show')) {
             closeModal();
         }

--- a/backend/forgather/src/main/resources/templates/admin/hosts/list.html
+++ b/backend/forgather/src/main/resources/templates/admin/hosts/list.html
@@ -110,25 +110,11 @@
 
             <!--
                 Pagination
-                - 페이지네이션 컨트롤을 제공합니다.
-                - 이전/다음 버튼과 현재 페이지 정보를 표시합니다.
-                - JavaScript에서 버튼 활성화/비활성화를 제어합니다.
+                - 숫자 페이지 네비게이션을 제공합니다.
+                - JavaScript의 PaginationUtil을 사용하여 동적으로 렌더링됩니다.
                 - 기본적으로 숨김 상태이며, 데이터 로드 후 표시됩니다.
             -->
-            <div class="pagination" id="pagination" style="display: none;">
-                <button class="pagination-btn" id="prevBtn" onclick="goToPreviousPage()">
-                    Previous
-                </button>
-
-                <span class="pagination-info">
-                    Page <span id="currentPage">1</span> of <span id="totalPages">1</span>
-                    (Total: <span id="totalCount">0</span> items)
-                </span>
-
-                <button class="pagination-btn" id="nextBtn" onclick="goToNextPage()">
-                    Next
-                </button>
-            </div>
+            <div class="pagination" id="pagination" style="display: none;"></div>
         </div>
     </main>
 
@@ -151,15 +137,18 @@
         Scripts
         - auth.js: 인증 관련 유틸리티 (토큰 관리, 로그인 체크)
         - api.js: API 호출 유틸리티 (fetch 래퍼, 401 자동 처리)
+        - pagination.js: 페이지네이션 렌더링 유틸리티
         - hosts.js: 호스트 목록 페이지 로직 (데이터 로딩, 테이블 렌더링, 페이지네이션)
 
         순서가 중요합니다:
         1. auth.js가 먼저 로드되어 Auth 전역 객체 생성
         2. api.js가 Auth를 사용하여 API 전역 객체 생성
-        3. hosts.js가 API를 사용하여 데이터 로드
+        3. pagination.js가 PaginationUtil 전역 객체 생성
+        4. hosts.js가 API와 PaginationUtil을 사용하여 데이터 로드 및 렌더링
     -->
     <script th:src="@{/js/admin/auth.js}"></script>
     <script th:src="@{/js/admin/api.js}"></script>
+    <script th:src="@{/js/admin/pagination.js}"></script>
     <script th:src="@{/js/admin/hosts.js}"></script>
 </body>
 </html>

--- a/backend/forgather/src/main/resources/templates/admin/spaces/list.html
+++ b/backend/forgather/src/main/resources/templates/admin/spaces/list.html
@@ -46,6 +46,43 @@
 
             <!-- Controls -->
             <div class="controls">
+                <!--
+                    필터 영역
+                    - 작품 소개 등록 여부에 따른 필터링 기능
+                    - radio 버튼으로 단일 선택 제공
+                    - 향후 다른 필터 조건 추가 시 filter-group을 복사하여 확장
+                -->
+                <div class="filter-section">
+                    <!--
+                        작품 소개 등록 여부 필터 그룹
+                        - name 속성을 동일하게 하여 radio 그룹화
+                        - value: 'all' (전체), 'true' (등록함), 'false' (미등록)
+                        - 기본값은 'all' (checked 속성)
+                    -->
+                    <div class="filter-group">
+                        <label class="filter-label">작품 소개 등록 여부:</label>
+                        <label class="filter-radio-label">
+                            <input type="radio" name="hasProduct" value="all" checked>
+                            <span>전체</span>
+                        </label>
+                        <label class="filter-radio-label">
+                            <input type="radio" name="hasProduct" value="true">
+                            <span>등록함</span>
+                        </label>
+                        <label class="filter-radio-label">
+                            <input type="radio" name="hasProduct" value="false">
+                            <span>등록하지 않음</span>
+                        </label>
+                    </div>
+
+                    <!--
+                        검색 버튼
+                        - 필터 선택 후 이 버튼을 클릭해야 필터가 적용됨
+                        - JavaScript의 applyFilter() 함수 호출
+                    -->
+                    <button type="button" class="btn-filter" id="applyFilterBtn">검색</button>
+                </div>
+
                 <div class="page-size-selector">
                     <label for="pageSize">Items per page:</label>
                     <select id="pageSize" class="form-select">

--- a/backend/forgather/src/main/resources/templates/admin/spaces/list.html
+++ b/backend/forgather/src/main/resources/templates/admin/spaces/list.html
@@ -187,7 +187,7 @@
                     </div>
 
                     <div class="modal-info-group">
-                        <label class="modal-info-label">작품 소개 등록 여부</label>
+                        <label class="modal-info-label">등록한 작품 소개</label>
                         <div id="modalHasProduct" class="modal-info-value"></div>
                     </div>
 

--- a/backend/forgather/src/main/resources/templates/admin/spaces/list.html
+++ b/backend/forgather/src/main/resources/templates/admin/spaces/list.html
@@ -84,21 +84,8 @@
                 </table>
             </div>
 
-            <!-- Pagination -->
-            <div class="pagination" id="pagination" style="display: none;">
-                <button class="pagination-btn" id="prevBtn" onclick="goToPreviousPage()">
-                    Previous
-                </button>
-
-                <span class="pagination-info">
-                    Page <span id="currentPage">1</span> of <span id="totalPages">1</span>
-                    (Total: <span id="totalCount">0</span> items)
-                </span>
-
-                <button class="pagination-btn" id="nextBtn" onclick="goToNextPage()">
-                    Next
-                </button>
-            </div>
+            <!-- Pagination: JavaScript에서 숫자 버튼들을 동적으로 생성 -->
+            <div class="pagination" id="pagination" style="display: none;"></div>
         </div>
     </main>
 
@@ -186,6 +173,7 @@
     <!-- Scripts -->
     <script th:src="@{/js/admin/auth.js}"></script>
     <script th:src="@{/js/admin/api.js}"></script>
+    <script th:src="@{/js/admin/pagination.js}"></script>
     <script th:src="@{/js/admin/spaces.js}"></script>
 </body>
 </html>

--- a/backend/forgather/src/test/java/com/forgather/acceptance/AdminSpaceAcceptanceTest.java
+++ b/backend/forgather/src/test/java/com/forgather/acceptance/AdminSpaceAcceptanceTest.java
@@ -232,10 +232,95 @@ class AdminSpaceAcceptanceTest extends AcceptanceTest {
         assertThat(result.statusCode()).isEqualTo(HttpStatus.FORBIDDEN.value());
     }
 
+    @DisplayName("작품 소개가 등록된 모든 스페이스를 조회한다.")
+    @Test
+    void getSpacesHasProduct() {
+        // given
+        createSpacesWithProduct(16);
+        createSpaces(4);
+
+        // when
+        AdminSpaceResponse result = RestAssuredMockMvc.given()
+            .headers("Authorization", "Bearer " + accessToken)
+            .queryParam("hasProduct", true)
+            .when()
+            .get("/admin/spaces/search")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .extract()
+            .body()
+            .as(AdminSpaceResponse.class);
+
+        // then
+        assertAll(
+            () -> assertThat(result.spaces()).hasSize(15),
+            () -> assertThat(result.currentPage()).isEqualTo(1),
+            () -> assertThat(result.pageSize()).isEqualTo(15),
+            () -> assertThat(result.totalCount()).isEqualTo(16),
+            () -> assertThat(result.totalPages()).isEqualTo(2)
+        );
+    }
+
+    @DisplayName("작품 소개가 등록되지 않은 모든 스페이스를 조회한다.")
+    @Test
+    void getSpacesHasNoProduct() {
+        // given
+        createSpaces(16);
+        createSpacesWithProduct(4);
+
+        // when
+        AdminSpaceResponse result = RestAssuredMockMvc.given()
+            .headers("Authorization", "Bearer " + accessToken)
+            .queryParam("hasProduct", false)
+            .when()
+            .get("/admin/spaces/search")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .extract()
+            .body()
+            .as(AdminSpaceResponse.class);
+
+        // then
+        assertAll(
+            () -> assertThat(result.spaces()).hasSize(15),
+            () -> assertThat(result.currentPage()).isEqualTo(1),
+            () -> assertThat(result.pageSize()).isEqualTo(15),
+            () -> assertThat(result.totalCount()).isEqualTo(16),
+            () -> assertThat(result.totalPages()).isEqualTo(2)
+        );
+    }
+
+    @DisplayName("어드민 유저가 아니면 필터링된 스페이스 목록을 조회할 수 없다.")
+    @Test
+    void getSpacesByFilterWithNonAdminUser() {
+        // given
+        String hostAccessToken = jwtTokenProvider.generateAccessToken(host.getId());
+
+        // when
+        var result = RestAssuredMockMvc.given()
+            .headers("Authorization", "Bearer " + hostAccessToken)
+            .queryParam("hasProduct", true)
+            .when()
+            .get("/admin/spaces/search")
+            .then()
+            .extract();
+
+        // then
+        assertThat(result.statusCode()).isEqualTo(HttpStatus.FORBIDDEN.value());
+    }
+
     private void createSpaces(int count) {
         for (int i = 0; i < count; i++) {
             Space space = spaceRepository.save(SpaceFixture.createSpace());
             spaceHostMapRepository.save(new SpaceHostMap(space, host));
+        }
+    }
+
+    private void createSpacesWithProduct(int count) {
+        for (int i = 0; i < count; i++) {
+            Space space = spaceRepository.save(SpaceFixture.createSpace());
+            spaceHostMapRepository.save(new SpaceHostMap(space, host));
+            productRepository.save(ProductFixture.createProductWithSpace(space));
         }
     }
 }

--- a/backend/forgather/src/test/java/com/forgather/acceptance/AdminSpaceAcceptanceTest.java
+++ b/backend/forgather/src/test/java/com/forgather/acceptance/AdminSpaceAcceptanceTest.java
@@ -32,6 +32,7 @@ import com.forgather.global.auth.model.Host;
 import com.forgather.global.auth.model.SpaceHostMap;
 import com.forgather.global.auth.repository.SpaceHostMapRepository;
 import com.forgather.global.auth.util.JwtTokenProvider;
+import com.forgather.global.util.RandomCodeGenerator;
 
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
 
@@ -64,6 +65,9 @@ class AdminSpaceAcceptanceTest extends AcceptanceTest {
 
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private RandomCodeGenerator randomCodeGenerator;
 
     private AdminUser adminUser;
     private String accessToken;
@@ -311,10 +315,7 @@ class AdminSpaceAcceptanceTest extends AcceptanceTest {
 
     private void createSpaces(int count) {
         for (int i = 0; i < count; i++) {
-            String spaceCode = String.valueOf(i);
-            while (spaceCode.length() != 10) {
-                spaceCode = spaceCode + "a";
-            }
+            String spaceCode = randomCodeGenerator.generate(10);
             Space space = spaceRepository.save(SpaceFixture.createSpaceWithCode(spaceCode));
             spaceHostMapRepository.save(new SpaceHostMap(space, host));
         }
@@ -322,7 +323,8 @@ class AdminSpaceAcceptanceTest extends AcceptanceTest {
 
     private void createSpacesWithProduct(int count) {
         for (int i = 0; i < count; i++) {
-            Space space = spaceRepository.save(SpaceFixture.createSpace());
+            String spaceCode = randomCodeGenerator.generate(10);
+            Space space = spaceRepository.save(SpaceFixture.createSpaceWithCode(spaceCode));
             spaceHostMapRepository.save(new SpaceHostMap(space, host));
             productRepository.save(ProductFixture.createProductWithSpace(space));
         }

--- a/backend/forgather/src/test/java/com/forgather/acceptance/AdminSpaceAcceptanceTest.java
+++ b/backend/forgather/src/test/java/com/forgather/acceptance/AdminSpaceAcceptanceTest.java
@@ -155,7 +155,7 @@ class AdminSpaceAcceptanceTest extends AcceptanceTest {
         // then
         assertAll(
             () -> assertThat(result.space().code()).isEqualTo(space.getCode()),
-            () -> assertThat(result.hasProduct()).isTrue(),
+            () -> assertThat(result.productCount()).isOne(),
             () -> assertThat(result.guestBookCount()).isEqualTo(2)
         );
     }
@@ -185,7 +185,7 @@ class AdminSpaceAcceptanceTest extends AcceptanceTest {
         // then
         assertAll(
             () -> assertThat(result.space().code()).isEqualTo(space.getCode()),
-            () -> assertThat(result.hasProduct()).isFalse(),
+            () -> assertThat(result.productCount()).isZero(),
             () -> assertThat(result.guestBookCount()).isEqualTo(2)
         );
     }
@@ -211,7 +211,7 @@ class AdminSpaceAcceptanceTest extends AcceptanceTest {
         // then
         assertAll(
             () -> assertThat(result.space().code()).isEqualTo(space.getCode()),
-            () -> assertThat(result.hasProduct()).isFalse(),
+            () -> assertThat(result.productCount()).isZero(),
             () -> assertThat(result.guestBookCount()).isZero()
         );
     }

--- a/backend/forgather/src/test/java/com/forgather/back_office/service/AdminHostServiceTest.java
+++ b/backend/forgather/src/test/java/com/forgather/back_office/service/AdminHostServiceTest.java
@@ -13,12 +13,10 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.forgather.back_office.dto.AdminHostResponse;
-import com.forgather.back_office.model.AdminUser;
 import com.forgather.back_office.repository.AdminUserRepository;
 import com.forgather.domain.space.model.Space;
 import com.forgather.domain.space.repository.HostRepository;
 import com.forgather.domain.space.repository.SpaceRepository;
-import com.forgather.fixture.AdminUserFixture;
 import com.forgather.fixture.HostFixture;
 import com.forgather.fixture.SpaceFixture;
 import com.forgather.global.auth.model.Host;
@@ -49,7 +47,6 @@ class AdminHostServiceTest {
     @Test
     void getAllHosts() {
         // given
-        AdminUser adminUser = adminUserRepository.save(AdminUserFixture.createAdminUser());
         Host host1 = hostRepository.save(HostFixture.createHost());
         Host host2 = hostRepository.save(HostFixture.createHost());
         Space space1 = spaceRepository.save(SpaceFixture.createSpaceWithCode("1111111111"));
@@ -59,7 +56,7 @@ class AdminHostServiceTest {
         Pageable pageable = PageRequest.of(0, 10);
 
         // when
-        AdminHostResponse result = adminHostService.getAllHosts(pageable, adminUser);
+        AdminHostResponse result = adminHostService.getAllHosts(pageable);
 
         // then
         assertAll(

--- a/backend/forgather/src/test/java/com/forgather/back_office/service/AdminSpaceServiceTest.java
+++ b/backend/forgather/src/test/java/com/forgather/back_office/service/AdminSpaceServiceTest.java
@@ -12,6 +12,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.forgather.back_office.dto.AdminSpaceFilterRequest;
 import com.forgather.back_office.dto.AdminSpaceResponse;
 import com.forgather.back_office.dto.SpaceDetailResponse;
 import com.forgather.back_office.repository.AdminUserRepository;
@@ -88,6 +89,47 @@ class AdminSpaceServiceTest {
             () -> assertThat(result.space().code()).isEqualTo("1234567890"),
             () -> assertThat(result.hasProduct()).isTrue(),
             () -> assertThat(result.guestBookCount()).isEqualTo(2)
+        );
+    }
+
+    @DisplayName("작품 소개가 등록된 스페이스 목록을 조회한다.")
+    @Test
+    void getSpacesHasProduct() {
+        // given
+        Space space1 = spaceRepository.save(SpaceFixture.createSpaceWithCode("3333333333"));
+        Space space2 = spaceRepository.save(SpaceFixture.createSpaceWithCode("4444444444"));
+        Space space3 = spaceRepository.save(SpaceFixture.createSpaceWithCode("5555555555"));
+        productRepository.save(ProductFixture.createProductWithSpace(space1));
+        productRepository.save(ProductFixture.createProductWithSpace(space2));
+        AdminSpaceFilterRequest request = new AdminSpaceFilterRequest(true);
+
+        // when
+        AdminSpaceResponse result = adminSpaceService.getSpacesByFilters(request, PageRequest.of(0, 10));
+
+        // then
+        assertAll(
+            () -> assertThat(result.spaces()).hasSize(2),
+            () -> assertThat(result.spaces().get(0).code()).isEqualTo(space2.getCode()),
+            () -> assertThat(result.spaces().get(1).code()).isEqualTo(space1.getCode())
+        );
+    }
+
+    @DisplayName("작품 소개가 등록되지 않은 스페이스 목록을 조회한다.")
+    @Test
+    void getSpacesHasNoProduct() {
+        // given
+        Space space1 = spaceRepository.save(SpaceFixture.createSpaceWithCode("6666666666"));
+        Space space2 = spaceRepository.save(SpaceFixture.createSpaceWithCode("7777777777"));
+        productRepository.save(ProductFixture.createProductWithSpace(space1));
+        AdminSpaceFilterRequest request = new AdminSpaceFilterRequest(false);
+
+        // when
+        AdminSpaceResponse result = adminSpaceService.getSpacesByFilters(request, PageRequest.of(0, 10));
+
+        // then
+        assertAll(
+            () -> assertThat(result.spaces()).hasSize(1),
+            () -> assertThat(result.spaces().get(0).code()).isEqualTo(space2.getCode())
         );
     }
 }

--- a/backend/forgather/src/test/java/com/forgather/back_office/service/AdminSpaceServiceTest.java
+++ b/backend/forgather/src/test/java/com/forgather/back_office/service/AdminSpaceServiceTest.java
@@ -84,7 +84,7 @@ class AdminSpaceServiceTest extends TestOnContainer {
         // then
         assertAll(
             () -> assertThat(result.space().code()).isEqualTo(space.getCode()),
-            () -> assertThat(result.hasProduct()).isTrue(),
+            () -> assertThat(result.productCount()).isOne(),
             () -> assertThat(result.guestBookCount()).isEqualTo(2)
         );
     }

--- a/backend/forgather/src/test/java/com/forgather/back_office/service/AdminSpaceServiceTest.java
+++ b/backend/forgather/src/test/java/com/forgather/back_office/service/AdminSpaceServiceTest.java
@@ -14,7 +14,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.forgather.back_office.dto.AdminSpaceResponse;
 import com.forgather.back_office.dto.SpaceDetailResponse;
-import com.forgather.back_office.model.AdminUser;
 import com.forgather.back_office.repository.AdminUserRepository;
 import com.forgather.domain.guestbook.model.Guest;
 import com.forgather.domain.guestbook.repository.GuestBookCardRepository;
@@ -22,7 +21,6 @@ import com.forgather.domain.guestbook.repository.GuestRepository;
 import com.forgather.domain.product.repository.ProductRepository;
 import com.forgather.domain.space.model.Space;
 import com.forgather.domain.space.repository.SpaceRepository;
-import com.forgather.fixture.AdminUserFixture;
 import com.forgather.fixture.GuestBookCardFixture;
 import com.forgather.fixture.GuestFixture;
 import com.forgather.fixture.ProductFixture;
@@ -55,13 +53,12 @@ class AdminSpaceServiceTest {
     @Test
     void getAllSpaces() {
         // given
-        AdminUser adminUser = adminUserRepository.save(AdminUserFixture.createAdminUser());
         spaceRepository.save(SpaceFixture.createSpaceWithCode("1111111111"));
         spaceRepository.save(SpaceFixture.createSpaceWithCode("2222222222"));
         Pageable pageable = PageRequest.of(0, 10);
 
         // when
-        AdminSpaceResponse result = adminSpaceService.getAllSpaces(pageable, adminUser);
+        AdminSpaceResponse result = adminSpaceService.getAllSpaces(pageable);
 
         // then
         assertAll(
@@ -77,7 +74,6 @@ class AdminSpaceServiceTest {
     @Test
     void getSpaceDetail() {
         // given
-        AdminUser adminUser = adminUserRepository.save(AdminUserFixture.createAdminUser());
         Space space = spaceRepository.save(SpaceFixture.createSpaceWithCode("1234567890"));
         productRepository.save(ProductFixture.createProductWithSpace(space));
         Guest guest = guestRepository.save(GuestFixture.createGuest());
@@ -85,7 +81,7 @@ class AdminSpaceServiceTest {
         guestBookCardRepository.save(GuestBookCardFixture.createGuestBookCard(space, guest, "메시지2"));
 
         // when
-        SpaceDetailResponse result = adminSpaceService.getSpaceDetail("1234567890", adminUser);
+        SpaceDetailResponse result = adminSpaceService.getSpaceDetail("1234567890");
 
         // then
         assertAll(

--- a/backend/forgather/src/test/java/com/forgather/back_office/service/AdminSpaceServiceTest.java
+++ b/backend/forgather/src/test/java/com/forgather/back_office/service/AdminSpaceServiceTest.java
@@ -15,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.forgather.back_office.dto.AdminSpaceFilterRequest;
 import com.forgather.back_office.dto.AdminSpaceResponse;
 import com.forgather.back_office.dto.SpaceDetailResponse;
-import com.forgather.back_office.repository.AdminUserRepository;
+import com.forgather.container.TestOnContainer;
 import com.forgather.domain.guestbook.model.Guest;
 import com.forgather.domain.guestbook.repository.GuestBookCardRepository;
 import com.forgather.domain.guestbook.repository.GuestRepository;
@@ -26,7 +26,6 @@ import com.forgather.fixture.GuestBookCardFixture;
 import com.forgather.fixture.GuestFixture;
 import com.forgather.fixture.ProductFixture;
 import com.forgather.fixture.SpaceFixture;
-import com.forgather.container.TestOnContainer;
 
 @Transactional
 @ActiveProfiles("test")
@@ -35,9 +34,6 @@ class AdminSpaceServiceTest extends TestOnContainer {
 
     @Autowired
     private AdminSpaceService adminSpaceService;
-
-    @Autowired
-    private AdminUserRepository adminUserRepository;
 
     @Autowired
     private SpaceRepository spaceRepository;
@@ -76,18 +72,18 @@ class AdminSpaceServiceTest extends TestOnContainer {
     @Test
     void getSpaceDetail() {
         // given
-        Space space = spaceRepository.save(SpaceFixture.createSpaceWithCode("1234567890"));
+        Space space = spaceRepository.save(SpaceFixture.createSpace());
         productRepository.save(ProductFixture.createProductWithSpace(space));
         Guest guest = guestRepository.save(GuestFixture.createGuest());
         guestBookCardRepository.save(GuestBookCardFixture.createGuestBookCard(space, guest, "메시지1"));
         guestBookCardRepository.save(GuestBookCardFixture.createGuestBookCard(space, guest, "메시지2"));
 
         // when
-        SpaceDetailResponse result = adminSpaceService.getSpaceDetail("1234567890");
+        SpaceDetailResponse result = adminSpaceService.getSpaceDetail(space.getCode());
 
         // then
         assertAll(
-            () -> assertThat(result.space().code()).isEqualTo("1234567890"),
+            () -> assertThat(result.space().code()).isEqualTo(space.getCode()),
             () -> assertThat(result.hasProduct()).isTrue(),
             () -> assertThat(result.guestBookCount()).isEqualTo(2)
         );
@@ -97,9 +93,9 @@ class AdminSpaceServiceTest extends TestOnContainer {
     @Test
     void getSpacesHasProduct() {
         // given
-        Space space1 = spaceRepository.save(SpaceFixture.createSpaceWithCode("3333333333"));
-        Space space2 = spaceRepository.save(SpaceFixture.createSpaceWithCode("4444444444"));
-        Space space3 = spaceRepository.save(SpaceFixture.createSpaceWithCode("5555555555"));
+        Space space1 = spaceRepository.save(SpaceFixture.createSpaceWithCode("1111111111"));
+        Space space2 = spaceRepository.save(SpaceFixture.createSpaceWithCode("2222222222"));
+        spaceRepository.save(SpaceFixture.createSpaceWithCode("3333333333"));
         productRepository.save(ProductFixture.createProductWithSpace(space1));
         productRepository.save(ProductFixture.createProductWithSpace(space2));
         AdminSpaceFilterRequest request = new AdminSpaceFilterRequest(true);
@@ -110,8 +106,9 @@ class AdminSpaceServiceTest extends TestOnContainer {
         // then
         assertAll(
             () -> assertThat(result.spaces()).hasSize(2),
-            () -> assertThat(result.spaces().get(0).code()).isEqualTo(space2.getCode()),
-            () -> assertThat(result.spaces().get(1).code()).isEqualTo(space1.getCode())
+            () -> assertThat(result.spaces())
+                .extracting("code")
+                .containsExactlyInAnyOrder(space1.getCode(), space2.getCode())
         );
     }
 
@@ -119,8 +116,8 @@ class AdminSpaceServiceTest extends TestOnContainer {
     @Test
     void getSpacesHasNoProduct() {
         // given
-        Space space1 = spaceRepository.save(SpaceFixture.createSpaceWithCode("6666666666"));
-        Space space2 = spaceRepository.save(SpaceFixture.createSpaceWithCode("7777777777"));
+        Space space1 = spaceRepository.save(SpaceFixture.createSpaceWithCode("1111111111"));
+        Space space2 = spaceRepository.save(SpaceFixture.createSpaceWithCode("2222222222"));
         productRepository.save(ProductFixture.createProductWithSpace(space1));
         AdminSpaceFilterRequest request = new AdminSpaceFilterRequest(false);
 


### PR DESCRIPTION
## 연관된 이슈

- close #992 

## 작업 내용

### 스페이스 목록 조회 시 작품 등록 여부 필터링 검색
- 작품 등록 여부에 따른 필터링 검색이 추가되었습니다

<br>
<img width="840" height="386" alt="image" src="https://github.com/user-attachments/assets/0d897257-8587-40b7-a453-f6f231971227" />
<img width="847" height="275" alt="image" src="https://github.com/user-attachments/assets/bd70cf95-6184-42d5-976e-6182c87c2de7" />
<img width="824" height="306" alt="image" src="https://github.com/user-attachments/assets/e7baf195-a760-4606-aae1-fa0efeb00250" />
<br>

### 스페이스 상세 조회 시 작품 등록 개수로 변경
- 기존 스페이스 상세 조회 모달에서 작품 등록 여부를 보여주던 것에서 등록한 작품 소개 개수를 보여주는 방식으로 변경되었습니다

<br>
작품 소개를 등록한 경우
<br>
<img width="514" height="552" alt="image" src="https://github.com/user-attachments/assets/b3482b47-c03c-4eb2-84ae-1144f91524dd" />
<br>

<br>
작품 소개를 등록하지 않은 경우
<br>
<img width="520" height="562" alt="image" src="https://github.com/user-attachments/assets/11fcbaee-9d33-41ac-95a3-91cdc736d6e9" />
<br>

### 기존 페이지네이션 페이지 이동 방식 변경
- 기존 페이지네이션 previous/next 버튼 방식을 숫자 페이지 네비게이션(1 2 3 4 5) 방식으로 변경
- 현재 페이지 기준 앞 2페이지, 뒤 2페이지를 표시합니다
  - ex) 현재 페이지가 3인 경우 -> 1 2 3 4 5
- 첫 페이지로 이동, 이전 페이지로 이동, 다음 페이지로 이동, 마지막 페이지로 이동 총 4개의 버튼이 숫자 버튼 옆에 추가되었습니다

<br>
<img width="831" height="193" alt="image" src="https://github.com/user-attachments/assets/db0bd4f2-f58f-449d-aec7-fd3048e94108" />

