### PR TITLE
refactor: 작품 관련 엔티티(Product, ProductPhoto) soft delete 도입

### DIFF
--- a/backend/forgather/src/main/java/com/forgather/back_office/service/AdminSpaceService.java
+++ b/backend/forgather/src/main/java/com/forgather/back_office/service/AdminSpaceService.java
@@ -31,7 +31,7 @@ public class AdminSpaceService {
 
     public SpaceDetailResponse getSpaceDetail(String spaceCode) {
         Space space = spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
-        Long productCount = productRepository.countBySpace(space);
+        Long productCount = productRepository.countBySpaceAndDeletedAtIsNull(space);
         Long guestBookCardCount = guestBookCardRepository.countBySpaceAndDeletedAtIsNull(space);
 
         return SpaceDetailResponse.of(space, productCount, guestBookCardCount);

--- a/backend/forgather/src/main/java/com/forgather/domain/product/controller/ProductController.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/product/controller/ProductController.java
@@ -60,7 +60,7 @@ public class ProductController {
         @RequestBody RegisterProductRequest request,
         @LoginHost(required = true) Host host
     ) {
-        var response = productService.registerV3(host, spaceCode, request);
+        var response = productService.register(host, spaceCode, request);
         return ResponseEntity.status(CREATED).body(response);
     }
 
@@ -74,7 +74,7 @@ public class ProductController {
         @RequestBody UpdateProductRequest request,
         @LoginHost(required = true) Host host
     ) {
-        var response = productService.updateV3(host, spaceCode, productId, request);
+        var response = productService.update(host, spaceCode, productId, request);
         return ResponseEntity.ok().body(response);
     }
 
@@ -86,7 +86,7 @@ public class ProductController {
         @PathVariable(value = "productId") Long productId,
         @LoginHost(required = true) Host host
     ) {
-        productService.deleteV2(host, spaceCode, productId);
+        productService.delete(host, spaceCode, productId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/forgather/src/main/java/com/forgather/domain/product/repository/ProductPhotoRepository.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/product/repository/ProductPhotoRepository.java
@@ -14,8 +14,6 @@ public interface ProductPhotoRepository {
 
     List<ProductPhoto> findAllByProduct(Product product);
 
-    void deleteAll(Iterable<? extends ProductPhoto> photos);
-
     <S extends ProductPhoto> List<S> saveAll(Iterable<S> photos);
 
 }

--- a/backend/forgather/src/main/java/com/forgather/domain/product/repository/ProductPhotoRepository.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/product/repository/ProductPhotoRepository.java
@@ -10,9 +10,9 @@ public interface ProductPhotoRepository {
 
     ProductPhoto save(ProductPhoto photo);
 
-    Optional<ProductPhoto> findFirstByProduct(Product product);
+    Optional<ProductPhoto> findFirstByProductAndDeletedAtIsNull(Product product);
 
-    List<ProductPhoto> findAllByProduct(Product product);
+    List<ProductPhoto> findAllByProductAndDeletedAtIsNull(Product product);
 
     <S extends ProductPhoto> List<S> saveAll(Iterable<S> photos);
 

--- a/backend/forgather/src/main/java/com/forgather/domain/product/repository/ProductRepository.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/product/repository/ProductRepository.java
@@ -13,8 +13,6 @@ import com.forgather.global.exception.NotFoundException;
 public interface ProductRepository {
     Product save(Product product);
 
-    void delete(Product product);
-
     List<Product> findAllBySpace(Space space);
 
     Optional<Product> findBySpaceAndId(Space space, Long id);

--- a/backend/forgather/src/main/java/com/forgather/domain/product/repository/ProductRepository.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/product/repository/ProductRepository.java
@@ -13,20 +13,20 @@ import com.forgather.global.exception.NotFoundException;
 public interface ProductRepository {
     Product save(Product product);
 
-    List<Product> findAllBySpace(Space space);
+    List<Product> findAllBySpaceAndDeletedAtIsNull(Space space);
 
-    Optional<Product> findBySpaceAndId(Space space, Long id);
+    Optional<Product> findBySpaceAndIdAndDeletedAtIsNull(Space space, Long id);
 
     Long countBySpace(Space space);
 
-    default Product getBySpaceAndIdOrThrow(Space space, Long id) {
+    default Product getBySpaceAndIdAndDeletedAtIsNullOrThrow(Space space, Long id) {
         if (space == null) {
             throw new BaseNullPointerException("스페이스는 null일 수 없습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
         }
         if (id == null) {
             throw new BaseNullPointerException("작품의 id는 null일 수 없습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
         }
-        return findBySpaceAndId(space, id)
+        return findBySpaceAndIdAndDeletedAtIsNull(space, id)
             .orElseThrow(() -> new NotFoundException("해당 스페이스에 존재하지 않는 작품입니다. spaceCode: %s, productId: %d"
                 .formatted(space.getCode(), id)));
     }

--- a/backend/forgather/src/main/java/com/forgather/domain/product/repository/ProductRepository.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/product/repository/ProductRepository.java
@@ -17,7 +17,7 @@ public interface ProductRepository {
 
     Optional<Product> findBySpaceAndIdAndDeletedAtIsNull(Space space, Long id);
 
-    Long countBySpace(Space space);
+    Long countBySpaceAndDeletedAtIsNull(Space space);
 
     default Product getBySpaceAndIdAndDeletedAtIsNullOrThrow(Space space, Long id) {
         if (space == null) {

--- a/backend/forgather/src/main/java/com/forgather/domain/product/service/ProductService.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/product/service/ProductService.java
@@ -48,11 +48,11 @@ public class ProductService {
     @Transactional(readOnly = true)
     public ProductsResponse getAll(String spaceCode) {
         Space space = spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
-        List<Product> products = productRepository.findAllBySpace(space);
+        List<Product> products = productRepository.findAllBySpaceAndDeletedAtIsNull(space);
         List<SimpleProductResponse> productResponses = products.stream()
             .map(product -> new SimpleProductResponse(
                 product,
-                productPhotoRepository.findFirstByProduct(product).orElse(null))
+                productPhotoRepository.findFirstByProductAndDeletedAtIsNull(product).orElse(null))
             ).toList();
         return new ProductsResponse(productResponses);
     }
@@ -60,8 +60,8 @@ public class ProductService {
     @Transactional(readOnly = true)
     public ProductResponse get(String spaceCode, Long productId) {
         Space space = spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
-        Product product = productRepository.getBySpaceAndIdOrThrow(space, productId);
-        ProductPhotos productPhotos = new ProductPhotos(productPhotoRepository.findAllByProduct(product));
+        Product product = productRepository.getBySpaceAndIdAndDeletedAtIsNullOrThrow(space, productId);
+        ProductPhotos productPhotos = new ProductPhotos(productPhotoRepository.findAllByProductAndDeletedAtIsNull(product));
         return new ProductResponse(product, productPhotos.getAll());
     }
 
@@ -98,12 +98,12 @@ public class ProductService {
         // Product 정보 수정
         Space space = spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
         validateSpaceHost(host, space);
-        Product product = productRepository.getBySpaceAndIdOrThrow(space, productId);
+        Product product = productRepository.getBySpaceAndIdAndDeletedAtIsNullOrThrow(space, productId);
         product.update(request.title(), request.category(), request.authorName(), request.description(),
             request.videoUrl(), request.isVideoAfterPhoto());
 
         // 삭제 사진 db 및 클라우드 삭제
-        ProductPhotos photos = new ProductPhotos(productPhotoRepository.findAllByProduct(product));
+        ProductPhotos photos = new ProductPhotos(productPhotoRepository.findAllByProductAndDeletedAtIsNull(product));
         List<ProductPhoto> deletedPhotos = photos.deleteByIds(request.deletePhotoIds());
         deleteProductPhotos(deletedPhotos);
 
@@ -128,7 +128,7 @@ public class ProductService {
     public void deleteV2(Host host, String spaceCode, Long productId) {
         Space space = spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
         validateSpaceHost(host, space);
-        Product product = productRepository.getBySpaceAndIdOrThrow(space, productId);
+        Product product = productRepository.getBySpaceAndIdAndDeletedAtIsNullOrThrow(space, productId);
         deleteAllProductPhotos(product);
         product.delete();
     }
@@ -139,7 +139,7 @@ public class ProductService {
     @Transactional
     public void deleteIfExists(Host host, Space space) {
         validateSpaceHost(host, space);
-        for (Product product : productRepository.findAllBySpace(space)) {
+        for (Product product : productRepository.findAllBySpaceAndDeletedAtIsNull(space)) {
             deleteAllProductPhotos(product);
             product.delete();
         }
@@ -149,7 +149,7 @@ public class ProductService {
      * product와 연관된 모든 ProductPhoto 삭제
      */
     private void deleteAllProductPhotos(Product product) {
-        List<ProductPhoto> photos = productPhotoRepository.findAllByProduct(product);
+        List<ProductPhoto> photos = productPhotoRepository.findAllByProductAndDeletedAtIsNull(product);
         if (!photos.isEmpty()) {
             deleteProductPhotos(photos);
         }

--- a/backend/forgather/src/main/java/com/forgather/domain/product/service/ProductService.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/product/service/ProductService.java
@@ -6,7 +6,6 @@ import static com.forgather.domain.upload.domain.UploadCategory.PRODUCT;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,7 +22,6 @@ import com.forgather.domain.product.repository.ProductRepository;
 import com.forgather.domain.space.model.Space;
 import com.forgather.domain.space.repository.SpaceRepository;
 import com.forgather.domain.upload.domain.ContentsStorage;
-import com.forgather.domain.upload.event.DeletePhotoEvent;
 import com.forgather.global.auth.model.Host;
 import com.forgather.global.auth.repository.SpaceHostMapRepository;
 import com.forgather.global.exception.BaseException;
@@ -38,7 +36,6 @@ public class ProductService {
 
     private static final int PRODUCTS_MAX_COUNT = 3;
 
-    private final ApplicationEventPublisher eventPublisher;
     private final ProductRepository productRepository;
     private final ProductPhotoRepository productPhotoRepository;
     private final SpaceRepository spaceRepository;
@@ -133,7 +130,7 @@ public class ProductService {
         validateSpaceHost(host, space);
         Product product = productRepository.getBySpaceAndIdOrThrow(space, productId);
         deleteAllProductPhotos(product);
-        productRepository.delete(product);
+        product.delete();
     }
 
     /**
@@ -144,7 +141,7 @@ public class ProductService {
         validateSpaceHost(host, space);
         for (Product product : productRepository.findAllBySpace(space)) {
             deleteAllProductPhotos(product);
-            productRepository.delete(product);
+            product.delete();
         }
     }
 
@@ -162,8 +159,9 @@ public class ProductService {
      * productPhotos만 삭제
      */
     private void deleteProductPhotos(List<ProductPhoto> productPhotos) {
-        productPhotoRepository.deleteAll(productPhotos);
-        eventPublisher.publishEvent(new DeletePhotoEvent(this, productPhotos)); // 클라우드 삭제 이벤트 발행
+        for (ProductPhoto productPhoto : productPhotos) {
+            productPhoto.delete();
+        }
     }
 
     private void validateSpaceHost(Host host, Space space) {

--- a/backend/forgather/src/main/java/com/forgather/domain/product/service/ProductService.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/product/service/ProductService.java
@@ -87,8 +87,8 @@ public class ProductService {
     }
 
     private void validateExceedProductMaxCount(Space space) {
-        Long counts = productRepository.countBySpaceAndDeletedAtIsNull(space);
-        if (counts >= PRODUCTS_MAX_COUNT) {
+        Long count = productRepository.countBySpaceAndDeletedAtIsNull(space);
+        if (count >= PRODUCTS_MAX_COUNT) {
             throw new BaseException("작품은 3개까지만 등록 가능합니다. spaceCode: " + space.getCode());
         }
     }

--- a/backend/forgather/src/main/java/com/forgather/domain/product/service/ProductService.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/product/service/ProductService.java
@@ -66,7 +66,7 @@ public class ProductService {
     }
 
     @Transactional
-    public ProductResponse registerV3(Host host, String spaceCode, RegisterProductRequest request) {
+    public ProductResponse register(Host host, String spaceCode, RegisterProductRequest request) {
         Space space = spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
         validateSpaceHost(host, space);
         validateExceedProductMaxCount(space);
@@ -94,7 +94,7 @@ public class ProductService {
     }
 
     @Transactional
-    public ProductResponse updateV3(Host host, String spaceCode, Long productId, UpdateProductRequest request) {
+    public ProductResponse update(Host host, String spaceCode, Long productId, UpdateProductRequest request) {
         // Product 정보 수정
         Space space = spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
         validateSpaceHost(host, space);
@@ -125,7 +125,7 @@ public class ProductService {
     }
 
     @Transactional
-    public void deleteV2(Host host, String spaceCode, Long productId) {
+    public void delete(Host host, String spaceCode, Long productId) {
         Space space = spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
         validateSpaceHost(host, space);
         Product product = productRepository.getBySpaceAndIdAndDeletedAtIsNullOrThrow(space, productId);

--- a/backend/forgather/src/main/java/com/forgather/domain/product/service/ProductService.java
+++ b/backend/forgather/src/main/java/com/forgather/domain/product/service/ProductService.java
@@ -87,7 +87,7 @@ public class ProductService {
     }
 
     private void validateExceedProductMaxCount(Space space) {
-        Long counts = productRepository.countBySpace(space);
+        Long counts = productRepository.countBySpaceAndDeletedAtIsNull(space);
         if (counts >= PRODUCTS_MAX_COUNT) {
             throw new BaseException("작품은 3개까지만 등록 가능합니다. spaceCode: " + space.getCode());
         }

--- a/backend/forgather/src/test/java/com/forgather/acceptance/ProductAcceptanceTest.java
+++ b/backend/forgather/src/test/java/com/forgather/acceptance/ProductAcceptanceTest.java
@@ -1,13 +1,8 @@
 package com.forgather.acceptance;
 
-import static java.time.Duration.ofSeconds;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.Mockito.atLeast;
-import static org.mockito.Mockito.verify;
 
 import java.util.List;
 
@@ -418,13 +413,7 @@ public class ProductAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(result.photos().get(2).order()).isEqualTo(3),
                 () -> assertThat(result.photos().get(3).originalName()).isEqualTo("photo5"),
                 () -> assertThat(result.photos().get(3).path()).endsWith("/spaces/1234567890/product/file5.png"),
-                () -> assertThat(result.photos().get(3).order()).isEqualTo(4),
-
-                () -> {
-                    await()
-                        .atMost(ofSeconds(6))
-                        .untilAsserted(() -> verify(awsS3Cloud, atLeast(1)).deletePhotos(anyList()));
-                }
+                () -> assertThat(result.photos().get(3).order()).isEqualTo(4)
             );
         }
 
@@ -546,14 +535,7 @@ public class ProductAcceptanceTest extends AcceptanceTest {
                 .then()
                 .statusCode(204);
 
-            assertAll(
-                () -> assertThat(productRepository.findBySpaceAndId(space, registerResponse.id())).isEmpty(),
-                () -> {
-                    await()
-                        .atMost(ofSeconds(6))
-                        .untilAsserted(() -> verify(awsS3Cloud, atLeast(1)).deletePhotos(anyList()));
-                }
-            );
+            assertThat(productRepository.findBySpaceAndIdAndDeletedAtIsNull(space, registerResponse.id())).isEmpty();
         }
 
         @DisplayName("방문자가 작품을 삭제하면 예외를 던진다")

--- a/backend/forgather/src/test/java/com/forgather/acceptance/SpaceAcceptanceTest.java
+++ b/backend/forgather/src/test/java/com/forgather/acceptance/SpaceAcceptanceTest.java
@@ -1,13 +1,10 @@
 package com.forgather.acceptance;
 
 import static com.forgather.fixture.HostFixture.createHost;
-import static java.time.Duration.ofSeconds;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -277,13 +274,10 @@ class SpaceAcceptanceTest extends AcceptanceTest {
             () -> assertThat(response.statusCode()).isEqualTo(204),
             () -> assertThat(spaceRepository.findByCodeAndDeletedAtIsNull(space.getCode())).isEmpty(),
             () -> assertThat(spacePhotoRepository.findBySpaceAndDeletedAtIsNull(space)).isEmpty(),
-            () -> assertThat(productRepository.findAllBySpace(space)).isEmpty(),
-            () -> assertThat(productPhotoRepository.findAllByProduct(product)).isEmpty(),
+            () -> assertThat(productRepository.findAllBySpaceAndDeletedAtIsNull(space)).isEmpty(),
+            () -> assertThat(productPhotoRepository.findAllByProductAndDeletedAtIsNull(product)).isEmpty(),
             () -> assertThat(guestBookCardRepository.findAllBySpaceAndDeletedAtIsNull(space)).isEmpty(),
-            () -> assertThat(guestBookCardPhotoRepository.findAllByGuestBookCardAndDeletedAtIsNull(guestBookCard)).isEmpty(),
-
-            () -> await().atMost(ofSeconds(6))
-                .untilAsserted(() -> verify(contentsStorage, atLeast(1)).deletePhotos(anyList()))
+            () -> assertThat(guestBookCardPhotoRepository.findAllByGuestBookCardAndDeletedAtIsNull(guestBookCard)).isEmpty()
         );
     }
 

--- a/backend/forgather/src/test/java/com/forgather/domain/product/model/ProductDeleteServiceTest.java
+++ b/backend/forgather/src/test/java/com/forgather/domain/product/model/ProductDeleteServiceTest.java
@@ -1,0 +1,117 @@
+package com.forgather.domain.product.model;
+
+import static com.forgather.fixture.ProductFixture.createProductWithSpace;
+import static com.forgather.fixture.ProductPhotoFixture.createProductPhotoWithProduct;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import com.forgather.domain.product.repository.ProductPhotoRepository;
+import com.forgather.domain.product.repository.ProductRepository;
+import com.forgather.domain.product.service.ProductService;
+import com.forgather.domain.space.model.Space;
+import com.forgather.domain.space.repository.HostRepository;
+import com.forgather.domain.space.repository.SpaceRepository;
+import com.forgather.fake.FakeContentStorage;
+import com.forgather.fixture.HostFixture;
+import com.forgather.fixture.SpaceFixture;
+import com.forgather.global.auth.model.Host;
+import com.forgather.global.auth.model.SpaceHostMap;
+import com.forgather.global.auth.repository.SpaceHostMapRepository;
+
+@Import({ProductService.class, FakeContentStorage.class})
+@DataJpaTest
+public class ProductDeleteServiceTest {
+
+    @Autowired
+    private ProductService productService;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private ProductPhotoRepository productPhotoRepository;
+
+    @Autowired
+    private HostRepository hostRepository;
+
+    @Autowired
+    private SpaceRepository spaceRepository;
+
+    @Autowired
+    private SpaceHostMapRepository spaceHostMapRepository;
+
+    private Host host;
+    private Space space;
+
+    @BeforeEach
+    void setUp() {
+        space = SpaceFixture.createSpace();
+        spaceRepository.save(space);
+
+        host = HostFixture.createHost();
+        hostRepository.save(host);
+
+        spaceHostMapRepository.save(new SpaceHostMap(space, host));
+    }
+
+    @DisplayName("특정 작품을 논리 삭제한다")
+    @Test
+    void softDeleteProduct() {
+        // given
+        Product product1 = productRepository.save(createProductWithSpace(space));
+        Product product2 = productRepository.save(createProductWithSpace(space));
+        Product product3 = productRepository.save(createProductWithSpace(space));
+        ProductPhoto productPhoto1 = createProductPhotoWithProduct(product2);
+        ProductPhoto productPhoto2 = createProductPhotoWithProduct(product2);
+        productPhotoRepository.saveAll(List.of(productPhoto1, productPhoto2));
+
+        // when
+        productService.delete(host, space.getCode(), product2.getId());
+
+        // then
+        assertAll(
+            () -> assertThat(productRepository.findAllBySpaceAndDeletedAtIsNull(space)).containsExactly(product1, product3),
+            () -> assertThat(product1.getDeletedAt()).isNull(),
+            () -> assertThat(product2.getDeletedAt()).isNotNull(),
+            () -> assertThat(product3.getDeletedAt()).isNull(),
+
+            () -> assertThat(productPhoto1.getDeletedAt()).isNotNull(),
+            () -> assertThat(productPhoto2.getDeletedAt()).isNotNull()
+        );
+    }
+
+    @DisplayName("주어진 스페이스에 속하는 모든 작품을 논리 삭제한다")
+    @Test
+    void softDeleteProductBySpace() {
+        // given
+        Product product1 = productRepository.save(createProductWithSpace(space));
+        Product product2 = productRepository.save(createProductWithSpace(space));
+        Product product3 = productRepository.save(createProductWithSpace(space));
+        ProductPhoto productPhoto1 = createProductPhotoWithProduct(product2);
+        ProductPhoto productPhoto2 = createProductPhotoWithProduct(product2);
+        productPhotoRepository.saveAll(List.of(productPhoto1, productPhoto2));
+
+        // when
+        productService.deleteIfExists(host, space);
+
+        // then
+        assertAll(
+            () -> assertThat(productRepository.findAllBySpaceAndDeletedAtIsNull(space)).isEmpty(),
+            () -> assertThat(product1.getDeletedAt()).isNotNull(),
+            () -> assertThat(product2.getDeletedAt()).isNotNull(),
+            () -> assertThat(product3.getDeletedAt()).isNotNull(),
+
+            () -> assertThat(productPhoto1.getDeletedAt()).isNotNull(),
+            () -> assertThat(productPhoto2.getDeletedAt()).isNotNull()
+        );
+    }
+}

--- a/backend/forgather/src/test/java/com/forgather/domain/product/service/ProductDeleteServiceTest.java
+++ b/backend/forgather/src/test/java/com/forgather/domain/product/service/ProductDeleteServiceTest.java
@@ -1,4 +1,4 @@
-package com.forgather.domain.product.model;
+package com.forgather.domain.product.service;
 
 import static com.forgather.fixture.ProductFixture.createProductWithSpace;
 import static com.forgather.fixture.ProductPhotoFixture.createProductPhotoWithProduct;
@@ -14,9 +14,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
+import com.forgather.domain.product.model.Product;
+import com.forgather.domain.product.model.ProductPhoto;
 import com.forgather.domain.product.repository.ProductPhotoRepository;
 import com.forgather.domain.product.repository.ProductRepository;
-import com.forgather.domain.product.service.ProductService;
 import com.forgather.domain.space.model.Space;
 import com.forgather.domain.space.repository.HostRepository;
 import com.forgather.domain.space.repository.SpaceRepository;


### PR DESCRIPTION
## 연관된 이슈

- close #1004

## 작업 내용

### 방명록 soft delete 도입
스페이스, 방명록 soft delete 도입에 이어서 작품에도 soft delete를 도입했습니다.

작품 삭제 시
- 해당 작품 논리 삭제
- 해당 작품의 모든 사진 논리 삭제

스페이스 삭제 시
- 해당 스페이스의 모든 작품 논리 삭제
- 해당 스페이스의 모든 작품 사진 논리 삭제