### PR TITLE
refactor: 방명록 관련 엔티티(GuestBookCard, GuestBookCardPhoto) soft delete 도입

### DIFF
--- a/backend/forgather/src/main/java/com/forgather/back_office/service/AdminSpaceService.java
+++ b/backend/forgather/src/main/java/com/forgather/back_office/service/AdminSpaceService.java
@@ -32,7 +32,7 @@ public class AdminSpaceService {
     public SpaceDetailResponse getSpaceDetail(String spaceCode) {
         Space space = spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
         Long productCount = productRepository.countBySpace(space);
-        Long guestBookCardCount = guestBookCardRepository.countBySpace(space);
+        Long guestBookCardCount = guestBookCardRepository.countBySpaceAndDeletedAtIsNull(space);
 
         return SpaceDetailResponse.of(space, productCount, guestBookCardCount);
     }

--- a/backend/forgather/src/main/java/com/forgather/domain/guestbook/repository/GuestBookCardPhotoRepository.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/guestbook/repository/GuestBookCardPhotoRepository.java
@@ -8,7 +8,7 @@ import com.forgather.domain.guestbook.model.GuestBookCardPhoto;
 public interface GuestBookCardPhotoRepository {
     <S extends GuestBookCardPhoto> List<S> saveAll(Iterable<S> photos);
 
-    List<GuestBookCardPhoto> findAllByGuestBookCard(GuestBookCard guestBookCard);
+    List<GuestBookCardPhoto> findAllByGuestBookCardAndDeletedAtIsNull(GuestBookCard guestBookCard);
 
     void deleteAll(Iterable<? extends GuestBookCardPhoto> photos);
 

--- a/backend/forgather/src/main/java/com/forgather/domain/guestbook/repository/GuestBookCardPhotoRepository.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/guestbook/repository/GuestBookCardPhotoRepository.java
@@ -9,8 +9,4 @@ public interface GuestBookCardPhotoRepository {
     <S extends GuestBookCardPhoto> List<S> saveAll(Iterable<S> photos);
 
     List<GuestBookCardPhoto> findAllByGuestBookCardAndDeletedAtIsNull(GuestBookCard guestBookCard);
-
-    void deleteAll(Iterable<? extends GuestBookCardPhoto> photos);
-
-    Boolean existsByGuestBookCard(GuestBookCard guestBookCard);
 }

--- a/backend/forgather/src/main/java/com/forgather/domain/guestbook/repository/GuestBookCardRepository.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/guestbook/repository/GuestBookCardRepository.java
@@ -20,11 +20,11 @@ public interface GuestBookCardRepository {
 
     GuestBookCard save(GuestBookCard guestBookCard);
 
-    Optional<GuestBookCard> findById(Long id);
+    Optional<GuestBookCard> findByIdAndDeletedAtIsNull(Long id);
 
     void delete(GuestBookCard guestBookCard);
 
-    Long countBySpace(Space space);
+    Long countBySpaceAndDeletedAtIsNull(Space space);
 
     @Query("""
         SELECT new com.forgather.domain.guestbook.repository.dto.SpaceGuestBookCountDto(
@@ -32,10 +32,10 @@ public interface GuestBookCardRepository {
             COUNT(g.id)
         )
         FROM GuestBookCard g
-        WHERE g.space.id IN :spaceIds
+        WHERE g.space.id IN :spaceIds AND g.deletedAt IS NULL
         GROUP BY g.space.id
         """)
-    List<SpaceGuestBookCountDto> countBySpaceIdIn(@Param("spaceIds") List<Long> spaceIds);
+    List<SpaceGuestBookCountDto> countBySpaceIdAndDeletedAtIsNullIn(@Param("spaceIds") List<Long> spaceIds);
 
     @Query("""
             SELECT new com.forgather.domain.guestbook.repository.dto.GuestBookCardListDto(
@@ -48,19 +48,19 @@ public interface GuestBookCardRepository {
             )
             FROM GuestBookCard g
             JOIN g.guest guest
-            WHERE g.space = :space
+            WHERE g.space = :space AND g.deletedAt IS NULL
         """)
-    Page<GuestBookCardListDto> findAllDtoBySpace(@Param("space") Space space, Pageable pageable);
+    Page<GuestBookCardListDto> findAllDtoBySpaceAndDeletedAtIsNull(@Param("space") Space space, Pageable pageable);
 
-    List<GuestBookCard> findAllBySpace(Space space);
+    List<GuestBookCard> findAllBySpaceAndDeletedAtIsNull(Space space);
 
     long count();
 
-    default GuestBookCard getByIdOrThrow(Long id) {
+    default GuestBookCard getByIdAndDeletedAtIsNullOrThrow(Long id) {
         if (id == null) {
             throw new BaseNullPointerException("방명록 카드의 id는 null일 수 없습니다.", HttpStatus.BAD_REQUEST);
         }
-        return findById(id)
+        return findByIdAndDeletedAtIsNull(id)
             .orElseThrow(() -> new NotFoundException("존재하지 않는 방명록 카드입니다. id: " + id));
     }
 }

--- a/backend/forgather/src/main/java/com/forgather/domain/guestbook/repository/GuestBookCardRepository.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/guestbook/repository/GuestBookCardRepository.java
@@ -22,8 +22,6 @@ public interface GuestBookCardRepository {
 
     Optional<GuestBookCard> findByIdAndDeletedAtIsNull(Long id);
 
-    void delete(GuestBookCard guestBookCard);
-
     Long countBySpaceAndDeletedAtIsNull(Space space);
 
     @Query("""

--- a/backend/forgather/src/main/java/com/forgather/domain/guestbook/service/GuestBookService.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/guestbook/service/GuestBookService.java
@@ -110,7 +110,7 @@ public class GuestBookService {
             guestBookCard.read();
         }
 
-        List<GuestBookCardPhoto> photos = guestBookCardPhotoRepository.findAllByGuestBookCard(guestBookCard);
+        List<GuestBookCardPhoto> photos = guestBookCardPhotoRepository.findAllByGuestBookCardAndDeletedAtIsNull(guestBookCard);
         return new GuestBookCardResponse(guestBookCard, photos);
     }
 
@@ -142,7 +142,7 @@ public class GuestBookService {
     }
 
     private void deleteGuestBookCardPhotos(GuestBookCard guestBookCard) {
-        List<GuestBookCardPhoto> photos = guestBookCardPhotoRepository.findAllByGuestBookCard(guestBookCard);
+        List<GuestBookCardPhoto> photos = guestBookCardPhotoRepository.findAllByGuestBookCardAndDeletedAtIsNull(guestBookCard);
         if (!photos.isEmpty()) {
             deleteGuestBookCardPhotos(photos);
         }
@@ -164,7 +164,7 @@ public class GuestBookService {
 
     private GuestBookCardPhotos getGuestBookCardPhotos(Space space, Long guestBookCardId) {
         GuestBookCard guestBookCard = getGuestBookCard(guestBookCardId, space);
-        return new GuestBookCardPhotos(guestBookCardPhotoRepository.findAllByGuestBookCard(guestBookCard));
+        return new GuestBookCardPhotos(guestBookCardPhotoRepository.findAllByGuestBookCardAndDeletedAtIsNull(guestBookCard));
     }
 
     private GuestBookCard getGuestBookCard(Long guestBookCardId, Space space) {

--- a/backend/forgather/src/main/java/com/forgather/domain/guestbook/service/GuestBookService.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/guestbook/service/GuestBookService.java
@@ -88,7 +88,7 @@ public class GuestBookService {
         Space space = spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
         validateCanRead(space, host);
         boolean isHost = host != null && isSpaceHost(space, host);
-        Page<GuestBookCardListDto> guestBookCardDtos = guestBookCardRepository.findAllDtoBySpace(space, pageable);
+        Page<GuestBookCardListDto> guestBookCardDtos = guestBookCardRepository.findAllDtoBySpaceAndDeletedAtIsNull(space, pageable);
         Page<GuestBookCardSimpleResponse> simpleResponses = guestBookCardDtos.map(
             guestBookCardDto -> new GuestBookCardSimpleResponse(
                 guestBookCardDto.id(),
@@ -127,7 +127,7 @@ public class GuestBookService {
     @Transactional
     public void deleteAllCardsBySpace(Host host, Space space) {
         validateSpaceHost(host, space);
-        for (GuestBookCard guestBookCard : guestBookCardRepository.findAllBySpace(space)) {
+        for (GuestBookCard guestBookCard : guestBookCardRepository.findAllBySpaceAndDeletedAtIsNull(space)) {
             deleteCard(host, space.getCode(), guestBookCard.getId());
         }
     }
@@ -168,7 +168,7 @@ public class GuestBookService {
     }
 
     private GuestBookCard getGuestBookCard(Long guestBookCardId, Space space) {
-        GuestBookCard guestBookCard = guestBookCardRepository.getByIdOrThrow(guestBookCardId);
+        GuestBookCard guestBookCard = guestBookCardRepository.getByIdAndDeletedAtIsNullOrThrow(guestBookCardId);
         if (guestBookCard.equalsSpace(space)) {
             return guestBookCard;
         }

--- a/backend/forgather/src/main/java/com/forgather/domain/guestbook/service/GuestBookService.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/guestbook/service/GuestBookService.java
@@ -7,7 +7,6 @@ import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -31,7 +30,6 @@ import com.forgather.domain.guestbook.repository.dto.GuestBookCardListDto;
 import com.forgather.domain.space.model.Space;
 import com.forgather.domain.space.repository.SpaceRepository;
 import com.forgather.domain.upload.domain.ContentsStorage;
-import com.forgather.domain.upload.event.DeletePhotoEvent;
 import com.forgather.global.auth.model.Host;
 import com.forgather.global.auth.repository.SpaceHostMapRepository;
 import com.forgather.global.exception.BaseNullPointerException;
@@ -44,7 +42,6 @@ import lombok.RequiredArgsConstructor;
 @Service
 public class GuestBookService {
 
-    private final ApplicationEventPublisher eventPublisher;
     private final SpaceRepository spaceRepository;
     private final SpaceHostMapRepository spaceHostMapRepository;
     private final GuestRepository guestRepository;
@@ -138,14 +135,12 @@ public class GuestBookService {
         validateSpaceHost(host, space);
         GuestBookCard guestBookCard = getGuestBookCard(guestBookCardId, space);
         deleteGuestBookCardPhotos(guestBookCard);
-        guestBookCardRepository.delete(guestBookCard);
+        guestBookCard.delete();
     }
 
     private void deleteGuestBookCardPhotos(GuestBookCard guestBookCard) {
         List<GuestBookCardPhoto> photos = guestBookCardPhotoRepository.findAllByGuestBookCardAndDeletedAtIsNull(guestBookCard);
-        if (!photos.isEmpty()) {
-            deleteGuestBookCardPhotos(photos);
-        }
+        deleteGuestBookCardPhotos(photos);
     }
 
     @Transactional
@@ -195,7 +190,8 @@ public class GuestBookService {
     }
 
     private void deleteGuestBookCardPhotos(List<GuestBookCardPhoto> photos) {
-        guestBookCardPhotoRepository.deleteAll(photos);
-        eventPublisher.publishEvent(new DeletePhotoEvent(this, photos)); // 클라우드 삭제 이벤트 발행
+        for (GuestBookCardPhoto photo : photos) {
+            photo.delete();
+        }
     }
 }

--- a/backend/forgather/src/main/java/com/forgather/domain/space/service/SpaceService.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/space/service/SpaceService.java
@@ -123,7 +123,7 @@ public class SpaceService {
     }
 
     private SpaceResponse createSpaceResponse(Space space) {
-        Long guestBookCardCount = guestBookCardRepository.countBySpace(space);
+        Long guestBookCardCount = guestBookCardRepository.countBySpaceAndDeletedAtIsNull(space);
         SpacePhoto spacePhoto = spacePhotoRepository.getBySpaceAndDeletedAtIsNullOrEmpty(space);
         return SpaceResponse.from(space, spacePhoto, guestBookCardCount);
     }
@@ -183,7 +183,7 @@ public class SpaceService {
             .map(spaceHostMap -> spaceHostMap.getSpace().getId())
             .toList();
 
-        Map<Long, Long> guestBookCardCounts = guestBookCardRepository.countBySpaceIdIn(spaceIds)
+        Map<Long, Long> guestBookCardCounts = guestBookCardRepository.countBySpaceIdAndDeletedAtIsNullIn(spaceIds)
             .stream()
             .collect(Collectors.toMap(
                 SpaceGuestBookCountDto::spaceId,

--- a/backend/forgather/src/test/java/com/forgather/acceptance/SpaceAcceptanceTest.java
+++ b/backend/forgather/src/test/java/com/forgather/acceptance/SpaceAcceptanceTest.java
@@ -279,7 +279,7 @@ class SpaceAcceptanceTest extends AcceptanceTest {
             () -> assertThat(spacePhotoRepository.findBySpaceAndDeletedAtIsNull(space)).isEmpty(),
             () -> assertThat(productRepository.findAllBySpace(space)).isEmpty(),
             () -> assertThat(productPhotoRepository.findAllByProduct(product)).isEmpty(),
-            () -> assertThat(guestBookCardRepository.findAllBySpace(space)).isEmpty(),
+            () -> assertThat(guestBookCardRepository.findAllBySpaceAndDeletedAtIsNull(space)).isEmpty(),
             () -> assertThat(guestBookCardPhotoRepository.findAllByGuestBookCard(guestBookCard)).isEmpty(),
 
             () -> await().atMost(ofSeconds(6))

--- a/backend/forgather/src/test/java/com/forgather/acceptance/SpaceAcceptanceTest.java
+++ b/backend/forgather/src/test/java/com/forgather/acceptance/SpaceAcceptanceTest.java
@@ -280,7 +280,7 @@ class SpaceAcceptanceTest extends AcceptanceTest {
             () -> assertThat(productRepository.findAllBySpace(space)).isEmpty(),
             () -> assertThat(productPhotoRepository.findAllByProduct(product)).isEmpty(),
             () -> assertThat(guestBookCardRepository.findAllBySpaceAndDeletedAtIsNull(space)).isEmpty(),
-            () -> assertThat(guestBookCardPhotoRepository.findAllByGuestBookCard(guestBookCard)).isEmpty(),
+            () -> assertThat(guestBookCardPhotoRepository.findAllByGuestBookCardAndDeletedAtIsNull(guestBookCard)).isEmpty(),
 
             () -> await().atMost(ofSeconds(6))
                 .untilAsserted(() -> verify(contentsStorage, atLeast(1)).deletePhotos(anyList()))

--- a/backend/forgather/src/test/java/com/forgather/domain/guestbook/service/GuestBookDeleteServiceTest.java
+++ b/backend/forgather/src/test/java/com/forgather/domain/guestbook/service/GuestBookDeleteServiceTest.java
@@ -102,7 +102,7 @@ public class GuestBookDeleteServiceTest {
 
     @DisplayName("주어진 스페이스에 속하는 모든 방명록을 논리 삭제한다")
     @Test
-    void aaa() {
+    void softDeleteGuestBookBySpace() {
         // given
         GuestBookCard guestBookCard1 = guestBookCardRepository.save(new GuestBookCard(space, guest, "test1"));
         GuestBookCard guestBookCard2 = guestBookCardRepository.save(new GuestBookCard(space, guest, "test2"));

--- a/backend/forgather/src/test/java/com/forgather/domain/guestbook/service/GuestBookDeleteServiceTest.java
+++ b/backend/forgather/src/test/java/com/forgather/domain/guestbook/service/GuestBookDeleteServiceTest.java
@@ -1,0 +1,122 @@
+package com.forgather.domain.guestbook.service;
+
+import static com.forgather.fixture.GuestBookCardPhotoFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import com.forgather.domain.guestbook.model.Guest;
+import com.forgather.domain.guestbook.model.GuestBookCard;
+import com.forgather.domain.guestbook.model.GuestBookCardPhoto;
+import com.forgather.domain.guestbook.repository.GuestBookCardPhotoRepository;
+import com.forgather.domain.guestbook.repository.GuestBookCardRepository;
+import com.forgather.domain.guestbook.repository.GuestRepository;
+import com.forgather.domain.space.model.Space;
+import com.forgather.domain.space.repository.HostRepository;
+import com.forgather.domain.space.repository.SpaceRepository;
+import com.forgather.fake.FakeContentStorage;
+import com.forgather.fixture.GuestFixture;
+import com.forgather.fixture.HostFixture;
+import com.forgather.fixture.SpaceFixture;
+import com.forgather.global.auth.model.Host;
+import com.forgather.global.auth.model.SpaceHostMap;
+import com.forgather.global.auth.repository.SpaceHostMapRepository;
+
+@Import({GuestBookService.class, FakeContentStorage.class})
+@DataJpaTest
+public class GuestBookDeleteServiceTest {
+
+    @Autowired
+    private GuestBookService guestBookService;
+
+    @Autowired
+    GuestBookCardRepository guestBookCardRepository;
+
+    @Autowired
+    GuestBookCardPhotoRepository guestBookCardPhotoRepository;
+
+    @Autowired
+    private GuestRepository guestRepository;
+
+    @Autowired
+    private HostRepository hostRepository;
+
+    @Autowired
+    private SpaceRepository spaceRepository;
+
+    @Autowired
+    private SpaceHostMapRepository spaceHostMapRepository;
+
+    private Host host;
+    private Space space;
+    private Guest guest;
+
+    @BeforeEach
+    void setUp() {
+        space = SpaceFixture.createSpace();
+        spaceRepository.save(space);
+
+        host = HostFixture.createHost();
+        hostRepository.save(host);
+
+        spaceHostMapRepository.save(new SpaceHostMap(space, host));
+
+        guest = GuestFixture.createGuest();
+        guestRepository.save(guest);
+    }
+
+    @DisplayName("지정한 방명록을 논리 삭제한다")
+    @Test
+    void softDeleteGuestBookCard() {
+        // given
+        GuestBookCard guestBookCard1 = guestBookCardRepository.save(new GuestBookCard(space, guest, "test1"));
+        GuestBookCard guestBookCard2 = guestBookCardRepository.save(new GuestBookCard(space, guest, "test2"));
+        GuestBookCard guestBookCard3 = guestBookCardRepository.save(new GuestBookCard(space, guest, "test3"));
+        GuestBookCardPhoto guestBookCardPhoto1 = createGuestBookCardPhotoWithGuestBookCard(guestBookCard1);
+        GuestBookCardPhoto guestBookCardPhoto2 = createGuestBookCardPhotoWithGuestBookCard(guestBookCard1);
+        guestBookCardPhotoRepository.saveAll(List.of(guestBookCardPhoto1, guestBookCardPhoto2));
+
+        // when
+        guestBookService.deleteCard(host, space.getCode(), guestBookCard1.getId());
+        guestBookService.deleteCard(host, space.getCode(), guestBookCard3.getId());
+
+        // then
+        assertAll(
+            () -> assertThat(guestBookCardRepository.count()).isEqualTo(3),
+            () -> assertThat(guestBookCard1.getDeletedAt()).isNotNull(),
+            () -> assertThat(guestBookCard2.getDeletedAt()).isNull(),
+            () -> assertThat(guestBookCard3.getDeletedAt()).isNotNull(),
+
+            () -> assertThat(guestBookCardPhoto1.getDeletedAt()).isNotNull(),
+            () -> assertThat(guestBookCardPhoto2.getDeletedAt()).isNotNull()
+        );
+    }
+
+    @DisplayName("주어진 스페이스에 속하는 모든 방명록을 논리 삭제한다")
+    @Test
+    void aaa() {
+        // given
+        GuestBookCard guestBookCard1 = guestBookCardRepository.save(new GuestBookCard(space, guest, "test1"));
+        GuestBookCard guestBookCard2 = guestBookCardRepository.save(new GuestBookCard(space, guest, "test2"));
+        GuestBookCard guestBookCard3 = guestBookCardRepository.save(new GuestBookCard(space, guest, "test3"));
+
+        // when
+        guestBookService.deleteAllCardsBySpace(host, space);
+
+        // then
+        assertAll(
+            () -> assertThat(guestBookCardRepository.count()).isEqualTo(3),
+            () -> assertThat(guestBookCard1.getDeletedAt()).isNotNull(),
+            () -> assertThat(guestBookCard2.getDeletedAt()).isNotNull(),
+            () -> assertThat(guestBookCard3.getDeletedAt()).isNotNull()
+        );
+    }
+}

--- a/backend/forgather/src/test/java/com/forgather/domain/guestbook/service/GuestBookDeleteServiceTest.java
+++ b/backend/forgather/src/test/java/com/forgather/domain/guestbook/service/GuestBookDeleteServiceTest.java
@@ -96,7 +96,11 @@ public class GuestBookDeleteServiceTest {
             () -> assertThat(guestBookCard3.getDeletedAt()).isNotNull(),
 
             () -> assertThat(guestBookCardPhoto1.getDeletedAt()).isNotNull(),
-            () -> assertThat(guestBookCardPhoto2.getDeletedAt()).isNotNull()
+            () -> assertThat(guestBookCardPhoto2.getDeletedAt()).isNotNull(),
+
+            () -> assertThat(guestBookCardRepository.findAllBySpaceAndDeletedAtIsNull(space))
+                .extracting(GuestBookCard::getId)
+                .containsExactly(guestBookCard2.getId())
         );
     }
 
@@ -116,7 +120,9 @@ public class GuestBookDeleteServiceTest {
             () -> assertThat(guestBookCardRepository.count()).isEqualTo(3),
             () -> assertThat(guestBookCard1.getDeletedAt()).isNotNull(),
             () -> assertThat(guestBookCard2.getDeletedAt()).isNotNull(),
-            () -> assertThat(guestBookCard3.getDeletedAt()).isNotNull()
+            () -> assertThat(guestBookCard3.getDeletedAt()).isNotNull(),
+
+            () -> assertThat(guestBookCardRepository.findAllBySpaceAndDeletedAtIsNull(space)).isEmpty()
         );
     }
 }


### PR DESCRIPTION
## 연관된 이슈

- close #1005 

## 작업 내용

### 방명록 soft delete 도입
스페이스 soft delete 도입([PR](https://github.com/woowacourse-teams/2025-PhotoGather/pull/999))에 이어서
방명록에도 soft delete를 도입했습니다.

스페이스 삭제 시
- 해당 스페이스의 모든 방명록 논리 삭제
- 해당 스페이스의 모든 방명록 사진 논리 삭제

방명록 삭제 시
- 해당 방명록 논리 삭제
- 해당 방명록의 모든 방명록 사진 논리 삭제

방명록 사진 삭제 시
- 해당 방명록 사진 논리 삭제

---

### 논리 삭제 시 s3 사진 미삭제

기존에는 사용자가 삭제 요청을 하면 바로 방명록 사진을 db에서 물리 삭제하고, 이벤트 발행을 통해 s3 사진을 비동기로 삭제했습니다.

하지만 논리 삭제가 도입된만큼,
데이터 정합성을 보장하기 위해 논리 삭제 시 s3 사진 삭제 로직을 제거했습니다.  

---

### 방명록 통계 논리 삭제 레코드 포함

현재 랜딩 페이지에서는 다음과 같이 누적 스페이스 수와 누적 방명록 수를 조회하고 있습니다. 

<img width="397" height="623" alt="image" src="https://github.com/user-attachments/assets/d380ab05-54f2-4935-986c-e1cdbcbb51bc" />

`누적` 통계인만큼 이 수치는 논리 삭제된 방명록의 개수도 포함해야한다고 판단했습니다. (스페이스도 마찬가지)

따라서 `GuestBookCardRepository#count()`에는 별도로 논리 삭제 필터링 조건을 추가하지 않았습니다.